### PR TITLE
Rename IntList to IntArrayRef

### DIFF
--- a/csrc/layer_norm_cuda.cpp
+++ b/csrc/layer_norm_cuda.cpp
@@ -5,7 +5,11 @@
 namespace {
 void compute_n1_n2(
     at::Tensor input,
+    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
+    #else
+    at::IntList normalized_shape,
+    #endif
     int& n1,
     int& n2)
 {
@@ -22,7 +26,11 @@ void compute_n1_n2(
 }
 
 void check_args(
+    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
+    #else
+    at::IntList normalized_shape,
+    #endif
     at::Tensor gamma,
     at::Tensor beta
     )
@@ -33,7 +41,11 @@ void check_args(
 
 void check_args(
     at::Tensor input,
+    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
+    #else
+    at::IntList normalized_shape,
+    #endif
     int& n1,
     int& n2
     )
@@ -69,7 +81,11 @@ void check_args(
 
 void check_args(
     at::Tensor input,
+    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
+    #else
+    at::IntList normalized_shape,
+    #endif
     at::Tensor gamma,
     at::Tensor beta,
     int& n1,
@@ -88,7 +104,11 @@ void cuda_layer_norm(
     at::Tensor* input,
     int n1,
     int n2,
+    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
+    #else
+    at::IntList normalized_shape,
+    #endif
     at::Tensor* gamma,
     at::Tensor* beta,
     double epsilon);
@@ -99,7 +119,11 @@ void cuda_layer_norm(
 
 std::vector<at::Tensor> layer_norm(
     at::Tensor input,
+    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
+    #else
+    at::IntList normalized_shape,
+    #endif
     double epsilon) {
   CHECK_INPUT(input);
   int n1,n2;
@@ -113,7 +137,11 @@ std::vector<at::Tensor> layer_norm(
 }
 std::vector<at::Tensor> layer_norm_affine(
     at::Tensor input,
+    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
+    #else
+    at::IntList normalized_shape,
+    #endif
     at::Tensor gamma,
     at::Tensor beta,
     double epsilon) {
@@ -137,7 +165,11 @@ void cuda_layer_norm_gradient(
     at::Tensor* input,
     int n1,
     int n2,
+    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
+    #else
+    at::IntList normalized_shape,
+    #endif
     at::Tensor* gamma,
     at::Tensor* beta,
     double epsilon,
@@ -151,7 +183,11 @@ at::Tensor layer_norm_gradient(
     at::Tensor mean,
     at::Tensor invvar,
     at::Tensor input,
+    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
+    #else
+    at::IntList normalized_shape,
+    #endif
     double epsilon) {
   CHECK_INPUT(dout);
   CHECK_INPUT(mean);
@@ -170,7 +206,11 @@ std::vector<at::Tensor> layer_norm_gradient_affine(
     at::Tensor mean,
     at::Tensor invvar,
     at::Tensor input,
+    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
+    #else
+    at::IntList normalized_shape,
+    #endif
     at::Tensor gamma,
     at::Tensor beta,
     double epsilon) {

--- a/csrc/layer_norm_cuda.cpp
+++ b/csrc/layer_norm_cuda.cpp
@@ -5,7 +5,7 @@
 namespace {
 void compute_n1_n2(
     at::Tensor input,
-    at::IntList normalized_shape,
+    at::IntArrayRef normalized_shape,
     int& n1,
     int& n2)
 {
@@ -22,7 +22,7 @@ void compute_n1_n2(
 }
 
 void check_args(
-    at::IntList normalized_shape,
+    at::IntArrayRef normalized_shape,
     at::Tensor gamma,
     at::Tensor beta
     )
@@ -33,7 +33,7 @@ void check_args(
 
 void check_args(
     at::Tensor input,
-    at::IntList normalized_shape,
+    at::IntArrayRef normalized_shape,
     int& n1,
     int& n2
     )
@@ -69,7 +69,7 @@ void check_args(
 
 void check_args(
     at::Tensor input,
-    at::IntList normalized_shape,
+    at::IntArrayRef normalized_shape,
     at::Tensor gamma,
     at::Tensor beta,
     int& n1,
@@ -88,7 +88,7 @@ void cuda_layer_norm(
     at::Tensor* input,
     int n1,
     int n2,
-    at::IntList normalized_shape,
+    at::IntArrayRef normalized_shape,
     at::Tensor* gamma,
     at::Tensor* beta,
     double epsilon);
@@ -99,7 +99,7 @@ void cuda_layer_norm(
 
 std::vector<at::Tensor> layer_norm(
     at::Tensor input,
-    at::IntList normalized_shape,
+    at::IntArrayRef normalized_shape,
     double epsilon) {
   CHECK_INPUT(input);
   int n1,n2;
@@ -113,7 +113,7 @@ std::vector<at::Tensor> layer_norm(
 }
 std::vector<at::Tensor> layer_norm_affine(
     at::Tensor input,
-    at::IntList normalized_shape,
+    at::IntArrayRef normalized_shape,
     at::Tensor gamma,
     at::Tensor beta,
     double epsilon) {
@@ -137,7 +137,7 @@ void cuda_layer_norm_gradient(
     at::Tensor* input,
     int n1,
     int n2,
-    at::IntList normalized_shape,
+    at::IntArrayRef normalized_shape,
     at::Tensor* gamma,
     at::Tensor* beta,
     double epsilon,
@@ -151,7 +151,7 @@ at::Tensor layer_norm_gradient(
     at::Tensor mean,
     at::Tensor invvar,
     at::Tensor input,
-    at::IntList normalized_shape,
+    at::IntArrayRef normalized_shape,
     double epsilon) {
   CHECK_INPUT(dout);
   CHECK_INPUT(mean);
@@ -170,7 +170,7 @@ std::vector<at::Tensor> layer_norm_gradient_affine(
     at::Tensor mean,
     at::Tensor invvar,
     at::Tensor input,
-    at::IntList normalized_shape,
+    at::IntArrayRef normalized_shape,
     at::Tensor gamma,
     at::Tensor beta,
     double epsilon) {

--- a/csrc/layer_norm_cuda_kernel.cu
+++ b/csrc/layer_norm_cuda_kernel.cu
@@ -672,7 +672,11 @@ void cuda_layer_norm(
     at::Tensor* input,
     int n1,
     int n2,
+    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
+    #else
+    at::IntList normalized_shape,
+    #endif
     at::Tensor* gamma,
     at::Tensor* beta,
     double epsilon)
@@ -767,7 +771,11 @@ void cuda_layer_norm_gradient(
     at::Tensor* input,
     int n1,
     int n2,
+    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
+    #else
+    at::IntList normalized_shape,
+    #endif
     at::Tensor* gamma,
     at::Tensor* beta,
     double epsilon,

--- a/csrc/layer_norm_cuda_kernel.cu
+++ b/csrc/layer_norm_cuda_kernel.cu
@@ -672,7 +672,7 @@ void cuda_layer_norm(
     at::Tensor* input,
     int n1,
     int n2,
-    at::IntList normalized_shape,
+    at::IntArrayRef normalized_shape,
     at::Tensor* gamma,
     at::Tensor* beta,
     double epsilon)
@@ -767,7 +767,7 @@ void cuda_layer_norm_gradient(
     at::Tensor* input,
     int n1,
     int n2,
-    at::IntList normalized_shape,
+    at::IntArrayRef normalized_shape,
     at::Tensor* gamma,
     at::Tensor* beta,
     double epsilon,


### PR DESCRIPTION
`IntList` has been deprecated by https://github.com/pytorch/pytorch/commit/4404762d7dd955383acee92e6f06b48144a0742e#diff-ff8fdb5222085eb1036fbebb7cc4f4a9

This PR should resolve some build warnings.