### PR TITLE
Add support for bool datatype (#601)

### DIFF
--- a/apex/pyprof/__init__.py
+++ b/apex/pyprof/__init__.py
@@ -1,3 +1,3 @@
 import warnings
 
-from . import nvtx
+from . import nvtx, prof

--- a/apex/pyprof/prof/__init__.py
+++ b/apex/pyprof/prof/__init__.py
@@ -1,0 +1,1 @@
+from . import data, prof

--- a/apex/pyprof/prof/utility.py
+++ b/apex/pyprof/prof/utility.py
@@ -9,10 +9,10 @@ class Utility(object):
 
 	@staticmethod
 	def typeToBytes(t):
-		if (t in ["uint8", "int8", "byte", "char"]):
+		if (t in ["uint8", "int8", "byte", "char", "bool"]):
 			return 1
 		elif (t in ["float16", "half", "int16", "short"]):
-			return 2 
+			return 2
 		elif (t in ["float32", "float", "int32", "int"]):
 			return 4
 		elif (t in ["int64", "long", "float64", "double"]):
@@ -21,7 +21,7 @@ class Utility(object):
 
 	@staticmethod
 	def typeToString(t):
-		if (t in ["uint8", "byte", "char"]):
+		if (t in ["uint8", "byte", "char",]):
 			return "uint8"
 		elif (t in ["int8",]):
 			return "int8"
@@ -37,6 +37,8 @@ class Utility(object):
 			return "int64"
 		elif (t in ["float64", "double",]):
 			return "fp64"
+		elif (t in ["bool",]):
+			return "bool"
 		assert False
 
 	@staticmethod

--- a/tests/L0/run_pyprof_data/test_pyprof_data.py
+++ b/tests/L0/run_pyprof_data/test_pyprof_data.py
@@ -1,0 +1,43 @@
+import inspect
+import unittest
+
+from apex.pyprof.prof.data import Data
+from apex.pyprof.prof.prof import foo
+
+
+class TestPyProfData(unittest.TestCase):
+
+	def __init__(self, testName):
+		super().__init__(testName)
+
+	def setUp(self):
+		pass
+
+	def tearDown(self):
+		pass
+
+	def test_data(self):
+		kernels = [
+			{'kShortName': 'elementwise_kernel', 'kDuration': 2848, 'layer': [], 'trace': [], 'reprMarkers': [], 'marker': ["{'mod': 'Tensor', 'op': 'float', 'args': [{'name': '', 'type': 'tensor', 'shape': (18, 104, 160), 'dtype': 'bool'}]}"], 'seqMarker': ['to, seq = 60471'], 'seqId': [60471], 'subSeqId': 0, 'altSeqId': [], 'dir': 'fprop', 'mod': ['Tensor'], 'op': ['float'], 'tid': 1431533376, 'device': 0, 'stream': 7, 'grid': (585, 1, 1), 'block': (512, 1, 1), 'kLongName': 'void at::native::elementwise_kernel<512, 1, void at::native::gpu_kernel_impl<void at::native::copy_kernel_impl<float, bool>(at::TensorIterator&)::{lambda(bool)#1}>(at::TensorIterator&, void at::native::copy_kernel_impl<float, bool>(at::TensorIterator&)::{lambda(bool)#1} const&)::{lambda(int)#1}>(int, void at::native::gpu_kernel_impl<void at::native::copy_kernel_impl<float, bool>(at::TensorIterator&)::{lambda(bool)#1}>(at::TensorIterator&, void at::native::copy_kernel_impl<float, bool>(at::TensorIterator&)::{lambda(bool)#1} const&)::{lambda(int)#1})'},
+			{'kShortName': 'elementwise_kernel', 'kDuration': 201182, 'layer': [], 'trace': [], 'reprMarkers': [], 'marker': ["{'mod': 'Tensor', 'op': 'clone', 'args': [{'name': '', 'type': 'tensor', 'shape': (18, 4, 416, 640), 'dtype': 'float32'}]}"], 'seqMarker': ['clone, seq = 60161'], 'seqId': [60161], 'subSeqId': 0, 'altSeqId': [], 'dir': 'fprop', 'mod': ['Tensor'], 'op': ['clone'], 'tid': 1431533376, 'device': 0, 'stream': 7, 'grid': (37440, 1, 1), 'block': (128, 1, 1), 'kLongName': 'void at::native::elementwise_kernel<128, 4, void at::native::gpu_kernel_impl<void at::native::copy_kernel_impl<float, float>(at::TensorIterator&)::{lambda(float)#1}>(at::TensorIterator&, void at::native::copy_kernel_impl<float, float>(at::TensorIterator&)::{lambda(float)#1} const&)::{lambda(int)#2}>(int, void at::native::gpu_kernel_impl<void at::native::copy_kernel_impl<float, float>(at::TensorIterator&)::{lambda(float)#1}>(at::TensorIterator&, void at::native::copy_kernel_impl<float, float>(at::TensorIterator&)::{lambda(float)#1} const&)::{lambda(int)#2})'},
+		]
+
+		for k in kernels:
+			d = Data(k)
+			mod = k['mod']
+			op = k['op']
+			xx = foo(mod, op, d)
+			d.setParams(xx.params())
+
+
+def run_tests(test_name):
+	dummy = TestPyProfData(test_name)
+	test_cases = list(filter(lambda x: 'test_' in x, map(lambda x: x[0], inspect.getmembers(dummy, predicate=inspect.ismethod))))
+	print(f'Running tests for {test_name}')
+	suite = unittest.TestSuite()
+	for test_case in test_cases:
+		suite.addTest(TestPyProfData(test_case))
+	unittest.TextTestRunner().run(suite)
+
+if __name__ == '__main__':
+	run_tests('test_data')

--- a/tests/L0/run_test.py
+++ b/tests/L0/run_test.py
@@ -1,7 +1,7 @@
 import unittest
 import sys
 
-test_dirs = ["run_amp", "run_fp16util", "run_optimizers", "run_fused_layer_norm", "run_pyprof_nvtx"]
+test_dirs = ["run_amp", "run_fp16util", "run_optimizers", "run_fused_layer_norm", "run_pyprof_nvtx", "run_pyprof_data"]
 
 runner = unittest.TextTestRunner(verbosity=2)
 


### PR DESCRIPTION
This seems like a possibly naive fix for #601. This unblocked us when using pyprof, but it's not clear to me if it breaks other use cases.