### PR TITLE
fix(docs): corrects typo in project documentation

### DIFF
--- a/apex/pyprof/README.md
+++ b/apex/pyprof/README.md
@@ -91,7 +91,7 @@ scripts as well.
 	# CSV output.
     python -m apex.pyprof.prof --csv net.dict
 
-	# Space seperated output.
+	# Space separated output.
     python -m apex.pyprof.prof net.dict
 
 	# Columnated output of width 130 with columns index,direction,kernel name,parameters,silicon time.


### PR DESCRIPTION
Scope of changes is restricted to docs only. Change is in agreement with Standard American English.

seperated => separated in pyprof README.