### PR TITLE
Type in variable name: hidden --> hiddens (w/ trailing 's')

### DIFF
--- a/apex/amp/wrap.py
+++ b/apex/amp/wrap.py
@@ -191,11 +191,11 @@ def rnn_cast(backend, fn, verbose=False):
             # 2) Inputs: either a tuple (for LSTM) or single tensor
             if isinstance(hiddens, tuple):
                 new_args.append(tuple(cast_fn(x) for x in hiddens))
-            elif utils.is_fp_tensor(hidden):
-                new_args.append(cast_fn(hidden))
+            elif utils.is_fp_tensor(hiddens):
+                new_args.append(cast_fn(hiddens))
             else:
-                # Hidden can, in principle, be `None` -- pass through
-                new_args.append(hidden)
+                # Hiddens can, in principle, be `None` -- pass through
+                new_args.append(hiddens)
 
             # 3) Batch sizes (0.4 or later only)
             if len(fargs) == 4:


### PR DESCRIPTION
__hidden__ in an undefined name in this context but __hiddens__ is used on the lines above.

flake8 testing of https://github.com/NVIDIA/apex on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./setup.py:50:23: F821 undefined name 'ctypes'
        cudart_path = ctypes.util.find_library('cudart')
                      ^
./apex/amp/wrap.py:194:37: F821 undefined name 'hidden'
            elif utils.is_fp_tensor(hidden):
                                    ^
./apex/amp/wrap.py:195:41: F821 undefined name 'hidden'
                new_args.append(cast_fn(hidden))
                                        ^
./apex/amp/wrap.py:198:33: F821 undefined name 'hidden'
                new_args.append(hidden)
                                ^
4     F821 undefined name 'hidden'
4
```