### PR TITLE
Update multi_tensor_adam.cu

### DIFF
--- a/csrc/multi_tensor_adam.cu
+++ b/csrc/multi_tensor_adam.cu
@@ -97,7 +97,7 @@ struct AdamFunctor
           r_v[ii] = beta2 * r_v[ii] + (1-beta2) * r_g[ii] * r_g[ii];
           MATH_T next_m_unbiased = r_m[ii] / beta1_correction;
           MATH_T next_v_unbiased = r_v[ii] / beta2_correction;
-          MATH_T denom = sqrtf(next_v_unbiased) + epsilon;
+          MATH_T denom = sqrtf(next_v_unbiased + epsilon);
           MATH_T update = next_m_unbiased / denom;
           r_p[ii] = r_p[ii] - (lr * update);
         }
@@ -106,7 +106,7 @@ struct AdamFunctor
           r_v[ii] = beta2 * r_v[ii] + (1-beta2) * r_g[ii] * r_g[ii];
           MATH_T next_m_unbiased = r_m[ii] / beta1_correction;
           MATH_T next_v_unbiased = r_v[ii] / beta2_correction;
-          MATH_T denom = sqrtf(next_v_unbiased) + epsilon;
+          MATH_T denom = sqrtf(next_v_unbiased + epsilon);
           MATH_T update = (next_m_unbiased / denom) + (decay * r_p[ii]);
           r_p[ii] = r_p[ii] - (lr * update);
         }


### PR DESCRIPTION
The current implementation of adam causes `nan` in gradients if `next_v_unbiased` is very close to zero. It sometimes happens during long-run training with `fp16`. I can't provide any short example where this problem occurs but from a discussion with my colleagues, it sometimes happens to all of them. 
The proposed fix is very small and it removes this problem completely. 