### PR TITLE
Fixed a typo in LAMB optimizer with O3 mode

### DIFF
--- a/apex/optimizers/fused_lamb.py
+++ b/apex/optimizers/fused_lamb.py
@@ -112,7 +112,7 @@ class FusedLAMB(torch.optim.Optimizer):
                     continue
                 if p.dtype == torch.float32:
                     g_all_32.append(p.grad.data)
-                elif p.dytpe == torch.float16:
+                elif p.dtype == torch.float16:
                     g_all_16.append(p.grad.data)
                 else:
                     raise RuntimeError('FusedLAMB only support fp16 and fp32.')


### PR DESCRIPTION
Simple fix a typo in LAMB optimizer when use O3 optimization level