### PR TITLE
amp API update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ apex.egg-info
 dist
 build
 docs/build
+*~

--- a/apex/amp/__init__.py
+++ b/apex/amp/__init__.py
@@ -1,1 +1,1 @@
-from .amp import enable, register_half, register_float
+from .amp import build, register_half, register_float, register_promote

--- a/apex/amp/__init__.py
+++ b/apex/amp/__init__.py
@@ -1,1 +1,2 @@
-from .amp import build, register_half, register_float, register_promote
+from .amp import build, half_function, float_function, promote_function,\
+    register_half_function, register_float_function, register_promote_function

--- a/apex/amp/__init__.py
+++ b/apex/amp/__init__.py
@@ -1,2 +1,2 @@
-from .amp import build, half_function, float_function, promote_function,\
+from .amp import init, half_function, float_function, promote_function,\
     register_half_function, register_float_function, register_promote_function

--- a/apex/amp/amp.py
+++ b/apex/amp/amp.py
@@ -51,10 +51,10 @@ def register_promote_function(module, name):
     if not hasattr(module, name):
         raise ValueError('No function named {} in module {}.'.format(
             name, module))
-    _USER_PROMOTE_REGISTRY.add((mod, fn.__name__))
+    _USER_PROMOTE_REGISTRY.add((module, name))
 
 # Top-level function to insert _all_ the hooks.
-def build(enabled=True, enable_caching=True, verbose=False):
+def init(enabled=True, enable_caching=True, verbose=False):
     global _DECORATOR_HANDLE
 
     if not enabled:

--- a/apex/amp/amp.py
+++ b/apex/amp/amp.py
@@ -54,7 +54,7 @@ def register_promote_function(module, name):
     _USER_PROMOTE_REGISTRY.add((module, name))
 
 # Top-level function to insert _all_ the hooks.
-def init(enabled=True, enable_caching=True, verbose=False):
+def init(enabled=True, enable_caching=True, verbose=False, allow_banned=False):
     global _DECORATOR_HANDLE
 
     if not enabled:
@@ -144,6 +144,11 @@ def init(enabled=True, enable_caching=True, verbose=False):
 
     # 5.5) Extra-special handling of RNN backend
     wrap.rnn_cast(torch.nn.backends.thnn.backend, 'RNN', verbose)
+
+    # 6) Place error+print message on banned functions
+    if not allow_banned:
+        for fn, err_msg in functional_overrides.BANNED_FUNCS:
+            wrap.err_if_any_half(functional_overrides.MODULE, fn, err_msg)
 
     _DECORATOR_HANDLE = handle
     return handle

--- a/apex/amp/handle.py
+++ b/apex/amp/handle.py
@@ -6,8 +6,9 @@ from .opt import OptimWrapper
 from .scaler import LossScaler
 
 class AmpHandle(object):
-    def __init__(self, enable_caching=True):
+    def __init__(self, enable_caching=True, verbose=False):
         self._enable_caching = enable_caching
+        self._verbose = verbose
         self._cache = dict()
         self._default_scaler = LossScaler()
 
@@ -67,6 +68,10 @@ class AmpHandle(object):
         if self.has_cache and param in self.cache:
             del self.cache[param]
 
+    @property
+    def verbose(self):
+        return self._verbose
+
 class NoOpHandle(object):
     def is_active(self):
         return False
@@ -80,4 +85,8 @@ class NoOpHandle(object):
 
     @property
     def has_cache(self):
+        return False
+
+    @property
+    def verbose(self):
         return False

--- a/apex/amp/handle.py
+++ b/apex/amp/handle.py
@@ -2,54 +2,53 @@ import contextlib
 import logging
 import warnings
 
-import torch
-
-from ._C import scale_lib
+from .opt import OptimWrapper
+from .scaler import LossScaler
 
 class AmpHandle(object):
     def __init__(self, enable_caching=True):
         self._enable_caching = enable_caching
         self._cache = dict()
