### PR TITLE
Fix 'local variable 'optimizers_was_list' referenced before assignmen…

### DIFF
--- a/apex/amp/_initialize.py
+++ b/apex/amp/_initialize.py
@@ -126,8 +126,8 @@ def _initialize(models, optimizers, properties):
     from apex.parallel import DistributedDataParallel as apex_DDP
     from .amp import init as amp_init
 
+    optimizers_was_list = False
     if isinstance(optimizers, torch.optim.Optimizer):
-        optimizers_was_list = False
         optimizers = [optimizers]
     elif optimizers is None:
         optimizers = []


### PR DESCRIPTION
…t' when amp.initialize() is called with optimizers=None