### PR TITLE
Fix example dockerfile

### DIFF
--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Base image must at least have pytorch and CUDA installed.
-ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:19.07-py3
+ARG BASE_IMAGE=pytorch/pytorch:1.6.0-cuda10.1-cudnn7-devel
 FROM $BASE_IMAGE
 ARG BASE_IMAGE
 RUN echo "Installing Apex on top of ${BASE_IMAGE}"
@@ -10,6 +10,8 @@ RUN pip uninstall -y apex || :
 RUN pip uninstall -y apex || :
 # SHA is something the user can touch to force recreation of this Docker layer,
 # and therefore force cloning of the latest version of Apex
+RUN apt-get update
+RUN apt-get install git -y
 RUN SHA=ToUcHMe git clone https://github.com/NVIDIA/apex.git
 WORKDIR /tmp/unique_for_apex/apex
 RUN pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" .


### PR DESCRIPTION
The example docker image does not build per my comments on this [issue](https://github.com/NVIDIA/apex/issues/101).

The suggested image also doesn't work unless an update/install of git is added. I changed the docker file to start with the `pytorch/pytorch:1.6.0-cuda10.1-cudnn7-devel` image and added the two needed commands. 

Output of successful build can be seen in this [gist](https://gist.github.com/liamwazherealso/ef1ff40c507c8f69baf15d879b0f1ec2). 