-        self._loss_scale = 2.**16
-        self._max_loss_scale = 2.**24
-        self._scale_seq_len = 2000
-        self._unskipped = 0
-        self._overflow_buf = torch.cuda.ByteTensor(1024,)
+        self._default_scaler = LossScaler()
+
+    def is_active(self):
+        return True
+
+    def wrap_optimizer(self, optimizer, num_loss=1):
+        self._default_scaler = None
+        return OptimWrapper(optimizer, self, num_loss)
 
     @contextlib.contextmanager
     def scale_loss(self, loss, optimizer):
+        if not self.is_active():
+            yield loss
+            return
+
+        if self._default_scaler is None:
+            raise RuntimeError(
+                'After calling `handle.wrap_optimizer()`, you must explicitly ' +
+                'use `optimizer.scale_loss(loss)`.')
+
+        # TODO: this code block is duplicated here and `opt.py`. Unify.
         loss_backward = loss.backward
         def warning_wrapper():
             warnings.warn("You called .backward() on the unscaled loss "
                           "inside a scale_loss block. This is almost "
                           "certainly an error.", stacklevel=2)
             loss_backward()
-
         loss.backward = warning_wrapper
-        yield loss * self._loss_scale
+        loss_scale = self._default_scaler.loss_scale()
+        yield loss * loss_scale
         loss.backward = loss_backward
 
-        self._overflow_buf.zero_()
-        for group in optimizer.param_groups:
-            for p in group['params']:
-                if p.grad is not None:
-                    scale_lib.scale_check_overflow(p.grad.data,
-                                                   1. / self._loss_scale,
-                                                   self._overflow_buf)
-        if self._overflow_buf.any():
-            self._loss_scale /= 2.
+        should_skip = self._default_scaler.unscale_and_update(
+            optimizer.param_groups, loss_scale)
+        if should_skip:
             optimizer_step = optimizer.step
             def skip_step():
                 logging.info('Gradient overflow, skipping update')
                 optimizer.step = optimizer_step
             optimizer.step = skip_step
-            self._unskipped = 0
-        else:
-            self._unskipped += 1
-
-        if self._unskipped == self._scale_seq_len:
-            self._loss_scale = min(self._max_loss_scale, self._loss_scale * 2.)
-            self._unskipped = 0
 
         self._clear_cache()
 
@@ -63,3 +62,22 @@ class AmpHandle(object):
     @property
     def cache(self):
         return self._cache
+
+    def remove_cache(self, param):
+        if self.has_cache and param in self.cache:
+            del self.cache[param]
+
+class NoOpHandle(object):
+    def is_active(self):
+        return False
+
+    def wrap_optimizer(self, optimizer, num_loss=1):
+        return OptimWrapper(optimizer, self, num_loss)
+
+    @contextlib.contextmanager
+    def scale_loss(self, loss, optimizer):
+        yield loss
+
+    @property
+    def has_cache(self):
+        return False

