### PR TITLE
fix import container_abcs issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,14 +122,14 @@ See the [Docker example folder](https://github.com/NVIDIA/apex/tree/master/examp
 For performance and full functionality, we recommend installing Apex with
 CUDA and C++ extensions via
 ```
-$ git clone https://github.com/NVIDIA/apex
-$ cd apex
-$ pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
+git clone https://github.com/NVIDIA/apex
+cd apex
+pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 ```
 
 Apex also supports a Python-only build (required with Pytorch 0.4) via
 ```
-$ pip install -v --disable-pip-version-check --no-cache-dir ./
+pip install -v --disable-pip-version-check --no-cache-dir ./
 ```
 A Python-only build omits:
 - Fused kernels required to use `apex.optimizers.FusedAdam`.

--- a/apex/amp/_amp_state.py
+++ b/apex/amp/_amp_state.py
@@ -4,14 +4,7 @@
 # http://effbot.org/pyfaq/how-do-i-share-global-variables-across-modules.htm
 import os
 import torch
-
-TORCH_MAJOR = int(torch.__version__.split('.')[0])
-TORCH_MINOR = int(torch.__version__.split('.')[1])
-
-if TORCH_MAJOR == 0:
-    import collections.abc as container_abcs
-else:
-    from torch._six import container_abcs
+import collections.abc as container_abcs
 
 
 class AmpState(object):

--- a/apex/amp/_amp_state.py
+++ b/apex/amp/_amp_state.py
@@ -4,7 +4,14 @@
 # http://effbot.org/pyfaq/how-do-i-share-global-variables-across-modules.htm
 import os
 import torch
-import collections.abc as container_abcs
+
+TORCH_MAJOR = int(torch.__version__.split('.')[0])
+TORCH_MINOR = int(torch.__version__.split('.')[1])
+
+if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
+    from torch._six import container_abcs
+else:
+    import collections.abc as container_abcs
 
 
 class AmpState(object):

--- a/apex/amp/_amp_state.py
+++ b/apex/amp/_amp_state.py
@@ -8,6 +8,7 @@ import torch
 TORCH_MAJOR = int(torch.__version__.split('.')[0])
 TORCH_MINOR = int(torch.__version__.split('.')[1])
 
+
 if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
     from torch._six import container_abcs
 else:


### PR DESCRIPTION
Nightly PyTorch has removed `container_abcs` from `torch._six`.
https://github.com/pytorch/pytorch/commit/58eb23378f2a376565a66ac32c93a316c45b6131#diff-b3c160475f0fbe8ad50310f92d3534172ba98203387a962b7dc8f4a23b15cf4dL35

Also fix https://github.com/NVIDIA/apex/issues/1048 and https://github.com/NVIDIA/apex/issues/1046