### PR TITLE
Include loss scaling in README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ model, optimizer = amp.initialize(model, optimizer, opt_level=opt_level)
 
 # Train your model
 ...
+with amp.scale_loss(loss, optimizer) as scaled_loss:
+    scaled_loss.backward()
+...
 
 # Save checkpoint
 checkpoint = {


### PR DESCRIPTION
The code example in the README, although meant to illustrate checkpointing, is the first `amp` usage example seen by a new user, and it looks so complete that it's tempting to just copy what's written there to adapt one's training script. Unfortunately, it misses the loss scaling, so a new user doing so will find that checkpointing works great, but training doesn't work at all. (Been there, done that.)

I'd propose to just add the two lines needed for loss scaling (this PR), or remove the code example completely so people will be forced to look at the documentation.