### PR TITLE
amp unit tests

### DIFF
--- a/apex/amp/handle.py
+++ b/apex/amp/handle.py
@@ -2,6 +2,7 @@ import contextlib
 import logging
 import warnings
 
+from . import utils
 from .opt import OptimWrapper
 from .scaler import LossScaler
 
@@ -12,6 +13,7 @@ class AmpHandle(object):
         self._cache = dict()
         self._default_scaler = LossScaler()
         self._is_active = True
+        self._all_wrappers = []
 
     def is_active(self):
         return self._is_active
@@ -62,6 +64,15 @@ class AmpHandle(object):
 
     def _clear_cache(self):
         self._cache.clear()
+
+    # Experimental support for saving / restoring uncasted versions of functions
+    def _save_func(self, mod, fn, func):
+        self._all_wrappers.append((mod, fn, func))
+
+    def _deactivate(self):
+        for mod, fn, func in self._all_wrappers:
+            utils.set_func(mod, fn, func)
+        self._all_wrappers = []
 
     @property
     def has_cache(self):

--- a/apex/amp/test/test_basic_casts.py
+++ b/apex/amp/test/test_basic_casts.py
@@ -1,0 +1,110 @@
+import unittest
+
+import functools as ft
+import itertools as it
+
+from apex import amp
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+HALF = 'torch.cuda.HalfTensor'
+FLOAT = 'torch.cuda.FloatTensor'
+
+ALWAYS_HALF = {torch.float: HALF,
+               torch.half: HALF}
+ALWAYS_FLOAT = {torch.float: FLOAT,
+                torch.half: FLOAT}
+MATCH_INPUT = {torch.float: FLOAT,
+               torch.half: HALF}
+
+def _common_init(test_case):
+    test_case.h = 64
+    test_case.b = 16
+    test_case.c = 16
+    test_case.k = 3
+    torch.set_default_tensor_type(torch.cuda.FloatTensor)
+
+class TestBasicCasts(unittest.TestCase):
+    def setUp(self):
+        self.handle = amp.init(enabled=True)
+        _common_init(self)
+
+    def tearDown(self):
+        self.handle._deactivate()
+
+    def run_layer_test(self, fns, expected, input_shape, test_backward=True):
+        for fn, typ in it.product(fns, expected.keys()):
+            x = torch.randn(input_shape, dtype=typ).requires_grad_()
+            y = fn(x)
+            self.assertEqual(y.type(), expected[typ])
+            if test_backward:
+                y.float().sum().backward()
+                self.assertEqual(x.grad.type(), MATCH_INPUT[typ])
+
+    def test_linear_is_half(self):
+        m = nn.Linear(self.h, self.h)
+        f = ft.partial(F.linear, weight=m.weight, bias=m.bias)
+        self.run_layer_test([m, f], ALWAYS_HALF, (self.b, self.h))
+
+    def test_conv2d_is_half(self):
+        m = nn.Conv2d(self.c, self.c, self.k)
+        f = ft.partial(F.conv2d, weight=m.weight, bias=m.bias)
+        self.run_layer_test([m, f], ALWAYS_HALF, (self.b, self.c, self.h, self.h))
+
+    def test_softmax_is_float(self):
+        m = nn.Softmax(dim=1)
+        f = ft.partial(F.softmax, dim=1)
+        self.run_layer_test([m, f], ALWAYS_FLOAT, (self.b, self.h))
+
+    def test_group_norm_is_float(self):
+        m = nn.GroupNorm(num_groups=4, num_channels=self.c)
+        self.run_layer_test([m], ALWAYS_FLOAT, (self.b, self.c, self.h, self.h))
+
+    def test_mse_loss_is_float(self):
+        shape = (self.b, self.h)
+        target = torch.randn(shape)
+        mod = nn.MSELoss()
+        m = lambda x: mod(x, target)
+        f = ft.partial(F.mse_loss, target=target)
+        self.run_layer_test([m], ALWAYS_FLOAT, shape)
+
+    def test_relu_is_match(self):
+        self.run_layer_test([nn.ReLU(), F.relu], MATCH_INPUT, (self.b, self.h))
+
+    def test_batch_norm_is_match(self):
+        m = nn.BatchNorm2d(num_features=self.c)
+        f = ft.partial(F.batch_norm, running_mean=m.running_mean, running_var=m.running_var,
+                       weight=m.weight, bias=m.bias, training=True)
+        self.run_layer_test([m], MATCH_INPUT, (self.b, self.c, self.h, self.h))
+
+        # Test forward-only for BN inference
+        m.eval()
+        f = ft.partial(F.batch_norm, running_mean=m.running_mean, running_var=m.running_var,
+                       weight=m.weight, bias=m.bias, training=False)
+        self.run_layer_test([m, f], MATCH_INPUT, (self.b, self.c, self.h, self.h), test_backward=False)
+
+class TestDisabledCasts(unittest.TestCase):
+    def setUp(self):
+        self.handle = amp.init(enabled=False)
+        _common_init(self)
+
+    def test_disabled_linear(self):
+        m = nn.Linear(self.h, self.h)
+        f = ft.partial(F.linear, weight=m.weight, bias=m.bias)
+        input_shape = (self.b, self.h)
+
+        for fn in [m, f]:
+            x = torch.randn(input_shape, dtype=torch.float).requires_grad_()
+            y = fn(x)
+            self.assertEqual(y.type(), FLOAT)
+            y.sum().backward()
+            self.assertEqual(x.grad.type(), FLOAT)
+
+            x = torch.randn(input_shape, dtype=torch.half).requires_grad_()
+            self.assertRaises(RuntimeError, fn, x)
+
+    # TODO: maybe more tests on disabled casting?
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apex/amp/test/test_basic_casts.py
+++ b/apex/amp/test/test_basic_casts.py
@@ -8,58 +8,44 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 
-HALF = 'torch.cuda.HalfTensor'
-FLOAT = 'torch.cuda.FloatTensor'
+from .utils import common_init, HALF, FLOAT,\
+    ALWAYS_HALF, ALWAYS_FLOAT, MATCH_INPUT
 
