### PR TITLE
More stringent check for parameter changes to trigger refresh of distributed

### DIFF
--- a/apex/fp16_utils/fp16_optimizer.py
+++ b/apex/fp16_utils/fp16_optimizer.py
@@ -428,9 +428,8 @@ class FP16_Optimizer(object):
             while(self.overflow):
                 scale = self.loss_scaler.loss_scale
                 self._update_scale(self.overflow)
-                if self.overflow:
-                    print("OVERFLOW within closure! Skipping step. Attempted loss scale: {}, "
-                          "reducing to {}".format(scale, self.loss_scale))
+                print("OVERFLOW within closure! Skipping step. Attempted loss scale: {}, "
+                      "reducing to {}".format(scale, self.loss_scale))
                 temp_loss = closure()
             return temp_loss
 

--- a/apex/parallel/distributed.py
+++ b/apex/parallel/distributed.py
@@ -198,11 +198,13 @@ class DistributedDataParallel(Module):
         #Force needs_refresh to True if there are shared params
         #this will force it to always, only call flush_buckets which is safe
         #for shared parameters in the model.
-        if not self.param_refs or self.shared_param:
+        #Parentheses are not necessary for correct order of operations, but make the intent clearer.
+        if (not self.param_refs) or self.shared_param:
             self.needs_refresh = True
         else:
-            self.needs_refresh = any(
-                [param1 is not param2 for param1, param2 in zip(param_list, self.param_refs)]
+            self.needs_refresh = (
+                len(param_list) != len(self.param_refs)) or 
+                any(param1 is not param2 for param1, param2 in zip(param_list, self.param_refs)])
             )
                 
         if  self.needs_refresh:

--- a/apex/parallel/distributed.py
+++ b/apex/parallel/distributed.py
@@ -203,9 +203,8 @@ class DistributedDataParallel(Module):
             self.needs_refresh = True
         else:
             self.needs_refresh = (
-                len(param_list) != len(self.param_refs)) or 
-                any(param1 is not param2 for param1, param2 in zip(param_list, self.param_refs)])
-            )
+                (len(param_list) != len(self.param_refs)) or any(
+                    [param1 is not param2 for param1, param2 in zip(param_list, self.param_refs)]))
                 
         if  self.needs_refresh:
             self.record = []


### PR DESCRIPTION
Previously, the check would fail to catch if a parameter was removed from the end of module.parameters(), but no other ordering changes occurred.
@csarofeen 

Also removed unnecessary if statement in closure handling for dynamic loss scaling.