--- a/apex/amp/lists/functional_overrides.py
+++ b/apex/amp/lists/functional_overrides.py
@@ -42,7 +42,6 @@ FP32_FUNCS = [
 
     # Loss functions
     # TODO: which of these can be fp16?
-    'binary_cross_entropy',
     'poisson_nll_loss',
     'cosine_embedding_loss',
     'cross_entropy',
@@ -59,4 +58,16 @@ FP32_FUNCS = [
     'smooth_l1_loss',
     'soft_margin_loss',
     'triplet_margin_loss'
+]
+
+BANNED_FUNCS = [
+    ('binary_cross_entropy',
+     ("\namp does not work out-of-the-box with `F.binary_cross_entropy` or `torch.nn.BCELoss.` "
+      "It requires that the output of the previous function be already a FloatTensor. \n\n"
+      "Most models have a Sigmoid right before BCELoss. In that case, you can use\n"
+      "    torch.nn.BCEWithLogitsLoss\nto combine Sigmoid+BCELoss into a single layer "
+      "that is compatible with amp.\nAnother option is to add\n"
+      "    amp.register_float_function(torch, 'sigmoid')\nbefore calling `amp.init()`.\n"
+      "If you _really_ know what you are doing, you can disable this warning by passing "
+      "allow_banned=True to `amp.init()`."))
 ]

--- a/apex/amp/opt.py
+++ b/apex/amp/opt.py
@@ -1,0 +1,101 @@
+import contextlib
+import warnings
+
+from .scaler import LossScaler
+
+import numpy as np
+
+class OptimWrapper(object):
+    def __init__(self, optimizer, amp_handle, num_loss):
+        self._optimizer = optimizer
+        self._amp_handle = amp_handle
+        self._num_loss = num_loss
+        self._loss_idx = 0
+        self._skip_next = [False] * num_loss
+        self._loss_scaler = [LossScaler() for _ in range(num_loss)]
+
+    @contextlib.contextmanager
+    def scale_loss(self, loss):
+        if not self._amp_handle.is_active():
+            yield loss
+            return
+
+        loss_backward = loss.backward
+        def warning_wrapper():
+            warnings.warn("You called .backward() on the unscaled loss "
+                          "inside a scale_loss block. This is almost "
+                          "certainly an error.", stacklevel=2)
+            loss_backward()
+        loss.backward = warning_wrapper
+
+
+        # if loss_idx > 0:
+        #    save out current grads to buffers
+        #    keep some group caches
+        #    .detach().clone()
+        #    zero grads
+        
+
+        
+        loss_scale = self._cur_loss_scaler().loss_scale()
+        print('Loss scale (log): {}'.format(np.log2(loss_scale)))
+        yield loss * loss_scale
+        loss.backward = loss_backward
+
+        self._skip_next[self._loss_idx] = self._cur_loss_scaler().unscale_and_update(
+            self._optimizer.param_groups, loss_scale)
+        print('GOT SKIP NEXT: {}'.format(self._skip_next[self._loss_idx]))
+        self._loss_idx += 1
+
+        # if loss_idx > 0:
+        #    += saved state into grads
+
+    def _cur_loss_scaler(self):
+        assert 0 <= self._loss_idx < self._num_loss
+        return self._loss_scaler[self._loss_idx]
+
+    def step(self, closure=None):
+        if not self._amp_handle.is_active():
+            return self._optimizer.step(closure=closure)
+
+        self._loss_idx = 0
+
+        for group in self._optimizer.param_groups:
+            for p in group['params']:
+                self._amp_handle.remove_cache(p)
+
+        if closure is not None:
+            raise NotImplementedError(
+                'The `closure` argument is unsupported by the amp ' +
+                'optimizer wrapper.')
+        if any(self._skip_next):
+            self._skip_next = [False] * self._num_loss
+            print('SKIP')
+        else:
+            return self._optimizer.step(closure=closure)
+
+    # Forward any attribute lookups
+    def __getattr__(self, attr):
+        return getattr(self._optimizer, attr)
+
+    # Forward all torch.optim.Optimizer methods
+    def __getstate__(self):
+        return self._optimizer.__getstate__()
+
+    def __setstate__(self):
+        return self._optimizer.__setstate__()
+
+    def __repr__(self):
+        return self._optimizer.__repr__()
+
+    def state_dict(self):
+        return self._optimizer.state_dict()
+
+    def load_state_dict(self, state_dict):
+        return self._optimizer.load_state_dict(state_dict)
+
+    def zero_grad(self):
+        return self._optimizer.zero_grad()
+
+    def add_param_group(self, param_group):
+        return self._optimizer.add_param_group(param_group)

--- a/apex/amp/scaler.py
+++ b/apex/amp/scaler.py
@@ -15,12 +15,11 @@ class LossScaler(object):
 
     def unscale_and_update(self, param_groups, scale):
         self._overflow_buf.zero_()
-        for group in param_groups:
-            for p in group['params']:
-                if p.grad is not None:
-                    scale_lib.scale_check_overflow(p.grad.data,
-                                                   1. / scale,
-                                                   self._overflow_buf)
+        for p in iter_params(param_groups):
+            if p.grad is not None:
+                scale_lib.scale_check_overflow(p.grad.data,
+                                               1. / scale,
+                                               self._overflow_buf)
 
         if self._overflow_buf.any():
             should_skip = True
@@ -35,3 +34,8 @@ class LossScaler(object):
             self._unskipped = 0
 
         return should_skip
+
+def iter_params(param_groups):
+    for group in param_groups:
+        for p in group['params']:
+            yield p

--- a/apex/amp/scaler.py
+++ b/apex/amp/scaler.py
@@ -1,0 +1,37 @@
+import torch
+
+from ._C import scale_lib
+
+class LossScaler(object):
+    def __init__(self):
+        self._loss_scale = 2.**16
+        self._max_loss_scale = 2.**24
+        self._scale_seq_len = 2000
+        self._unskipped = 0
+        self._overflow_buf = torch.cuda.ByteTensor(1024,)
+
+    def loss_scale(self):
+        return self._loss_scale
+
+    def unscale_and_update(self, param_groups, scale):
+        self._overflow_buf.zero_()
+        for group in param_groups:
+            for p in group['params']:
+                if p.grad is not None:
+                    scale_lib.scale_check_overflow(p.grad.data,
+                                                   1. / scale,
+                                                   self._overflow_buf)
+
+        if self._overflow_buf.any():
+            should_skip = True
+            self._loss_scale /= 2.
+            self._unskipped = 0
+        else:
+            should_skip = False
+            self._unskipped += 1
+
+        if self._unskipped == self._scale_seq_len:
+            self._loss_scale = min(self._max_loss_scale, self._loss_scale * 2.)
+            self._unskipped = 0
+
+        return should_skip

--- a/apex/amp/wrap.py
+++ b/apex/amp/wrap.py
@@ -94,7 +94,7 @@ def promote_match_arg0(mod, fn, verbose=False):
         return orig_fn(arg0, *new_args, **kwargs)
     utils.set_func(mod, fn, wrapper)
 
-def err_if_any_half(mod, fn):
+def err_if_any_half(mod, fn, custom_err_msg=None):
     if not utils.has_func(mod, fn):
         return
 
@@ -103,8 +103,11 @@ def err_if_any_half(mod, fn):
     def wrapper(*args, **kwargs):
         types = utils.collect_fp_tensor_types(args, kwargs)
         if 'HalfTensor' in types:
-            raise NotImplementedError('Cannot call in-place function ' +
-                                      '{} with fp16 arguments.'.format(fn))
+            if custom_err_msg:
+                raise NotImplementedError(custom_err_msg)
+            else:
+                raise NotImplementedError('Cannot call in-place function ' +
+                                          '{} with fp16 arguments.'.format(fn))
         else:
             return orig_fn(*args, **kwargs)
     utils.set_func(mod, fn, wrapper)

--- a/build_cffi.py
+++ b/build_cffi.py
@@ -8,7 +8,6 @@ import os
 import torch
 from torch.utils.ffi import create_extension
 
-assert torch.cuda.is_available()
 abs_path = os.path.dirname(os.path.realpath(__file__))
 
 sources = ['apex/amp/src/scale_cuda.c']


### PR DESCRIPTION
Big overhaul of the amp API, described in the updated README. Top items:

1. Main function now called `amp.init()` with a boolean argument `enabled` that allows a pass-through mode when set to false. Useful for writing, eg, `amp_handle = amp.init(enabled=args.amp)` and then not needing if statements anywhere.
2. Support for explicit optimizer wrapping: `optimizer = amp_handle.wrap_optimizer(optimizer)`. The wrapper supports the `loss_scale()` context manager. Enables use w/ multiple optimizers.
3. Support for multiple backward passes per-step with `num_loss` argument to `wrap_optimizer()`.
4. Improved annotations and registration functions for handling backend code in a less fragile way.

The other big change is a refactoring of optimizer wrapping / loss scaling code to split it all out into separate classes so it's much tidier. One possible future is one where we converge on a single optimizer wrapper API (but not implementation, necessarily) between amp and the fp16_optimizer.