### PR TITLE
Run interpolation in fp32 because it's faster

### DIFF
--- a/apex/amp/lists/functional_overrides.py
+++ b/apex/amp/lists/functional_overrides.py
@@ -27,6 +27,10 @@ FP16_FUNCS = [
 ]
 
 FP32_FUNCS = [
+
+    # Interpolation/Upsampling
+    'interpolate',
+
     # Pointwise
     'softplus',
     'softmin',


### PR DESCRIPTION
Running interpolation (nearest neigbor and bilinear) in fp16 is slower than fp32, because the backprop depends on individual half atomicAdds (as opposed to half2 atomicAdds), which actually translates to atomicCAS under the hood. For networks that heavily depend on upsampling (any kind of generative CV models, say GANs), the overall impact of using fp16 upsampling results in up to 30% end-to-end training slowdowns. 

The long-term fix is to fix upsampling (I'm planning to make PRs to this effect), but for now I think it's better to run upsampling in fp32 instead.