### PR TITLE
Add support for CPU and sparse tensors

### DIFF
--- a/apex/amp/_process_optimizer.py
+++ b/apex/amp/_process_optimizer.py
@@ -22,9 +22,7 @@ def lazy_init_with_master_weights(self):
             fp32_from_fp16_params_this_group = []
             for i, param in enumerate(param_group['params']):
                 if param.requires_grad:
-                    if param.type() == 'torch.cuda.HalfTensor':
-                        # maybe_print("FP16_Optimizer received torch.cuda.HalfTensor with {}"
-                        #             .format(param.size()))
+                    if param.type() == 'torch.cuda.HalfTensor' or param.type() == 'torch.HalfTensor':
                         fp16_params_this_group.append(param)
                         master_param = param.detach().clone().float()
                         master_param.requires_grad = True
@@ -34,14 +32,13 @@ def lazy_init_with_master_weights(self):
                         # We still need to recast per-param state tensors, if any, to FP32.
                         if param in self.state:
                            self.state[master_param] = self.state.pop(param)
-                    elif param.type() == 'torch.cuda.FloatTensor':
-                        # maybe_print("FP16_Optimizer received torch.cuda.FloatTensor with {}"
-                        #             .format(param.size()))
+                    elif param.type() == 'torch.cuda.FloatTensor' or param.type() == 'torch.FloatTensor':
                         fp32_params_this_group.append(param)
                         param_group['params'][i] = param
                     else:
                         raise TypeError("Optimizer's parameters must be either "
-                                        "torch.cuda.FloatTensor or torch.cuda.HalfTensor. "
+                                        "torch.cuda.FloatTensor or torch.FloatTensor or "
+                                        "torch.cuda.HalfTensor or torch.HalfTensor. "
                                         "Received {}".format(param.type()))
 
             stash.fp16_groups.append(fp16_params_this_group)
@@ -168,9 +165,9 @@ def lazy_init_no_master_weights(self):
     stash.all_fp32_params = []
     for i, param_group in enumerate(self.param_groups):
         for i, param in enumerate(param_group['params']):
-            if param.type() == 'torch.cuda.HalfTensor':
+            if param.type() == 'torch.cuda.HalfTensor' or param.type() == 'torch.HalfTensor':
                 stash.all_fp16_params.append(param)
-            elif param.type() == 'torch.cuda.FloatTensor':
+            elif param.type() == 'torch.cuda.FloatTensor' or param.type() == 'torch.FloatTensor':
                 stash.all_fp32_params.append(param)
             else:
                 raise TypeError("Optimizer's parameters must be either "

--- a/apex/amp/frontend.py
+++ b/apex/amp/frontend.py
@@ -18,6 +18,7 @@ class Properties(object):
             "keep_batchnorm_fp32" : None,
             "master_weights" : None,
             "loss_scale" : 1.0,
+            "all_reduce_overflow" : False,
             # Reserved for future functionality
             # "fused_optimizer" : False,
             # "enable_ddp_interop" : False,
@@ -115,6 +116,7 @@ class O3:
         properties.keep_batchnorm_fp32 = False
         properties.master_weights = False
         properties.loss_scale = 1.0
+        properties.all_reduce_overflow = False
         # properties.fused_optimizer = False
         # properties.enable_ddp_interop = False
         return properties # modified in place so this isn't really necessary
@@ -138,6 +140,7 @@ class O2:
         properties.keep_batchnorm_fp32 = True
         properties.master_weights = True
         properties.loss_scale = "dynamic"
+        properties.all_reduce_overflow = False
         # properties.fused_optimizer = False
         # properties.enable_ddp_interop = False
         return properties # modified in place so this isn't really necessary
@@ -160,6 +163,7 @@ class O1:
         properties.keep_batchnorm_fp32 = None
         properties.master_weights = None
         properties.loss_scale = "dynamic"
+        properties.all_reduce_overflow = False
         # properties.fused_optimizer = False
         # properties.enable_ddp_interop = False
         return properties # modified in place so this isn't really necessary
@@ -179,6 +183,7 @@ class O0:
         properties.keep_batchnorm_fp32 = None
         properties.master_weights = False
         properties.loss_scale = 1.0
+        properties.all_reduce_overflow = False
         # properties.fused_optimizer = False
         # properties.enable_ddp_interop = False
         return properties # modified in place so this isn't really necessary
@@ -201,6 +206,7 @@ def initialize(
     keep_batchnorm_fp32=None,
     master_weights=None,
     loss_scale=None,
+    all_reduce_overflow=None,
     num_losses=1,
     verbosity=1,
     ):
@@ -240,6 +246,7 @@ def initialize(
         master_weights (bool, optional, default=None):  Optional property override.
         loss_scale (float or str, optional, default=None):  Optional property override.  If passed as a string,
             must be a string representing a number, e.g., "128.0", or the string "dynamic".
+        all_reduce_overflow (bool, optional, default=None): Optional property override.
         num_losses (int, optional, default=1):  Option to tell Amp in advance how many losses/backward
             passes you plan to use.  When used in conjunction with the ``loss_id`` argument to
             ``amp.scale_loss``, enables Amp to use a different loss scale per loss/backward pass,
@@ -328,6 +335,8 @@ def initialize(
         _amp_state.opt_properties.master_weights = master_weights
     if loss_scale is not None:
         _amp_state.opt_properties.loss_scale = loss_scale
+    if all_reduce_overflow is not None:
+        _amp_state.opt_properties.all_reduce_overflow = all_reduce_overflow
 
     maybe_print("After processing overrides, optimization options are:", True)
     for k, v in _amp_state.opt_properties.options.items():


### PR DESCRIPTION
1) Added CPU tensor support (all cases with cuda.FloatTensor and cuda.HalfTensor are replaced with also allowing FloatTensor and HalfTensor. Whether tensor is on CPU vs GPU should make no difference algorithmically).

2) Added sparse tensor support (overflow checks need special case for Sparse tensors since previous logic of `float(model_grad.float().sum())` does not work for sparse). For additional safety since sparse tensors cannot be distributed, I added an option to explicitly `all_reduce_overflow` to ensure all nodes receive the same overflow state per update. Since some parameters are not distributed for sparse use-cases (Pytorch doesn't support DistributedDataParallel with sparse tensors), it's possible some nodes can have inconsistent overflow states with other nodes which can un-sync their parameter updates after loss scaling.