### PR TITLE
Bug fix in next power of 2

### DIFF
--- a/csrc/welford.cu
+++ b/csrc/welford.cu
@@ -20,13 +20,13 @@ __device__ __forceinline__ int lastpow2(int n)
 }
 
 __host__ __forceinline__ int h_next_pow2(unsigned int n) {
-    unsigned int old = n;
+    n--;
     n |= (n >>  1);
     n |= (n >>  2);
     n |= (n >>  4);
     n |= (n >>  8);
     n |= (n >> 16);
-    return n == old? n : n + 1;
+    return ++n;
 }
 
 __host__ __forceinline__ int h_last_pow2(unsigned int n) {


### PR DESCRIPTION
The existing "next power of 2" implementation produces incorrect results in some cases. The one identified so far is that for every value less than a power of 2 by 1 keeps value the same, e.g. h_next_pow2(7) produces 7, etc. For numbers farther away, the output is correct, e.g. h_next_pow2(26) gives 32.

The fix is identical to the "popular" way of doing this, i.e. subtracting 1 before the bit shifts, doing bitwise ORs with the bit-shifted values, and then adding 1 again, as in [here](https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2) for instance.

Note that the [earlier commit](https://github.com/NVIDIA/apex/blame/8bd382fadd42f77922fbc3dfacc3e4cc2f89ece5/csrc/welford.cu#L22:L29) was also wrong because it didn't subtract 1 at the beginning.