### PR TITLE
Fix lack of proper loading of best_prec1 from the checkpoint

### DIFF
--- a/examples/imagenet/main_amp.py
+++ b/examples/imagenet/main_amp.py
@@ -182,6 +182,7 @@ def main():
                 print("=> loading checkpoint '{}'".format(args.resume))
                 checkpoint = torch.load(args.resume, map_location = lambda storage, loc: storage.cuda(args.gpu))
                 args.start_epoch = checkpoint['epoch']
+                global best_prec1
                 best_prec1 = checkpoint['best_prec1']
                 model.load_state_dict(checkpoint['state_dict'])
                 optimizer.load_state_dict(checkpoint['optimizer'])


### PR DESCRIPTION
- resume() is a nested function and when it loads best_prec1 it creates
  a local variable that hides the one from the parent function. This
  PR adds `nonlocal` to modify the parent function variable as intended

Signed-off-by: Janusz Lisiecki <jlisiecki@nvidia.com>