### PR TITLE
Reducer

### DIFF
--- a/apex/parallel/__init__.py
+++ b/apex/parallel/__init__.py
@@ -1,1 +1,1 @@
-from .distributed import DistributedDataParallel
+from .distributed import DistributedDataParallel, Reducer

--- a/examples/imagenet/main.py
+++ b/examples/imagenet/main.py
@@ -19,7 +19,7 @@ import torchvision.models as models
 import numpy as np
 
 try:
-    from apex.parallel import DistributedDataParallel as DDP
+    from apex.parallel import Reducer as DDP
     from apex.fp16_utils import *
 except ImportError:
     raise ImportError("Please install apex from https://www.github.com/nvidia/apex to run this example.")
@@ -122,7 +122,8 @@ def main():
         model = network_to_half(model)
     if args.distributed:
         # shared param turns off bucketing in DDP, for lower latency runs this can improve perf
-        model = DDP(model, shared_param=True)
+        global reducer
+        reducer = DDP(model)
 
     global model_params, master_params
     if args.fp16:
@@ -301,6 +302,7 @@ def train(train_loader, model, criterion, optimizer, epoch):
         if args.fp16:
             model.zero_grad()
             loss.backward()
+            reducer.reduce()
             model_grads_to_master_grads(model_params, master_params)
             if args.static_loss_scale != 1:
                 for param in master_params:
@@ -310,6 +312,7 @@ def train(train_loader, model, criterion, optimizer, epoch):
         else:
             optimizer.zero_grad()
             loss.backward()
+            reducer.reduce()
             optimizer.step()
 
         torch.cuda.synchronize()

--- a/examples/imagenet/main_reducer.py
+++ b/examples/imagenet/main_reducer.py
@@ -19,7 +19,7 @@ import torchvision.models as models
 import numpy as np
 
 try:
-    from apex.parallel import Reducer as DDP
+    from apex.parallel import Reducer
     from apex.fp16_utils import *
 except ImportError:
     raise ImportError("Please install apex from https://www.github.com/nvidia/apex to run this example.")
@@ -121,9 +121,8 @@ def main():
     if args.fp16:
         model = network_to_half(model)
     if args.distributed:
-        # shared param turns off bucketing in DDP, for lower latency runs this can improve perf
         global reducer
-        reducer = DDP(model)
+        reducer = Reducer(model)
 
     global model_params, master_params
     if args.fp16:

--- a/examples/imagenet/main_reducer.py
+++ b/examples/imagenet/main_reducer.py
@@ -19,7 +19,7 @@ import torchvision.models as models
 import numpy as np
 
 try:
-    from apex.parallel import DistributedDataParallel as DDP
+    from apex.parallel import Reducer as DDP
     from apex.fp16_utils import *
 except ImportError:
     raise ImportError("Please install apex from https://www.github.com/nvidia/apex to run this example.")
@@ -122,7 +122,8 @@ def main():
         model = network_to_half(model)
     if args.distributed:
         # shared param turns off bucketing in DDP, for lower latency runs this can improve perf
-        model = DDP(model, shared_param=True)
+        global reducer
+        reducer = DDP(model)
 
     global model_params, master_params
     if args.fp16:
@@ -301,6 +302,7 @@ def train(train_loader, model, criterion, optimizer, epoch):
         if args.fp16:
             model.zero_grad()
             loss.backward()
+            reducer.reduce()
             model_grads_to_master_grads(model_params, master_params)
             if args.static_loss_scale != 1:
                 for param in master_params:
@@ -310,6 +312,7 @@ def train(train_loader, model, criterion, optimizer, epoch):
         else:
             optimizer.zero_grad()
             loss.backward()
+            reducer.reduce()
             optimizer.step()
 
         torch.cuda.synchronize()


### PR DESCRIPTION
Separate examples for reducer and DDP. Don't confuse people that DDP should be replaced by reducer. Reducer utility is separate from DDP and used in different circumstances.