### PR TITLE
[fused layer norm] THCDeviceUtils.cuh -> ATen/cuda/DeviceUtils.cuh

### DIFF
--- a/csrc/layer_norm_cuda_kernel.cu
+++ b/csrc/layer_norm_cuda_kernel.cu
@@ -1,7 +1,7 @@
 #include "ATen/ATen.h"
 #include "ATen/AccumulateType.h"
 #include "ATen/cuda/CUDAContext.h"
-#include <THC/THCDeviceUtils.cuh>
+#include "ATen/cuda/DeviceUtils.cuh"
 
 #include <cuda.h>
 #include <cuda_runtime.h>


### PR DESCRIPTION
- THC/THCDeviceUtils.cuh is being removed: https://github.com/pytorch/pytorch/pull/65472
- Currently fused layer norm includes THC/THCDeviceUtils.cuh only for WARP_SHFL but this function is already implemented in https://github.com/pytorch/pytorch/blob/c371542efc31b1abfe6f388042aa3ab0cef935f2/aten/src/ATen/cuda/DeviceUtils.cuh#L44

So there's no need to wait 65472

cc @ptrblck @xwang233 