### PR TITLE
add an option to skip minor ver check

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ $ cd apex
 $ pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 ```
 
+If the major version of cuda installed system-wide matches the one pytorch was built with, but the minor don't match, if the changes are minor it may still build and work successfully (e.g. apex builds fine with cuda-11.1, while pytorch was built with cuda-11.0). In such case add: `--global-option="--skip-minor-ver-check" to the `pip install` command above.
+
+
 Apex also supports a Python-only build (required with Pytorch 0.4) via
 ```
 $ pip install -v --no-cache-dir ./

--- a/setup.py
+++ b/setup.py
@@ -98,13 +98,22 @@ def check_cuda_torch_binary_vs_bare_metal(cuda_dir):
     print("\nCompiling cuda extensions with")
     print(raw_output + "from " + cuda_dir + "/bin\n")
 
-    if (bare_metal_major != torch_binary_major) or (bare_metal_minor != torch_binary_minor):
+    major_match = bare_metal_major == torch_binary_major
+    minor_match = bare_metal_minor == torch_binary_minor
+    if "--skip-minor-ver-check" in sys.argv:
+        sys.argv.remove("--skip-minor-ver-check")
+        if not minor_match:
+            print(f"--skip-minor-ver-check activated: Attempting to use cuda-{bare_metal_major}.{bare_metal_minor}, "
+                  "despite pytorch using cuda-{torch_binary_major}.{torch_binary_minor} - this may or may not work")
+        minor_match = True
+    
+    if not (major_match and minor_match):
         raise RuntimeError("Cuda extensions are being compiled with a version of Cuda that does " +
                            "not match the version used to compile Pytorch binaries.  " +
                            "Pytorch binaries were compiled with Cuda {}.\n".format(torch.version.cuda) +
                            "In some cases, a minor-version mismatch will not cause later errors:  " +
                            "https://github.com/NVIDIA/apex/pull/323#discussion_r287021798.  "
-                           "You can try commenting out this check (at your own risk).")
+                           "At your own risk add --skip-minor-ver-check to try that")
 
 
 # Set up macros for forward/backward compatibility hack around

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ def check_cuda_torch_binary_vs_bare_metal(cuda_dir):
         sys.argv.remove("--skip-minor-ver-check")
         if not minor_match:
             print(f"--skip-minor-ver-check activated: Attempting to use cuda-{bare_metal_major}.{bare_metal_minor}, "
-                  "despite pytorch using cuda-{torch_binary_major}.{torch_binary_minor} - this may or may not work")
+                  f"despite pytorch using cuda-{torch_binary_major}.{torch_binary_minor} - this may or may not work")
         minor_match = True
     
     if not (major_match and minor_match):


### PR DESCRIPTION
As discussed at https://github.com/NVIDIA/apex/issues/988#issuecomment-726343453 we can build apex with cuda-11.1 while having pytorch built with cuda-11.0, so this PR adds an option to skip the minor version check. I understand the same happens with cuda-10. Docs updated.
`setup.py` will also print a note:
```
--skip-minor-ver-check activated: Attempting to use cuda-11.1, despite pytorch using cuda-11.0 - this may or may not work
```
so that it's in the logs.