### PR TITLE
Fix typo in contrib FusedLamb.

### DIFF
--- a/apex/contrib/optimizers/fused_lamb.py
+++ b/apex/contrib/optimizers/fused_lamb.py
@@ -111,7 +111,7 @@ class FusedLAMB(torch.optim.Optimizer):
                     continue
                 if p.dtype == torch.float32:
                     g_all_32.append(p.grad.data)
-                elif p.dytpe == torch.float16:
+                elif p.dtype == torch.float16:
                     g_all_16.append(p.grad.data)
                 else:
                     raise RuntimeError('FusedLAMB only support fp16 and fp32.')


### PR DESCRIPTION
There was a typo (`dytpe` instead of `dtype`) in the contrib FusedLamb that would only cause error in cases with FP16 gradients (which are uncommon).