-ALWAYS_HALF = {torch.float: HALF,
-               torch.half: HALF}
-ALWAYS_FLOAT = {torch.float: FLOAT,
-                torch.half: FLOAT}
-MATCH_INPUT = {torch.float: FLOAT,
-               torch.half: HALF}
-
-def _common_init(test_case):
-    test_case.h = 64
-    test_case.b = 16
-    test_case.c = 16
-    test_case.k = 3
-    torch.set_default_tensor_type(torch.cuda.FloatTensor)
+def run_layer_test(test_case, fns, expected, input_shape, test_backward=True):
+    for fn, typ in it.product(fns, expected.keys()):
+        x = torch.randn(input_shape, dtype=typ).requires_grad_()
+        y = fn(x)
+        test_case.assertEqual(y.type(), expected[typ])
+        if test_backward:
+            y.float().sum().backward()
+            test_case.assertEqual(x.grad.type(), MATCH_INPUT[typ])
 
 class TestBasicCasts(unittest.TestCase):
     def setUp(self):
         self.handle = amp.init(enabled=True)
-        _common_init(self)
+        common_init(self)
 
     def tearDown(self):
         self.handle._deactivate()
 
-    def run_layer_test(self, fns, expected, input_shape, test_backward=True):
-        for fn, typ in it.product(fns, expected.keys()):
-            x = torch.randn(input_shape, dtype=typ).requires_grad_()
-            y = fn(x)
-            self.assertEqual(y.type(), expected[typ])
-            if test_backward:
-                y.float().sum().backward()
-                self.assertEqual(x.grad.type(), MATCH_INPUT[typ])
-
     def test_linear_is_half(self):
         m = nn.Linear(self.h, self.h)
         f = ft.partial(F.linear, weight=m.weight, bias=m.bias)
-        self.run_layer_test([m, f], ALWAYS_HALF, (self.b, self.h))
+        run_layer_test(self, [m, f], ALWAYS_HALF, (self.b, self.h))
 
     def test_conv2d_is_half(self):
         m = nn.Conv2d(self.c, self.c, self.k)
         f = ft.partial(F.conv2d, weight=m.weight, bias=m.bias)
-        self.run_layer_test([m, f], ALWAYS_HALF, (self.b, self.c, self.h, self.h))
+        run_layer_test(self, [m, f], ALWAYS_HALF, (self.b, self.c, self.h, self.h))
 
     def test_softmax_is_float(self):
         m = nn.Softmax(dim=1)
         f = ft.partial(F.softmax, dim=1)
