### PR TITLE
Undefined name: delay_allreduce -> self.delay_allreduce

### DIFF
--- a/apex/parallel/distributed.py
+++ b/apex/parallel/distributed.py
@@ -255,8 +255,8 @@ class DistributedDataParallel(Module):
 
     def __setstate__(self, state):
         super(DistributedDataParallel, self).__setstate__(state)
-        if self.allreduce_different_streams and delay_allreduce:
-            raise ValueError("self.allreduce_different_streams may only be used if delay_allreduce=False.")
+        if self.allreduce_different_streams and self.delay_allreduce:
+            raise ValueError("self.allreduce_different_streams may only be used if self.delay_allreduce=False.")
 
         if self.delay_allreduce:
             self.needs_refresh = True
@@ -597,7 +597,7 @@ class DistributedDataParallel(Module):
                             len(self.buckets), self.num_buckets)
                         for b, bucket in enumerate(self.buckets):
                             assert len(bucket) == self.bucket_sizes[b], "len(buckets[{}]) = {}, expected {})".format(
-                                b, len(buckets[b]), self.bucket_sizes[b])
+                                b, len(bucket), self.bucket_sizes[b])
                             for i in range(len(bucket)):
                                 bucket[i] = None
 


### PR DESCRIPTION
__delay_allreduce__ is an _undefined name_ in this context which will raise NameError at runtime instead of the expected ValueError.  __self.delay_allreduce__ is set on line 223 and is used three lines below the modified line.

__buckets__ is an _undefined name_ in this context which will raise NameError at runtime.  __self.buckets__ is used on the previous line and __bucket__ best matches the use on this same line.

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./apex/parallel/distributed.py:258:49: F821 undefined name 'delay_allreduce'
        if self.allreduce_different_streams and delay_allreduce:
                                                ^
./apex/parallel/distributed.py:600:40: F821 undefined name 'buckets'
                                b, len(buckets[b]), self.bucket_sizes[b])
                                       ^
```