### PR TITLE
Give custom to method a higher priority

### DIFF
--- a/apex/amp/_initialize.py
+++ b/apex/amp/_initialize.py
@@ -40,12 +40,12 @@ def applier(value, fn):
         return value
     elif isinstance(value, np.ndarray):
         return value
+    elif hasattr(value, "to"): # Allow handling of custom batch classes
+        return fn(value)
     elif isinstance(value, container_abcs.Mapping):
         return {applier(k, fn) : applier(v, fn) for k, v in value.items()}
     elif isinstance(value, container_abcs.Iterable):
         return type(value)(applier(v, fn) for v in value)
-    elif hasattr(value, "to"): # Allow handling of custom batch classes
-        return fn(value)
     else:
         # Do I want this to fire off even if someone chooses to pass something ordinary like
         # an int or float?  May be more annoying than it's worth.


### PR DESCRIPTION
Fix for https://github.com/NVIDIA/apex/issues/363.

There's a tradeoff here:

This version (giving the `to` method lower priority than Tensors, string_classes, and numpy.ndarrays) will ignore a custom `to` method if the custom batch is an instance of string_classes or numpy.ndarray.  

However, if we give the custom `to` method higher priority, it might be spuriously called if one of the string_classes or numpy.ndarray has a `.to` method already.

A third option is to force user-defined `to` method to have a more unique name, like `to_amp_type`.  But this would require changing the existing code.

@felix-schneider do you see a strong reason to prefer one of these options?