### PR TITLE
Fix typo

### DIFF
--- a/apex/optimizers/fused_novograd.py
+++ b/apex/optimizers/fused_novograd.py
@@ -47,7 +47,7 @@ class FusedNovoGrad(torch.optim.Optimizer):
         reg_inside_moment (bool, optional): whether do regularization (norm and L2)
             in momentum calculation. True for include, False for not include and
             only do it on update term. (default: False)
-        grad_averaging (bool, optional): whether apply (1-beta2) to grad when
+        grad_averaging (bool, optional): whether apply (1-beta1) to grad when
             calculating running averages of gradient. (default: True)
         norm_type (int, optional): which norm to calculate for each layer.
             2 for L2 norm, and 0 for infinite norm. These 2 are only supported


### PR DESCRIPTION
There is a little typo in docs for Novograd optimizer. It should be beta1 not beta2. Here is an algorithm from the paper. 
![image](https://user-images.githubusercontent.com/14337581/71075563-52ba3480-2195-11ea-9fda-be9593ea096c.png)
Also in C sources it is https://github.com/NVIDIA/apex/blob/4ad9b3bd4fab0c8f0e7811b369f59c234ee72ac7/csrc/multi_tensor_novograd.cu#L156
