### PR TITLE
Better FP16 support in pytorch fp16 utils.

### DIFF
--- a/apex/fp16_utils/__init__.py
+++ b/apex/fp16_utils/__init__.py
@@ -3,10 +3,13 @@ from .fp16util import (
     network_to_half,
     prep_param_lists,
     model_grads_to_master_grads,
-    master_params_to_model_params, 
+    master_params_to_model_params,
     tofp16,
     to_python_float,
     clip_grad_norm,
+    convert_module,
+    convert_network,
+    FP16Model,
 )
 
 

--- a/tests/run_fp16util/test_fp16util.py
+++ b/tests/run_fp16util/test_fp16util.py
@@ -1,0 +1,75 @@
+import unittest
+
+import torch
+import torch.nn as nn
+
+from apex.fp16_utils import FP16Model
+
+
+class DummyBlock(nn.Module):
+    def __init__(self):
+        super(DummyBlock, self).__init__()
+
+        self.conv = nn.Conv2d(10, 10, 2)
+        self.bn = nn.BatchNorm2d(10, affine=True)
+
+    def forward(self, x):
+        return self.conv(self.bn(x))
+
+
+class DummyNet(nn.Module):
+    def __init__(self):
+        super(DummyNet, self).__init__()
+
+        self.conv1 = nn.Conv2d(3, 10, 2)
+        self.bn1 = nn.BatchNorm2d(10, affine=False)
+        self.db1 = DummyBlock()
+        self.db2 = DummyBlock()
+
+    def forward(self, x):
+        out = x
+        out = self.conv1(out)
+        out = self.bn1(out)
+        out = self.db1(out)
+        out = self.db2(out)
+        return out
+
+
+class DummyNetWrapper(nn.Module):
+    def __init__(self):
+        super(DummyNetWrapper, self).__init__()
+
+        self.bn = nn.BatchNorm2d(3, affine=True)
+        self.dn = DummyNet()
+
+    def forward(self, x):
+        return self.dn(self.bn(x))
+
+
+class TestFP16Model(unittest.TestCase):
+    def setUp(self):
+        self.N = 64
+        self.C_in = 3
+        self.H_in = 16
+        self.W_in = 32
+        self.in_tensor = torch.randn((self.N, self.C_in, self.H_in, self.W_in)).cuda()
+        self.orig_model = DummyNetWrapper().cuda()
+        self.fp16_model = FP16Model(self.orig_model)
+
+    def test_params_and_buffers(self):
+        exempted_modules = [
+            self.fp16_model.network.bn,
+            self.fp16_model.network.dn.db1.bn,
+            self.fp16_model.network.dn.db2.bn,
+        ]
+        for m in self.fp16_model.modules():
+            expected_dtype = torch.float if (m in exempted_modules) else torch.half
+            for p in m.parameters(recurse=False):
+                assert p.dtype == expected_dtype
+            for b in m.buffers(recurse=False):
+                assert b.dtype in (expected_dtype, torch.int64)
+
+    def test_output_is_half(self):
+        out_tensor = self.fp16_model(self.in_tensor)
+        assert out_tensor.dtype == torch.half
+

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -1,7 +1,7 @@
 import unittest
 import sys
 
-test_dirs = ["run_amp", "run_mixed_adam"]
+test_dirs = ["run_amp", "run_fp16util", "run_mixed_adam"]
 
 runner = unittest.TextTestRunner(verbosity=2)
 


### PR DESCRIPTION
This commit adds an FP16Model class as a successor to `network_to_half()`.

The benefits of this class are:

- Preservation of single-precision for BatchNorm layers. The models
  generated by `network_to_half()` convert BatchNorm moment tensors to
  half-precision, then back to single-precision, which hurts the
  accuracy of the moment estimators and occasionally results in NaNs.
- Support for multi-argument `nn.Module`s (self-explanatory from code).