### PR TITLE
use verbose parameter to control print of grad overflow

### DIFF
--- a/apex/optimizers/fp16_optimizer.py
+++ b/apex/optimizers/fp16_optimizer.py
@@ -83,6 +83,7 @@ class FP16_Optimizer(object):
             self.dynamic_loss_scale = False
             self.cur_iter = 0
             self.cur_scale = static_loss_scale
+        self.verbose = verbose
 
     def zero_grad(self, set_grads_to_None=True):
         """
@@ -173,8 +174,9 @@ class FP16_Optimizer(object):
     def _update_scale(self, skip):
         if self.dynamic_loss_scale:
             if skip:
-                print("\nGrad overflow on iteration", self.cur_iter)
-                print("Using dynamic loss scale of", self.cur_scale)
+                if self.verbose:
+                    print("\nGrad overflow on iteration", self.cur_iter)
+                    print("Using dynamic loss scale of", self.cur_scale)
                 self.cur_scale = max(self.cur_scale/self.scale_factor, 1)
                 self.last_overflow_iter = self.cur_iter
             else:


### PR DESCRIPTION
Since gradient overflow is a normal part of dynamic loss scaling until the right loss scaling is established, it seems appropriate to gate the print statements with the 'verbose' parameter.

In distributed training, with dozens of processes all printing 'Grad overflow...' to the log, it can be tedious to scroll past. In this setting the verbose=True can be reserved for the process with world rank 0.