### PR TITLE
Fix a typo in optimized_sync_batchnorm_kernel.py

### DIFF
--- a/apex/parallel/optimized_sync_batchnorm_kernel.py
+++ b/apex/parallel/optimized_sync_batchnorm_kernel.py
@@ -51,7 +51,7 @@ class SyncBatchnormFunction(Function):
             running_variance.data = running_variance.data * (1-momentum) + momentum*r_v_inc
         else:
             mean = running_mean.data
-            inv_std = 1.0 / torch.sqrt(running_var.data + eps)
+            inv_std = 1.0 / torch.sqrt(running_variance.data + eps)
 
         ctx.save_for_backward(input, weight, mean, inv_std)
         ctx.process_group = process_group


### PR DESCRIPTION
in line 54, running_var should be running_variance..