### PR TITLE
Bug fix for non-affine layer-norm + add backward unit test

### DIFF
--- a/csrc/layer_norm_cuda_kernel.cu
+++ b/csrc/layer_norm_cuda_kernel.cu
@@ -795,11 +795,13 @@ void cuda_layer_norm_gradient(
 	    invvar->data<accscalar_t>(),
 	    input,
 	    n1,n2,
-	    gamma->data<scalar_t_0>(),
-	    beta->data<scalar_t_0>(),
+            // TMJ pass NULL argument for gamma, beta, grad_gamma and grad_beta
+            // if gamma Tensor is NULL on input.
+	    gamma != NULL ? gamma->data<scalar_t_0>() : NULL,
+	    gamma != NULL ? beta->data<scalar_t_0>() : NULL,
 	    epsilon,
 	    grad_input->data<scalar_t_0>(),
-	    grad_gamma->data<scalar_t_0>(),
-	    grad_beta->data<scalar_t_0>());
+	    gamma != NULL ? grad_gamma->data<scalar_t_0>() : NULL,
+	    gamma != NULL ? grad_beta->data<scalar_t_0>() : NULL);
       )
 }

--- a/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
+++ b/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
@@ -4,38 +4,40 @@ import random
 
 import torch
 import apex
+from torch.autograd import Variable
 
         
 class TestFusedLayerNorm(unittest.TestCase):
     def setUp(self):
-        self.module = apex.normalization.FusedLayerNorm(normalized_shape=[32, 64], elementwise_affine=False)
-        self.input_ = torch.randn(16, 32, 64)
+        self.module_cpu_ = apex.normalization.FusedLayerNorm(normalized_shape=[32, 64], elementwise_affine=False).cpu()
+        self.module_cuda_ = apex.normalization.FusedLayerNorm(normalized_shape=[32, 64], elementwise_affine=False).cuda()
         torch.cuda.manual_seed(42)
-        
-    def forward_cpu(self, input_):
-        self.module.cpu()
-        return self.module(input_.cpu())
-    
-    def forward_cuda(self, input_):
-        self.module.cuda()
-        return self.module(input_.cuda())
-    
-    def test_forward_cuda(self):
-        out_ = self.forward_cuda(self.input_)
-        assert out_.is_cuda == True
-        
-    def test_forward_cpu(self):
-        out_ = self.forward_cpu(self.input_)
-        assert out_.is_cuda == False
-        
+        self.input_ = torch.randn(16, 32, 64)
+        self.loss_ = torch.randn(16, 32, 64)
+        self.input_cpu_ = Variable(self.input_.detach().clone(), requires_grad=True)
+        self.loss_cpu_ = self.loss_.detach().clone()
+        self.input_cuda_ = Variable(self.input_.detach().clone().cuda(), requires_grad=True)
+        self.loss_cuda_ = self.loss_.detach().clone().cuda()
+
     def test_same_output(self):
-        out_cpu = self.forward_cpu(self.input_)
-        out_cuda = self.forward_cuda(self.input_)
-        torch.testing.assert_allclose(out_cpu, out_cuda.cpu())
+        out_cpu_ = self.module_cpu_(self.input_cpu_)
+        out_cpu_.backward(self.loss_cpu_)
+        out_cuda_ = self.module_cuda_(self.input_cuda_)
+        out_cuda_.backward(self.loss_cuda_)
+        assert out_cpu_.is_cuda == False
+        assert out_cuda_.is_cuda == True
+        torch.testing.assert_allclose(out_cpu_, out_cuda_.cpu())
+        torch.testing.assert_allclose(self.input_cpu_.grad, self.input_cuda_.grad.cpu())
         
         
 class TestFusedLayerNormElemWise(TestFusedLayerNorm):
     def setUp(self):
-        self.module = apex.normalization.FusedLayerNorm(normalized_shape=[32, 64], elementwise_affine=True)
-        self.input_ = torch.randn(16, 32, 64)
+        self.module_cpu_ = apex.normalization.FusedLayerNorm(normalized_shape=[32, 64], elementwise_affine=True).cpu()
+        self.module_cuda_ = apex.normalization.FusedLayerNorm(normalized_shape=[32, 64], elementwise_affine=True).cuda()
         torch.cuda.manual_seed(42)
+        self.input_ = torch.randn(16, 32, 64)
+        self.loss_ = torch.randn(16, 32, 64)
+        self.input_cpu_ = Variable(self.input_.detach().clone(), requires_grad=True)
+        self.loss_cpu_ = self.loss_.detach().clone()
+        self.input_cuda_ = Variable(self.input_.detach().clone().cuda(), requires_grad=True)
+        self.loss_cuda_ = self.loss_.detach().clone().cuda()


### PR DESCRIPTION
Some NULL checks were missing for the CPU driver code in the backward call chain. These went undiscovered because the unit test missed a backward test. Added the NULL checks and added backward unit tests.