### PR TITLE
[syncBN]

### DIFF
--- a/apex/parallel/__init__.py
+++ b/apex/parallel/__init__.py
@@ -1,14 +1,5 @@
 import torch
 
-# Backward compatibility hack around
-# https://github.com/pytorch/pytorch/pull/14767
-if hasattr(torch.distributed, 'get_default_group'):
-    group_creator = torch.distributed.get_default_group
-elif hasattr(torch.distributed, 'new_group'):
-    group_creator = torch.distributed.new_group
-else:
-    group_creator = torch.distributed.deprecated.new_group
-
 if hasattr(torch.distributed, 'ReduceOp'):
     ReduceOp = torch.distributed.ReduceOp
 elif hasattr(torch.distributed, 'reduce_op'):

--- a/apex/parallel/sync_batchnorm_kernel.py
+++ b/apex/parallel/sync_batchnorm_kernel.py
@@ -1,7 +1,7 @@
 import torch
 from torch.autograd.function import Function
 
-from apex.parallel import group_creator, ReduceOp
+from apex.parallel import ReduceOp
 
 
 class SyncBatchnormFunction(Function):


### PR DESCRIPTION
replacing new_group with torch.distributed.group.WORLD, avoids creating new
group in every iteration.

This should resolve the issue in Training gets stuck when using SyncBN #105