### PR TITLE
Return internal optimizer's param_groups from LARC

### DIFF
--- a/apex/parallel/LARC.py
+++ b/apex/parallel/LARC.py
@@ -37,7 +37,6 @@ class LARC(object):
     """
 
     def __init__(self, optimizer, trust_coefficient=0.02, clip=True, eps=1e-8):
-        self.param_groups = optimizer.param_groups
         self.optim = optimizer
         self.trust_coefficient = trust_coefficient
         self.eps = eps
@@ -52,6 +51,14 @@ class LARC(object):
     def __repr__(self):
         return self.optim.__repr__()
 
+    @property
+    def param_groups(self):
+        return self.optim.param_groups
+
+    @param_groups.setter
+    def param_groups(self, value):
+        self.optim.param_groups = value
+    
     def state_dict(self):
         return self.optim.state_dict()
 


### PR DESCRIPTION
Add a `param_groups` property which passes the setter and getter calls to the internal optimizer.
Fixes https://github.com/NVIDIA/apex/issues/766.