### PR TITLE
Don't forget self in Properties._update_options_dict()

### DIFF
--- a/apex/amp/frontend.py
+++ b/apex/amp/frontend.py
@@ -29,7 +29,7 @@ class Properties(object):
     Currently not intended to be exposed; users are expected to select an opt_level
     and apply consistent modifications.
     """
-    def _update_options_dict(new_options):
+    def _update_options_dict(self, new_options):
         for k, v in new_options:
             if k in self.options:
                 self.options[k] = v

--- a/tests/L0/run_mixed_adam/test_fp16_optimizer.py
+++ b/tests/L0/run_mixed_adam/test_fp16_optimizer.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import torch
 import apex


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/NVIDIA/apex on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./apex/amp/frontend.py:34:21: F821 undefined name 'self'
            if k in self.options:
                    ^
./apex/amp/frontend.py:35:17: F821 undefined name 'self'
                self.options[k] = v
                ^
./tests/L0/run_mixed_adam/test_fp16_optimizer.py:133:19: F821 undefined name 'os'
    script_path = os.path.dirname(os.path.realpath(__file__))
                  ^
./tests/L0/run_mixed_adam/test_fp16_optimizer.py:133:35: F821 undefined name 'os'
    script_path = os.path.dirname(os.path.realpath(__file__))
                                  ^
./docs/source/conf.py:210:5: F821 undefined name 'List'
    # type: (List, unicode, Tuple) -> nodes.field
    ^
./docs/source/conf.py:210:5: F821 undefined name 'unicode'
    # type: (List, unicode, Tuple) -> nodes.field
    ^
./docs/source/conf.py:210:5: F821 undefined name 'Tuple'
    # type: (List, unicode, Tuple) -> nodes.field
    ^
7     F821 undefined name 'self'
7
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree