### PR TITLE
Don't patch tensor ops that aren't present  

### DIFF
--- a/apex/amp/compat.py
+++ b/apex/amp/compat.py
@@ -42,5 +42,5 @@ def scalar_python_val(x):
             return x[0]
 
 # Accounts for the possibility that some ops may be removed from a namespace.
-def filter_attrs(module, attrs)
+def filter_attrs(module, attrs):
     return list(attrname for attrname in attrs if hasattr(module, attrname))

--- a/apex/amp/compat.py
+++ b/apex/amp/compat.py
@@ -40,3 +40,7 @@ def scalar_python_val(x):
             return x.data[0]
         else:
             return x[0]
+
+# Accounts for the possibility that some ops may be removed from a namespace.
+def filter_attrs(module, attrs)
+    return list(attrname for attrname in attrs if hasattr(module, attrname))

--- a/apex/amp/lists/tensor_overrides.py
+++ b/apex/amp/lists/tensor_overrides.py
@@ -11,20 +11,20 @@ MODULE = torch.Tensor
 #     MODULE = torch.autograd.Variable
 
 
-FP16_FUNCS = [
+FP16_FUNCS = compat.filter_attrs(MODULE, [
     '__matmul__',
-]
+])
 
-FP32_FUNCS = [
+FP32_FUNCS = compat.filter_attrs(MODULE, [
     '__ipow__',
     '__pow__',
     '__rpow__',
 
     # Cast to fp32 before transfer to CPU
     'cpu',
-]
+])
 
-CASTS = [
+CASTS = compat.filter_attrs(MODULE, [
     '__add__',
     '__div__',
     '__eq__',
@@ -46,7 +46,7 @@ CASTS = [
     '__rtruediv__',
     '__sub__',
     '__truediv__',
-]
+])
 
 # None of these, but here to make code cleaner.
 SEQUENCE_CASTS = []


### PR DESCRIPTION
Gives pytorch the liberty to remove some Tensor methods if desired (e.g. `__div__`, https://github.com/pytorch/pytorch/pull/39151)

Necessary as a stopgap to support existing scripts that use apex amp with recent pytorch.  Fix is not an endorsement of apex amp over [`torch.cuda.amp`](https://github.com/NVIDIA/apex/issues/818).  `torch.cuda.amp` is still 100% the best way forward.

Fixes errors with https://github.com/pytorch/pytorch/pull/39151 and Amp tests pass locally.