### PR TITLE
Hard error on mismatch between torch.version.cuda and + the Cuda toolkit version being used to compile Apex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,9 @@ def check_cuda_torch_binary_vs_bare_metal(cuda_dir):
     print(raw_output + "from " + cuda_dir + "/bin\n")
 
     if (bare_metal_major != torch_binary_major) or (bare_metal_minor != torch_binary_minor):
-        # TODO:  make this a hard error?
-        print("\nWarning:  Cuda extensions are being compiled with a version of Cuda that does "
-              "not match the version used to compile Pytorch binaries.\n")
-    print("Pytorch binaries were compiled with Cuda {}\n".format(torch.version.cuda))
+        raise RuntimeError("Cuda extensions are being compiled with a version of Cuda that does "
+                           "not match the version used to compile Pytorch binaries.  "
+                           "Pytorch binaries were compiled with Cuda {}.\n".format(torch.version.cuda))
 
 if "--cuda_ext" in sys.argv:
     from torch.utils.cpp_extension import CUDAExtension


### PR DESCRIPTION
The warning message was too subtle/too easy to overlook in the output of setup.py, and it really should be a hard error.

Making it a hard error should also assist with cuda _driver_ version errors like https://github.com/NVIDIA/apex/issues/314.  https://github.com/NVIDIA/apex/issues/314 resulted because the cuda _driver_ (libcuda.so) version was 10.0, the cuda _toolkit_ version used to compile the Pytorch binaries was 10.0 (which was fine), but the cuda _toolkit_ version used to compile Apex was 10.1** (which triggered a PTX JIT compilation error at runtime because the 10.0 libcuda.so couldn't handle the PTX produced by the 10.1 nvcc).  The PTX JIT compilation error message was cryptic and unhelpful.

However, if the _toolkit_ version that was used to compile _Pytorch_ binaries is too recent for the system's cuda _driver_ version, Pytorch will raise a much more helpful error, something like
```
"AssertionError: 
The NVIDIA driver on your system is too old (found version 10000)..."
```
If we hard-enforce that the cuda toolkit version used to compile Apex == the cuda toolkit version used to compile Pytorch, we also ensure that if the toolkit version used to compile Apex is too new for the driver, the toolkit version used to compile Pytorch must also be too new for the driver, and therefore in such cases we will receive the helpful Pytorch error instead of the bizarre PTX JIT error.

**A warning of the mismatch between torch.version.cuda and the toolkit (nvcc) had likely been issued by the setup.py while compiling apex, but this warning had likely been overlooked, so what ended up surfacing was the PTX JIT error, which was not at all a clear indication of what had gone wrong.