### PR TITLE
Avoid exception when initializing FusedNovoGrad with amp

### DIFF
--- a/apex/optimizers/fused_novograd.py
+++ b/apex/optimizers/fused_novograd.py
@@ -99,7 +99,7 @@ class FusedNovoGrad(torch.optim.Optimizer):
         super(FusedNovoGrad, self).load_state_dict(state_dict)
         # in case exp_avg_sq is not on the same device as params, move it there
         for group in self.param_groups:
-            if len(group['params']) > 0:
+            if (len(group['params']) > 0) and ("exp_avg_sq" in group):
                 group['exp_avg_sq'][0] = group['exp_avg_sq'][0].to(group['params'][0].device)
                 group['exp_avg_sq'][1] = group['exp_avg_sq'][1].to(group['params'][0].device)
 


### PR DESCRIPTION
Initializing FusedNovoGrad with amp (in O0 or O2) will throw an exception on a clean start.

This is because 'load_state_dict()' tries to set the device for 'exp_avg_sq' but it does not exist yet.

This is the exception that is thrown:
```
Traceback (most recent call last):
  File "train.py", line 122, in <module>
    num_losses=2)
  File "/opt/conda/lib/python3.6/site-packages/apex/amp/frontend.py", line 358, in initialize
    return _initialize(models, optimizers, _amp_state.opt_properties, num_losses, cast_model_outputs)
  File "/opt/conda/lib/python3.6/site-packages/apex/amp/_initialize.py", line 206, in _initialize
    optimizer.load_state_dict(optimizer.state_dict())
  File "/opt/conda/lib/python3.6/site-packages/apex/optimizers/fused_novograd.py", line 103, in load_state_dict
    group['exp_avg_sq'][0] = group['exp_avg_sq'][0].to(group['params'][0].device)
KeyError: 'exp_avg_sq'
```

This patch just checks for the existence of 'exp_avg_sq' before attempting to set the device on it.