### PR TITLE
Update examples to PyTorch >=0.4.0

### DIFF
--- a/examples/FP16_Optimizer_simple/closure.py
+++ b/examples/FP16_Optimizer_simple/closure.py
@@ -1,13 +1,12 @@
 import torch
-from torch.autograd import Variable
 from apex.fp16_utils import FP16_Optimizer
 
 torch.backends.cudnn.benchmark = True
 
 N, D_in, D_out = 64, 1024, 16
 
-x = Variable(torch.cuda.FloatTensor(N, D_in ).normal_()).half()
-y = Variable(torch.cuda.FloatTensor(N, D_out).normal_()).half()
+x = torch.randn(N, D_in, device='cuda', dtype=torch.half)
+y = torch.randn(N, D_out, device='cuda', dtype=torch.half)
 
 model = torch.nn.Linear(D_in, D_out).cuda().half()
 
@@ -29,4 +28,4 @@ for t in range(5):
         return loss
     loss = optimizer.step(closure)
 
-print("final loss = ", loss) 
+print("final loss = ", loss)

--- a/examples/FP16_Optimizer_simple/distributed_apex/distributed_data_parallel.py
+++ b/examples/FP16_Optimizer_simple/distributed_apex/distributed_data_parallel.py
@@ -1,5 +1,4 @@
 import torch
-from torch.autograd import Variable
 import argparse
 from apex.parallel import DistributedDataParallel as DDP
 from apex.fp16_utils import FP16_Optimizer
@@ -16,8 +15,8 @@ torch.backends.cudnn.benchmark = True
 
 N, D_in, D_out = 64, 1024, 16
 
-x = Variable(torch.cuda.FloatTensor(N, D_in ).normal_()).half()
-y = Variable(torch.cuda.FloatTensor(N, D_out).normal_()).half()
+x = torch.randn(N, D_in, device='cuda', dtype=torch.half)
+y = torch.randn(N, D_out, device='cuda', dtype=torch.half)
 
 model = torch.nn.Linear(D_in, D_out).cuda().half()
 model = DDP(model)

--- a/examples/FP16_Optimizer_simple/distributed_apex_legacy_launcher/distributed_data_parallel.py
+++ b/examples/FP16_Optimizer_simple/distributed_apex_legacy_launcher/distributed_data_parallel.py
@@ -1,5 +1,4 @@
 import torch
-from torch.autograd import Variable
 import argparse
 from apex.parallel import DistributedDataParallel as DDP
 from apex.fp16_utils import FP16_Optimizer
@@ -24,8 +23,8 @@ torch.backends.cudnn.benchmark = True
 
 N, D_in, D_out = 64, 1024, 16
 
-x = Variable(torch.cuda.FloatTensor(N, D_in ).normal_()).half()
-y = Variable(torch.cuda.FloatTensor(N, D_out).normal_()).half()
+x = torch.randn(N, D_in, device='cuda', dtype=torch.half)
+y = torch.randn(N, D_out, device='cuda', dtype=torch.half)
 
 model = torch.nn.Linear(D_in, D_out).cuda().half()
 model = DDP(model)

--- a/examples/FP16_Optimizer_simple/distributed_pytorch/distributed_data_parallel.py
+++ b/examples/FP16_Optimizer_simple/distributed_pytorch/distributed_data_parallel.py
@@ -1,5 +1,4 @@
 import torch
-from torch.autograd import Variable
 import argparse
 from apex.fp16_utils import FP16_Optimizer
 
@@ -15,8 +14,8 @@ torch.backends.cudnn.benchmark = True
 
 N, D_in, D_out = 64, 1024, 16
 
