### PR TITLE
Use `value` in assert statement for keep_batchnorm_fp32

### DIFF
--- a/apex/amp/frontend.py
+++ b/apex/amp/frontend.py
@@ -70,7 +70,7 @@ class Properties(object):
                     if self.opt_level == "O1" and value is not None:
                         warn_or_err("With opt_level O1, batchnorm functions are automatically patched "
                                     "to run in FP32, so keep_batchnorm_fp32 should be None." +
-                                    "keep_batchnorm_fp32 was {}".format(keep_batchnorm_fp32))
+                                    " keep_batchnorm_fp32 was {}".format(value))
                     if value == "False":
                         self.options[name] = False
                     elif value == "True":

--- a/apex/amp/frontend.py
+++ b/apex/amp/frontend.py
@@ -78,7 +78,7 @@ class Properties(object):
                     else:
                         assert (value is True or value is False or value is None),\
                             "keep_batchnorm_fp32 must be a boolean, the string 'True' or 'False', "\
-                            "or None, found keep_batchnorm_fp32={}".format(keep_batchnorm_fp32)
+                            "or None, found keep_batchnorm_fp32={}".format(value)
                         self.options[name] = value
                 elif name == "master_weights":
                     if self.opt_level == "O1" and value is not None:


### PR DESCRIPTION
Fixes #320 

`keep_batchnorm_fp32` is undefined in [this line of code](https://github.com/NVIDIA/apex/blob/c490bd368faafb19986f857f9baa145d30872e92/apex/amp/frontend.py#L81). Use `value` instead to rais the proper error message.