-        self.run_layer_test([m, f], ALWAYS_FLOAT, (self.b, self.h))
+        run_layer_test(self, [m, f], ALWAYS_FLOAT, (self.b, self.h))
 
     def test_group_norm_is_float(self):
         m = nn.GroupNorm(num_groups=4, num_channels=self.c)
-        self.run_layer_test([m], ALWAYS_FLOAT, (self.b, self.c, self.h, self.h))
+        run_layer_test(self, [m], ALWAYS_FLOAT, (self.b, self.c, self.h, self.h))
 
     def test_mse_loss_is_float(self):
         shape = (self.b, self.h)
@@ -67,27 +53,76 @@ class TestBasicCasts(unittest.TestCase):
         mod = nn.MSELoss()
         m = lambda x: mod(x, target)
         f = ft.partial(F.mse_loss, target=target)
-        self.run_layer_test([m], ALWAYS_FLOAT, shape)
+        run_layer_test(self, [m], ALWAYS_FLOAT, shape)
 
     def test_relu_is_match(self):
-        self.run_layer_test([nn.ReLU(), F.relu], MATCH_INPUT, (self.b, self.h))
+        run_layer_test(self, [nn.ReLU(), F.relu], MATCH_INPUT, (self.b, self.h))
 
     def test_batch_norm_is_match(self):
         m = nn.BatchNorm2d(num_features=self.c)
         f = ft.partial(F.batch_norm, running_mean=m.running_mean, running_var=m.running_var,
                        weight=m.weight, bias=m.bias, training=True)
-        self.run_layer_test([m], MATCH_INPUT, (self.b, self.c, self.h, self.h))
+        run_layer_test(self, [m], MATCH_INPUT, (self.b, self.c, self.h, self.h))
 
         # Test forward-only for BN inference
         m.eval()
         f = ft.partial(F.batch_norm, running_mean=m.running_mean, running_var=m.running_var,
                        weight=m.weight, bias=m.bias, training=False)
-        self.run_layer_test([m, f], MATCH_INPUT, (self.b, self.c, self.h, self.h), test_backward=False)
+        run_layer_test(self, [m, f], MATCH_INPUT, (self.b, self.c, self.h, self.h),
+                            test_backward=False)
+
+    def test_bce_raises(self):
+        shape = (self.b, self.h)
+        target = torch.randn(shape)
+        mod = nn.BCELoss()
+        m = lambda x: mod(x, target)
+        f = ft.partial(F.binary_cross_entropy, target=target)
+        for fn in [m, f]:
+            x = torch.randn(shape, dtype=torch.half)
+            self.assertRaises(NotImplementedError, fn, x)
+
+class TestTensorCasts(unittest.TestCase):
+    def setUp(self):
+        self.handle = amp.init(enabled=True)
+        common_init(self)
+
+    def tearDown(self):
+        self.handle._deactivate()
+
+    def test_matmul_method_is_half(self):
+        other = torch.randn(self.h, self.h)
+        lhs = lambda x: x.matmul(other)
+        rhs = lambda x: other.matmul(x)
+        run_layer_test(self, [lhs, rhs], ALWAYS_HALF, (self.h, self.h))
+
+    def test_matmul_op_is_half(self):
+        other = torch.randn(self.h, self.h)
+        lhs = lambda x: x @ other
+        rhs = lambda x: other @ x
+        run_layer_test(self, [lhs, rhs], ALWAYS_HALF, (self.h, self.h))
+
+    def test_pow_method_is_float(self):
+        fn = lambda x: x.pow(2.)
+        run_layer_test(self, [fn], ALWAYS_FLOAT, (self.b, self.h))
+
+    def test_pow_op_is_float(self):
+        fn = lambda x: x ** 2.
+        run_layer_test(self, [fn], ALWAYS_FLOAT, (self.b, self.h))
+
+    def test_cpu_is_float(self):
+        fn = lambda x: x.cpu()
+        always_cpu_float = {torch.float: 'torch.FloatTensor',
+                            torch.half: 'torch.FloatTensor'}
+        run_layer_test(self, [fn], always_cpu_float, (self.b, self.h))
+
+    def test_sum_is_float(self):
+        fn = lambda x: x.sum()
+        run_layer_test(self, [fn], ALWAYS_FLOAT, (self.b, self.h))
 
 class TestDisabledCasts(unittest.TestCase):
     def setUp(self):
         self.handle = amp.init(enabled=False)
