### PR TITLE
Add "dynamic" argument to loss scaler

### DIFF
--- a/apex/amp/opt.py
+++ b/apex/amp/opt.py
@@ -13,7 +13,7 @@ class OptimWrapper(object):
         self._num_loss = num_loss
         self._loss_idx = 0
         self._skip_next = [False] * num_loss
-        self._loss_scaler = [LossScaler() for _ in range(num_loss)]
+        self._loss_scaler = [LossScaler('dynamic') for _ in range(num_loss)]
 
     @contextlib.contextmanager
     def scale_loss(self, loss):


### PR DESCRIPTION
Adds missing argument to `LossScaler`.

Would fix #183 

Alternative would be to make this a default argument in the scaler.