### PR TITLE
amp support for Aten RNNs

### DIFF
--- a/apex/amp/rnn_compat.py
+++ b/apex/amp/rnn_compat.py
@@ -1,0 +1,48 @@
+from . import utils, wrap
+
+import torch
+_VF = torch._C._VariableFunctions
+RNN_NAMES = ['rnn_relu', 'rnn_tanh', 'gru', 'lstm']
+
+def _gen_VF_wrapper(name):
+    def wrapper(*args, **kwargs):
+        return getattr(_VF, name)(*args, **kwargs)
+    return wrapper
+
+# Some python magic to generate an object that has the rnn cell functions
+# defined on it, all of which call into corresponding _VF version.
+class VariableFunctionsShim(object):
+    def __init__(self):
+        for name in RNN_NAMES:
+            setattr(self, name + '_cell', _gen_VF_wrapper(name + '_cell'))
+
+def has_old_rnns():
+    try:
+        torch.nn.backends.thnn.backend.LSTMCell
+        return True
+    except:
+        return False
+
+def whitelist_rnn_cells(handle, verbose):
+    # Different module + function names in old/new RNN cases
+    if has_old_rnns():
+        fn_names = ['RNNReLUCell', 'RNNTanhCell', 'LSTMCell', 'GRUCell']
+        mod = torch.nn.backends.thnn.backend
+    else:
+        fn_names = [x + '_cell' for x in RNN_NAMES]
+        mod = torch.nn.modules.rnn._VF
+        assert isinstance(mod, VariableFunctionsShim)
+
+    # Insert casts on cell functions
+    for fn in fn_names:
+        wrap.cached_cast(mod, fn, utils.maybe_half, handle,
+                         try_caching=True, verbose=verbose)
+
+    if has_old_rnns():
+        # Special handling of `backward` for fused gru / lstm:
+        # The `backward` method calls Tensor.sum() (blacklist) internally,
+        # and then the resulting grad_input has the wrong type.
+        # TODO: where else is this a problem?
+        for rnn_type in ['GRUFused', 'LSTMFused']:
+            mod = getattr(torch.nn._functions.thnn.rnnFusedPointwise, rnn_type)
+            wrap.disable_casts(mod, 'backward', handle)

--- a/apex/amp/utils.py
+++ b/apex/amp/utils.py
@@ -111,18 +111,24 @@ def as_inplace(fns):
 def has_func(mod, fn):
     if isinstance(mod, torch.nn.backends.backend.FunctionBackend):
         return fn in mod.function_classes
+    elif isinstance(mod, dict):
+        return fn in mod
     else:
         return hasattr(mod, fn)
 
 def get_func(mod, fn):
     if isinstance(mod, torch.nn.backends.backend.FunctionBackend):
         return mod.function_classes[fn]
+    elif isinstance(mod, dict):
+        return mod[fn]
     else:
         return getattr(mod, fn)
 
 def set_func(mod, fn, new_fn):
     if isinstance(mod, torch.nn.backends.backend.FunctionBackend):
         mod.function_classes[fn] = new_fn
+    elif isinstance(mod, dict):
+        mod[fn] = new_fn
     else:
         setattr(mod, fn, new_fn)
 
@@ -164,4 +170,24 @@ def synthesize_flattened_rnn_weights(fp32_weights,
                 print('Float->Half ({})'.format(rnn_fn))
             fp16_layer_weights.append(w_fp16)
         fp16_weights.append(fp16_layer_weights)
+    return fp16_weights
+
+# Roughly same as above, just the `fp32_weights` aren't nested.
+# Code kept separate for readability.
+def new_synthesize_flattened_rnn_weights(fp32_weights,
+                                         fp16_flat_tensor,
+                                         rnn_fn='',
+                                         verbose=False):
+    fp16_weights = []
+    fp32_base_ptr = fp32_weights[0].data_ptr()
+    for w_fp32 in fp32_weights:
+        w_fp16 = w_fp32.new().half()
+        offset = (w_fp32.data_ptr() - fp32_base_ptr) // w_fp32.element_size()
+        w_fp16.set_(fp16_flat_tensor.storage(),
+                    offset,
+                    w_fp32.shape)
+        w_fp16.copy_(w_fp32)
+        if verbose:
+            print('Float->Half ({})'.format(rnn_fn))
+        fp16_weights.append(w_fp16)
     return fp16_weights


### PR DESCRIPTION
Adds code to handle casts for the Aten-based RNN API, along with compatibility logic to continue working with 0.4.

Tests so far are:
- RNN unit tests (added an extra one here to check the padded sequence logic)
- Check training curves match on word-lm example w/ amp enabled