### PR TITLE
Have to_type behave the same for torch.Tensor and custom types

### DIFF
--- a/apex/amp/_initialize.py
+++ b/apex/amp/_initialize.py
@@ -19,7 +19,7 @@ if torch.distributed.is_available():
 
 
 def to_type(dtype, t):
-    if isinstance(t, torch.Tensor):
+    if hasattr(t, "is_floating_point") and hasattr(t, "is_cuda") and hasattr(t, "to"):
         if not t.is_cuda:
             # This should not be a hard error, since it may be legitimate.
             warnings.warn("An input tensor was not cuda.")


### PR DESCRIPTION
Currently, `to_type()` behaves differently for `torch.Tensor` and custom types, calling `to()` directly on the custom type object without checking wether its data is floating point and residing on a GPU.
This change allows for custom types to be treated the same as standard tensors, properly handling non-floating point values, provided they also expose `is_floating_point`, `is_cuda` and `to`.