### PR TITLE
Fixed error in convert_syncbn_model function

### DIFF
--- a/apex/parallel/__init__.py
+++ b/apex/parallel/__init__.py
@@ -41,6 +41,7 @@ def convert_syncbn_model(module, process_group=None, channel_last=False):
         mod = SyncBatchNorm(module.num_features, module.eps, module.momentum, module.affine, module.track_running_stats, process_group, channel_last=channel_last)
         mod.running_mean = module.running_mean
         mod.running_var = module.running_var
+        mod.num_batches_tracked = module.num_batches_tracked
         if module.affine:
             mod.weight.data = module.weight.data.clone().detach()
             mod.bias.data = module.bias.data.clone().detach()


### PR DESCRIPTION
Current, `apex.parallel.convert_syncbn_model` method does not obtain `num_batches_tracked' property from original batch norm object.
So i added a line for that.
`mod.num_batches_tracked = module.num_batches_tracked`