-x = Variable(torch.cuda.FloatTensor(N, D_in ).normal_()).half()
-y = Variable(torch.cuda.FloatTensor(N, D_out).normal_()).half()
+x = torch.randn(N, D_in, device='cuda', dtype=torch.half)
+y = torch.randn(N, D_out, device='cuda', dtype=torch.half)
 
 model = torch.nn.Linear(D_in, D_out).cuda().half()
 model = torch.nn.parallel.DistributedDataParallel(model,

--- a/examples/FP16_Optimizer_simple/minimal.py
+++ b/examples/FP16_Optimizer_simple/minimal.py
@@ -1,13 +1,12 @@
 import torch
-from torch.autograd import Variable
 from apex.fp16_utils import FP16_Optimizer
 
 torch.backends.cudnn.benchmark = True
 
 N, D_in, D_out = 64, 1024, 16
 
-x = Variable(torch.cuda.FloatTensor(N, D_in ).normal_()).half()
-y = Variable(torch.cuda.FloatTensor(N, D_out).normal_()).half()
+x = torch.randn(N, D_in, device='cuda', dtype=torch.half)
+y = torch.randn(N, D_out, device='cuda', dtype=torch.half)
 
 model = torch.nn.Linear(D_in, D_out).cuda().half()
 

--- a/examples/FP16_Optimizer_simple/save_load.py
+++ b/examples/FP16_Optimizer_simple/save_load.py
@@ -1,13 +1,12 @@
 import torch
-from torch.autograd import Variable
 from apex.fp16_utils import FP16_Optimizer
 
 torch.backends.cudnn.benchmark = True
 
 N, D_in, D_out = 64, 1024, 16
 
-x = Variable(torch.cuda.FloatTensor(N, D_in ).normal_()).half()
-y = Variable(torch.cuda.FloatTensor(N, D_out).normal_()).half()
+x = torch.randn(N, D_in, device='cuda', dtype=torch.half)
+y = torch.randn(N, D_out, device='cuda', dtype=torch.half)
 
 model = torch.nn.Linear(D_in, D_out).cuda().half()
 

--- a/examples/distributed/main.py
+++ b/examples/distributed/main.py
@@ -175,7 +175,7 @@ def test():
             output = model(data)
             test_loss += to_python_float(F.nll_loss(output, target, size_average=False).data) # sum up batch loss
             pred = output.data.max(1, keepdim=True)[1] # get the index of the max log-probability
-            correct += pred.eq(target.data.view_as(pred)).cpu().float().sum()
+            correct += pred.eq(target.data.view_as(pred)).float().cpu().sum()
 
     test_loss /= len(test_loader.dataset)
 

--- a/examples/imagenet/main.py
+++ b/examples/imagenet/main.py
@@ -4,7 +4,6 @@ import shutil
 import time
 
 import torch
-from torch.autograd import Variable
 import torch.nn as nn
 import torch.nn.parallel
 import torch.backends.cudnn as cudnn
@@ -315,12 +314,9 @@ def train(train_loader, model, criterion, optimizer, epoch):
         # measure data loading time
         data_time.update(time.time() - end)
 
-        input_var = Variable(input)
-        target_var = Variable(target)
-
         # compute output
-        output = model(input_var)
-        loss = criterion(output, target_var)
+        output = model(input)
+        loss = criterion(output, target)
 
         # measure accuracy and record loss
         prec1, prec5 = accuracy(output.data, target, topk=(1, 5))
@@ -392,13 +388,11 @@ def validate(val_loader, model, criterion):
         i += 1
 
         target = target.cuda(async=True)
-        input_var = Variable(input)
-        target_var = Variable(target)
 
         # compute output
         with torch.no_grad():
-            output = model(input_var)
-            loss = criterion(output, target_var)
+            output = model(input)
+            loss = criterion(output, target)
 
         # measure accuracy and record loss
         prec1, prec5 = accuracy(output.data, target, topk=(1, 5))

--- a/examples/imagenet/main_fp16_optimizer.py
+++ b/examples/imagenet/main_fp16_optimizer.py
@@ -4,7 +4,6 @@ import shutil
 import time
 
 import torch
-from torch.autograd import Variable
 import torch.nn as nn
 import torch.nn.parallel
 import torch.backends.cudnn as cudnn
@@ -307,12 +306,9 @@ def train(train_loader, model, criterion, optimizer, epoch):
         # measure data loading time
         data_time.update(time.time() - end)
 
-        input_var = Variable(input)
-        target_var = Variable(target)
-
         # compute output
-        output = model(input_var)
-        loss = criterion(output, target_var)
+        output = model(input)
+        loss = criterion(output, target)
 
         # measure accuracy and record loss
         prec1, prec5 = accuracy(output.data, target, topk=(1, 5))
@@ -376,13 +372,11 @@ def validate(val_loader, model, criterion):
         i += 1
 
         target = target.cuda(async=True)
-        input_var = Variable(input)
-        target_var = Variable(target)
 
         # compute output
         with torch.no_grad():
-            output = model(input_var)
-            loss = criterion(output, target_var)
+            output = model(input)
+            loss = criterion(output, target)
 
         # measure accuracy and record loss
         prec1, prec5 = accuracy(output.data, target, topk=(1, 5))

--- a/examples/imagenet/main_fp16_optimizer.py
+++ b/examples/imagenet/main_fp16_optimizer.py
@@ -371,8 +371,6 @@ def validate(val_loader, model, criterion):
     while input is not None:
         i += 1
 
-        target = target.cuda(async=True)
-
         # compute output
         with torch.no_grad():
             output = model(input)

--- a/examples/imagenet/main_reducer.py
+++ b/examples/imagenet/main_reducer.py
@@ -4,7 +4,6 @@ import shutil
 import time
 
 import torch
-from torch.autograd import Variable
 import torch.nn as nn
 import torch.nn.parallel
 import torch.backends.cudnn as cudnn
@@ -301,12 +300,9 @@ def train(train_loader, model, criterion, optimizer, epoch):
         # measure data loading time
         data_time.update(time.time() - end)
 
-        input_var = Variable(input)
-        target_var = Variable(target)
-
         # compute output
-        output = model(input_var)
-        loss = criterion(output, target_var)
+        output = model(input)
+        loss = criterion(output, target)
 
         # measure accuracy and record loss
         prec1, prec5 = accuracy(output.data, target, topk=(1, 5))
@@ -382,13 +378,11 @@ def validate(val_loader, model, criterion):
         i += 1
 
         target = target.cuda(async=True)
-        input_var = Variable(input)
-        target_var = Variable(target)
 
         # compute output
         with torch.no_grad():
-            output = model(input_var)
-            loss = criterion(output, target_var)
+            output = model(input)
+            loss = criterion(output, target)
 
         # measure accuracy and record loss
         prec1, prec5 = accuracy(output.data, target, topk=(1, 5))

--- a/examples/word_language_model/main.py
+++ b/examples/word_language_model/main.py
@@ -4,7 +4,6 @@ import time
 import math
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
 import data
 import model
 
@@ -58,8 +57,6 @@ torch.manual_seed(args.seed)
 if torch.cuda.is_available():
     if not args.cuda:
         print("WARNING: You have a CUDA device, so you should probably run with --cuda")
-    else:
-        torch.cuda.manual_seed(args.seed)
 if args.fp16 and not args.cuda:
     print("WARNING: --fp16 requires --cuda, ignoring --fp16 option")
 
@@ -117,7 +114,7 @@ criterion = nn.CrossEntropyLoss()
 
 
 def repackage_hidden(h):
-    """Wraps hidden states in new Variables, to detach them from their history."""
+    """Detaches hidden states from their history."""
     if torch.is_tensor(h):
         return h.detach()
     else:
@@ -136,8 +133,8 @@ def repackage_hidden(h):
 
 def get_batch(source, i):
     seq_len = min(args.bptt, len(source) - 1 - i)
-    data = Variable(source[i:i+seq_len])
-    target = Variable(source[i+1:i+1+seq_len].view(-1))
+    data = source[i:i+seq_len]
+    target = source[i+1:i+1+seq_len].view(-1)
     return data, target
 
 

--- a/examples/word_language_model/main_fp16_optimizer.py
+++ b/examples/word_language_model/main_fp16_optimizer.py
@@ -4,7 +4,6 @@ import time
 import math
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
 import data
 import model
 
@@ -61,8 +60,6 @@ torch.manual_seed(args.seed)
 if torch.cuda.is_available():
     if not args.cuda:
         print("WARNING: You have a CUDA device, so you should probably run with --cuda")
-    else:
-        torch.cuda.manual_seed(args.seed)
 if args.fp16 and not args.cuda:
     print("WARNING: --fp16 requires --cuda, ignoring --fp16 option")
 
@@ -132,7 +129,7 @@ if args.cuda and args.fp16:
 
 
 def repackage_hidden(h):
-    """Wraps hidden states in new Variables, to detach them from their history."""
+    """Detaches hidden states from their history."""
     if torch.is_tensor(h):
         return h.detach()
     else:
@@ -151,8 +148,8 @@ def repackage_hidden(h):
 
 def get_batch(source, i):
     seq_len = min(args.bptt, len(source) - 1 - i)
-    data = Variable(source[i:i+seq_len])
-    target = Variable(source[i+1:i+1+seq_len].view(-1))
+    data = source[i:i+seq_len]
+    target = source[i+1:i+1+seq_len].view(-1)
     return data, target
 
 

--- a/examples/word_language_model/model.py
+++ b/examples/word_language_model/model.py
@@ -1,5 +1,4 @@
 import torch.nn as nn
-from torch.autograd import Variable
 
 
 class RNNModel(nn.Module):
@@ -53,7 +52,7 @@ class RNNModel(nn.Module):
     def init_hidden(self, bsz):
         weight = next(self.parameters()).data
         if self.rnn_type == 'LSTM':
-            return (Variable(weight.new(self.nlayers, bsz, self.nhid).zero_()),
-                    Variable(weight.new(self.nlayers, bsz, self.nhid).zero_()))
+            return (weight.new(self.nlayers, bsz, self.nhid).zero_(),
+                    weight.new(self.nlayers, bsz, self.nhid).zero_())
         else:
-            return Variable(weight.new(self.nlayers, bsz, self.nhid).zero_())
+            return weight.new(self.nlayers, bsz, self.nhid).zero_()


### PR DESCRIPTION
This PR updates the examples to PyTorch versions >= 0.4.0.

Minor cleanups were performed in all examples:

- Remove `Variables` as they are deprecated
- Remove `torch.cuda.manual_seed`, since `torch.manual_seed` also seeds all CUDA devices if available ([source](https://pytorch.org/docs/master/notes/randomness.html#pytorch))
- Add `with torch.no_grad()` statements where they were missing or `Variable(, volatile=True)` was used

Minor potential bugs fixed:

- [`examples/distributed/main.py`](https://github.com/ptrblck/apex/blob/28bdc04eec8304c4985bb6625828f3c8fdaf321e/examples/distributed/main.py#L178): Convert `correct` to `float`, since `torch.tensor.eq` op returns a `torch.uint8` tensor, which might overflow for large batch sizes
- [`examples/word_language_model/generate.py`](https://github.com/ptrblck/apex/blob/28bdc04eec8304c4985bb6625828f3c8fdaf321e/examples/word_language_model/generate.py#L64): Convert `word_weights` to `float` before calling `torch.multinominal`, since this function is not implemented for `torch.HalfTensors` and yields an error

I've tested these changes on my local machine as far as possible. However, since I only have a Single-GPU system, I couldn't test the distributed examples. Let me know, how to proceed with these examples.

Best,
ptrblck