### PR TITLE
tolerate pip 19.3 for --pyprof builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@ from setuptools import setup, find_packages
 import subprocess
 
 from pip._internal import main as pipmain
+if not callable(pipmain):
+    from pip._internal.main import main as pipmain
+
 import sys
 import warnings
 import os


### PR DESCRIPTION
The 'main' function was moved between pip 19.2.3 and 19.3, which
causes '--pyprof' build to fail with (at least) pip 19.3 and 19.3.1:

    Traceback (most recent call last):
      File "setup.py", line 37, in <module>
        pipmain(["install"] + required_packages)
    TypeError: 'module' object is not callable

A permanent solution for this might require rewriting the '--pyprof'
install section to use 'python -m pip', but this change just adjusts
the import to tolerate the 19.3 change.

See:

- https://github.com/pypa/pip/commit/09fd200c599de4fadf2ff814a1bef855bc6d77e8
- https://github.com/pypa/pip/issues/7498
- https://github.com/pypa/pip/pull/7499