### PR TITLE
fix URLs in docs of apex.parallel

### DIFF
--- a/apex/parallel/distributed.py
+++ b/apex/parallel/distributed.py
@@ -104,8 +104,6 @@ class Reducer(object):
     When used with this launcher, :class:`Reducer` assumes 1:1 mapping of processes to GPUs.
     It also assumes that your script calls ``torch.cuda.set_device(args.rank)`` before creating the model.
 
-    main_amp.py in https://github.com/NVIDIA/apex/tree/master/examples/imagenet shows example usage.
-
     Args:
         module_or_grads_list: Either a network definition (module) being run in multi-gpu/distributed mode, or an iterable of gradients to be reduced.  If a module is passed in, the Reducer constructor will sync the parameters across processes (broadcasting from rank 0) to make sure they're all initialized with the same values.  If a list of gradients (that came from some module) is passed in, the user is responsible for manually syncing that module's parameters at the beginning of training.
     """

--- a/apex/parallel/distributed.py
+++ b/apex/parallel/distributed.py
@@ -104,7 +104,7 @@ class Reducer(object):
     When used with this launcher, :class:`Reducer` assumes 1:1 mapping of processes to GPUs.
     It also assumes that your script calls ``torch.cuda.set_device(args.rank)`` before creating the model.
 
-    main_reducer.py in https://github.com/NVIDIA/apex/tree/master/examples/imagenet shows example usage.
+    main_amp.py in https://github.com/NVIDIA/apex/tree/master/examples/imagenet shows example usage.
 
     Args:
         module_or_grads_list: Either a network definition (module) being run in multi-gpu/distributed mode, or an iterable of gradients to be reduced.  If a module is passed in, the Reducer constructor will sync the parameters across processes (broadcasting from rank 0) to make sure they're all initialized with the same values.  If a list of gradients (that came from some module) is passed in, the user is responsible for manually syncing that module's parameters at the beginning of training.
@@ -143,7 +143,7 @@ class DistributedDataParallel(Module):
     When used with this launcher, :class:`DistributedDataParallel` assumes 1:1 mapping of processes to GPUs.
     It also assumes that your script calls ``torch.cuda.set_device(args.rank)`` before creating the model.
 
-    https://github.com/NVIDIA/apex/tree/master/examples/distributed shows detailed usage.
+    https://github.com/NVIDIA/apex/tree/master/examples/simple/distributed shows detailed usage.
     https://github.com/NVIDIA/apex/tree/master/examples/imagenet shows another example
     that combines :class:`DistributedDataParallel` with mixed precision training.
 


### PR DESCRIPTION
Fixes minor errors in the URLs for [apex.parellel](https://nvidia.github.io/apex/parallel.html) pointing to old source code locations.