### PR TITLE
Add prelu to list of torch overrides

### DIFF
--- a/apex/amp/lists/torch_overrides.py
+++ b/apex/amp/lists/torch_overrides.py
@@ -12,7 +12,6 @@ FP16_FUNCS = [
     'conv_transpose2d',
     'conv_transpose3d',
     'conv_tbc',
-    'prelu',
 
     # BLAS
     'addmm',
@@ -71,6 +70,7 @@ CASTS = [
     'addcmul',
     'atan2',
     'cross',
+    'prelu',
 
     # Element-wise _or_ tensor-wise math
     'add',

--- a/apex/amp/lists/torch_overrides.py
+++ b/apex/amp/lists/torch_overrides.py
@@ -12,6 +12,7 @@ FP16_FUNCS = [
     'conv_transpose2d',
     'conv_transpose3d',
     'conv_tbc',
+    'prelu',
 
     # BLAS
     'addmm',


### PR DESCRIPTION
This is to fix the following error:

  File "/opt/conda/lib/python3.6/site-packages/torch/nn/modules/module.py", line 489, in __call__
    result = self.forward(*input, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/torch/nn/modules/container.py", line 92, in forward
    input = module(input)
  File "/opt/conda/lib/python3.6/site-packages/torch/nn/modules/module.py", line 489, in __call__
    result = self.forward(*input, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/torch/nn/modules/activation.py", line 722, in forward
    return F.prelu(input, self.weight)
  File "/opt/conda/lib/python3.6/site-packages/torch/nn/functional.py", line 1040, in prelu
    return torch.prelu(input, weight)
RuntimeError: expected scalar type Half but found Float