-        _common_init(self)
+        common_init(self)
 
     def test_disabled_linear(self):
         m = nn.Linear(self.h, self.h)

--- a/apex/amp/test/test_promotion.py
+++ b/apex/amp/test/test_promotion.py
@@ -1,0 +1,58 @@
+import unittest
+
+import itertools as it
+
+from apex import amp
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+from .utils import common_init, HALF, FLOAT, DTYPES
+
+class TestPromotion(unittest.TestCase):
+    def setUp(self):
+        self.handle = amp.init(enabled=True)
+        common_init(self)
+
+    def tearDown(self):
+        self.handle._deactivate()
+
+    def run_binary_promote_test(self, fns, input_shape):
+        type_pairs = it.product(DTYPES, DTYPES)
+        for fn, (xtype, ytype) in it.product(fns, type_pairs):
+            x = torch.randn(input_shape, dtype=xtype).requires_grad_()
+            y = torch.randn(input_shape, dtype=ytype)
+            out = fn(x, y)
+            if xtype == torch.float or ytype == torch.float:
+                self.assertEqual(out.type(), FLOAT)
+            else:
+                self.assertEqual(out.type(), HALF)
+            out.float().sum().backward()
+            self.assertEqual(x.grad.dtype, xtype)
+
+    def test_atan2_matches_widest(self):
+        fns = [lambda x, y : torch.atan2(x, y),
+               lambda x, y : x.atan2(y)]
+        self.run_binary_promote_test(fns, (self.b,))
+
+    def test_mul_matches_widest(self):
+        fns = [lambda x, y : torch.mul(x, y),
+               lambda x, y: x.mul(y)]
+        self.run_binary_promote_test(fns, (self.b,))
+
+    def test_cat_matches_widest(self):
+        shape = self.b
+        ys = [torch.randn(shape, dtype=torch.half) for _ in range(5)]
+        x_float = torch.randn(shape)
+        out = torch.cat(ys + [x_float])
+        self.assertEqual(out.type(), FLOAT)
+        x_half = torch.randn(shape, dtype=torch.half)
+        out = torch.cat(ys + [x_half])
+        self.assertEqual(out.type(), HALF)
+
+    # TODOs:
+    # In-place methods on fp16 are errors for fp32
+    # In-place methods match type of self tensor
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apex/amp/test/test_rnn.py
+++ b/apex/amp/test/test_rnn.py
@@ -1,0 +1,97 @@
+import unittest
+
+from apex import amp
+import torch
+from torch import nn
+
+from .utils import common_init, HALF
+
+class TestRnnCells(unittest.TestCase):
+    def setUp(self):
+        self.handle = amp.init(enabled=True)
+        common_init(self)
+
+    def tearDown(self):
+        self.handle._deactivate()
+
+    def run_cell_test(self, cell, state_tuple=False):
+        shape = (self.b, self.h)
+        for typ in [torch.float, torch.half]:
+            xs = [torch.randn(shape, dtype=typ).requires_grad_()
+                  for _ in range(self.t)]
+            hidden_fn = lambda: torch.zeros(shape, dtype=typ)
+            if state_tuple:
+                hidden = (hidden_fn(), hidden_fn())
+            else:
+                hidden = hidden_fn()
+            outputs = []
+            for i in range(self.t):
+                hidden = cell(xs[i], hidden)
+                if state_tuple:
+                    output = hidden[0]
+                else:
+                    output = hidden
+                outputs.append(output)
+            for y in outputs:
+                self.assertEqual(y.type(), HALF)
+            outputs[-1].float().sum().backward()
+            for i, x in enumerate(xs):
+                self.assertEqual(x.grad.dtype, x.dtype)
+
+    def test_rnn_cell_is_half(self):
+        cell = nn.RNNCell(self.h, self.h)
+        self.run_cell_test(cell)
+
+    def test_gru_cell_is_half(self):
+        cell = nn.GRUCell(self.h, self.h)
+        self.run_cell_test(cell)
+
+    def test_lstm_cell_is_half(self):
+        cell = nn.LSTMCell(self.h, self.h)
+        self.run_cell_test(cell, state_tuple=True)
+
+class TestRnns(unittest.TestCase):
+    def setUp(self):
+        self.handle = amp.init(enabled=True)
+        common_init(self)
+
+    def tearDown(self):
+        self.handle._deactivate()
+
+    def run_rnn_test(self, rnn, layers, bidir, state_tuple=False):
+        for typ in [torch.float, torch.half]:
+            x = torch.randn((self.t, self.b, self.h), dtype=typ).requires_grad_()
+            hidden_fn = lambda: torch.zeros((layers + (layers * bidir),
+                                             self.b, self.h), dtype=typ)
+            if state_tuple:
+                hidden = (hidden_fn(), hidden_fn())
+            else:
+                hidden = hidden_fn()
+            output, _ = rnn(x, hidden)
+            self.assertEqual(output.type(), HALF)
+            output[-1, :, :].float().sum().backward()
+            self.assertEqual(x.grad.dtype, x.dtype)
+
+    def test_rnn_is_half(self):
+        configs = [(1, False), (2, False), (2, True)]
+        for layers, bidir in configs:
+            rnn = nn.RNN(input_size=self.h, hidden_size=self.h, num_layers=layers,
+                         nonlinearity='relu', bidirectional=bidir)
+            self.run_rnn_test(rnn, layers, bidir)
+
+    def test_gru_is_half(self):
+        configs = [(1, False), (2, False), (2, True)]
+        for layers, bidir in configs:
+            rnn = nn.GRU(input_size=self.h, hidden_size=self.h, num_layers=layers,
+                         bidirectional=bidir)
+            self.run_rnn_test(rnn, layers, bidir)
+
+    def test_lstm_is_half(self):
+        configs = [(1, False), (2, False), (2, True)]
+        for layers, bidir in configs:
+            rnn = nn.LSTM(input_size=self.h, hidden_size=self.h, num_layers=layers,
+                         bidirectional=bidir)
+            self.run_rnn_test(rnn, layers, bidir, state_tuple=True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apex/amp/test/utils.py
+++ b/apex/amp/test/utils.py
@@ -1,0 +1,20 @@
+import torch
+
+HALF = 'torch.cuda.HalfTensor'
+FLOAT = 'torch.cuda.FloatTensor'
+
+DTYPES = [torch.half, torch.float]
+
+ALWAYS_HALF = {torch.float: HALF,
+               torch.half: HALF}
+ALWAYS_FLOAT = {torch.float: FLOAT,
+                torch.half: FLOAT}
+MATCH_INPUT = {torch.float: FLOAT,
+               torch.half: HALF}
+
+def common_init(test_case):
+    test_case.h = 64
+    test_case.b = 16
+    test_case.c = 16
+    test_case.k = 3
+    torch.set_default_tensor_type(torch.cuda.FloatTensor)

--- a/apex/amp/test/utils.py
+++ b/apex/amp/test/utils.py
@@ -17,4 +17,5 @@ def common_init(test_case):
     test_case.b = 16
     test_case.c = 16
     test_case.k = 3
+    test_case.t = 10
     torch.set_default_tensor_type(torch.cuda.FloatTensor)

--- a/apex/amp/utils.py
+++ b/apex/amp/utils.py
@@ -126,6 +126,11 @@ def set_func(mod, fn, new_fn):
     else:
         setattr(mod, fn, new_fn)
 
+def set_func_save(handle, mod, fn, new_fn):
+    cur_fn = get_func(mod, fn)
+    handle._save_func(mod, fn, cur_fn)
+    set_func(mod, fn, new_fn)
+
 # A couple problems get solved here:
 # - The flat_weight buffer is disconnected from autograd graph,
 #   so the fp16 weights need to be derived from the input weights

--- a/apex/amp/wrap.py
+++ b/apex/amp/wrap.py
@@ -34,7 +34,7 @@ def cached_cast(mod, fn, cast_fn, handle,
     orig_fn = utils.get_func(mod, fn)
     cast_fn = utils.verbosify(cast_fn, fn, verbose)
     wrapper = make_cast_wrapper(orig_fn, cast_fn, handle, try_caching)
-    utils.set_func(mod, fn, wrapper)
+    utils.set_func_save(handle, mod, fn, wrapper)
 
 # `handle` arg is unused, but simplifies API to make `make_cast_wrapper`
 def make_promote_wrapper(orig_fn, cast_fn, handle=None):
@@ -54,13 +54,13 @@ def make_promote_wrapper(orig_fn, cast_fn, handle=None):
                                       .format(types))
     return wrapper
 
-def promote(mod, fn, verbose=False):
+def promote(mod, fn, handle, verbose=False):
     orig_fn = utils.get_func(mod, fn)
     maybe_float = utils.verbosify(utils.maybe_float, fn, verbose)
     wrapper = make_promote_wrapper(orig_fn, maybe_float)
-    utils.set_func(mod, fn, wrapper)
+    utils.set_func_save(handle, mod, fn, wrapper)
 
-def sequence_promote(mod, fn, verbose=False):
+def sequence_promote(mod, fn, handle, verbose=False):
     orig_fn = utils.get_func(mod, fn)
     maybe_float = utils.verbosify(utils.maybe_float, fn, verbose)
     @functools.wraps(orig_fn)
@@ -76,9 +76,9 @@ def sequence_promote(mod, fn, verbose=False):
             # TODO: other mixed-type cases aren't due to amp.
             #       Just pass through?
             return orig_fn(seq, *args, **kwargs)
-    utils.set_func(mod, fn, wrapper)
+    utils.set_func_save(handle, mod, fn, wrapper)
 
-def promote_match_arg0(mod, fn, verbose=False):
+def promote_match_arg0(mod, fn, handle, verbose=False):
     if not utils.has_func(mod, fn):
         return
 
@@ -95,9 +95,9 @@ def promote_match_arg0(mod, fn, verbose=False):
         cast_fn = utils.verbosify(cast_fn, fn, verbose)
         new_args = utils.casted_args(cast_fn, args, kwargs)
         return orig_fn(arg0, *new_args, **kwargs)
-    utils.set_func(mod, fn, wrapper)
+    utils.set_func_save(handle, mod, fn, wrapper)
 
-def err_if_any_half(mod, fn, custom_err_msg=None):
+def err_if_any_half(mod, fn, handle, custom_err_msg=None):
     if not utils.has_func(mod, fn):
         return
 
@@ -113,9 +113,9 @@ def err_if_any_half(mod, fn, custom_err_msg=None):
                                           '{} with fp16 arguments.'.format(fn))
         else:
             return orig_fn(*args, **kwargs)
