### PR TITLE
remove deprecated backend.FunctionBackend calls

### DIFF
--- a/apex/amp/utils.py
+++ b/apex/amp/utils.py
@@ -129,25 +129,19 @@ def as_inplace(fns):
         yield x + '_'
 
 def has_func(mod, fn):
-    if isinstance(mod, torch.nn.backends.backend.FunctionBackend):
-        return fn in mod.function_classes
-    elif isinstance(mod, dict):
+    if isinstance(mod, dict):
         return fn in mod
     else:
         return hasattr(mod, fn)
 
 def get_func(mod, fn):
-    if isinstance(mod, torch.nn.backends.backend.FunctionBackend):
-        return mod.function_classes[fn]
-    elif isinstance(mod, dict):
+    if isinstance(mod, dict):
         return mod[fn]
     else:
         return getattr(mod, fn)
 
 def set_func(mod, fn, new_fn):
-    if isinstance(mod, torch.nn.backends.backend.FunctionBackend):
-        mod.function_classes[fn] = new_fn
-    elif isinstance(mod, dict):
+    if isinstance(mod, dict):
         mod[fn] = new_fn
     else:
         setattr(mod, fn, new_fn)


### PR DESCRIPTION
PyTorch PR removed `backend.FunctionBackend` in this PR:
https://github.com/pytorch/pytorch/commit/23fde77d3d14c1e3582ac1f8c1456b4f59a242d1

Issue reported in #460 

Thanks @labor00 for reporting!