### PR TITLE
Adding changes due to https://github.com/pytorch/pytorch/pull/8660

### DIFF
--- a/csrc/scale_cuda.cu
+++ b/csrc/scale_cuda.cu
@@ -1,7 +1,7 @@
 #include <ATen/ATen.h>
 // #include "ATen/AccumulateType.h"
 #include "ATen/cuda/CUDATensorMethods.cuh"
-#include "ATen/cuda/CUDATypeConversion.cuh"
+// #include "ATen/cuda/CUDATypeConversion.cuh"
 // #include <THC/THCTensorMathReduce.cuh>
 #include <THC/THCGeneral.h>
 

--- a/csrc/weight_norm_bwd_cuda.cu
+++ b/csrc/weight_norm_bwd_cuda.cu
@@ -9,7 +9,7 @@
 #endif
 
 #include "ATen/cuda/CUDATensorMethods.cuh"
-#include "ATen/cuda/CUDATypeConversion.cuh"
+// #include "ATen/cuda/CUDATypeConversion.cuh"
 // #include <THC/THCTensorMathReduce.cuh>
 
 template

--- a/csrc/weight_norm_fwd_cuda.cu
+++ b/csrc/weight_norm_fwd_cuda.cu
@@ -9,7 +9,7 @@
 #endif
 
 #include "ATen/cuda/CUDATensorMethods.cuh"
-#include "ATen/cuda/CUDATypeConversion.cuh"
+// #include "ATen/cuda/CUDATypeConversion.cuh"
 // #include <THC/THCTensorMathReduce.cuh>
 
 template


### PR DESCRIPTION
Build was breaking against upstream PyTorch. Could have just changed the header to the local `CUDATypeConversion.cuh` but decided to keep things consistent with the ustream PR.