### PR TITLE
include iostream in groupbn/batch_norm headers

### DIFF
--- a/apex/contrib/csrc/groupbn/batch_norm.h
+++ b/apex/contrib/csrc/groupbn/batch_norm.h
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <vector>
 #include <string>
+#include <iostream>
 
 #include "nhwc_batch_norm_kernel.h"
 #include "cuda_utils.h"

--- a/apex/contrib/csrc/groupbn/batch_norm_add_relu.h
+++ b/apex/contrib/csrc/groupbn/batch_norm_add_relu.h
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <vector>
 #include <string>
+#include <iostream>
 
 #include "nhwc_batch_norm_kernel.h"
 #include "cuda_utils.h"


### PR DESCRIPTION
This fixes a build issue due to a recent upstream change which removed many `#include <iostream>` lines.

See https://github.com/pytorch/pytorch/issues/63653 for details.