-    utils.set_func(mod, fn, wrapper)
+    utils.set_func_save(handle, mod, fn, wrapper)
 
-def err_if_arg0_half(mod, fn, verbose=False):
+def err_if_arg0_half(mod, fn, handle, verbose=False):
     if not utils.has_func(mod, fn):
         return
 
@@ -130,7 +130,7 @@ def err_if_arg0_half(mod, fn, verbose=False):
             cast_fn = utils.verbosify(utils.maybe_float, fn, verbose)
             new_args = utils.casted_args(cast_fn, args, kwargs)
             return orig_fn(arg0, *new_args, **kwargs)
-    utils.set_func(mod, fn, wrapper)
+    utils.set_func_save(handle, mod, fn, wrapper)
 
 # Current RNN approach:
 # - Wrap top-level `RNN` function in thnn backend
@@ -140,7 +140,7 @@ def err_if_arg0_half(mod, fn, verbose=False):
 # - We interpose on the factory function to:
 #   1) Interpose on the actual forward function and put in casts
 #   2) Insert an fp16 `flat_weight` if necessary
-def rnn_cast(backend, fn, verbose=False):
+def rnn_cast(backend, fn, handle, verbose=False):
     orig_rnn = utils.get_func(backend, fn)
     @functools.wraps(orig_rnn)
     def rnn_wrapper(*args, **kwargs):
@@ -203,7 +203,7 @@ def rnn_cast(backend, fn, verbose=False):
 
             return forward(*new_args, **fkwargs)
         return fwd_wrapper
-    utils.set_func(backend, fn, rnn_wrapper)
+    utils.set_func_save(handle, backend, fn, rnn_wrapper)
 
 def disable_casts(mod, fn, handle):
     if not utils.has_func(mod, fn):
@@ -214,4 +214,4 @@ def disable_casts(mod, fn, handle):
     def wrapper(*args, **kwargs):
         with handle._disable_casts():
             return orig_fn(*args, **kwargs)
-    utils.set_func(mod, fn, wrapper)
+    utils.set_func_save(handle, mod, fn, wrapper)


### PR DESCRIPTION
Main change here is the first set of unit tests for amp. Tests all the different casting cases. Tests for things like loss scaling or the optimizer wrapper are still TODO.

Also adds experimental support for calling `handle._deactivate()` on an initialized amp handle -- it unwinds all monkey patching. This makes test running easier.

Run `python -m unittest discover -v` in the apex root directory to run tests.