### PR TITLE
Fix: DDP.__setstate__

### DIFF
--- a/apex/parallel/distributed.py
+++ b/apex/parallel/distributed.py
@@ -255,7 +255,7 @@ class DistributedDataParallel(Module):
 
     def __setstate__(self, state):
         super(DistributedDataParallel, self).__setstate__(state)
-        if self.allreduce_different_streams and delay_allreduce:
+        if self.allreduce_different_streams and self.delay_allreduce:
             raise ValueError("self.allreduce_different_streams may only be used if delay_allreduce=False.")
 
         if self.delay_allreduce:


### PR DESCRIPTION
The reference of `delay_allreduce` in `DistributedDataParallel.__setstate__` should be `self.delay_allreduce`, even though the `if` condition wouldn't be true actually in runtime.