### PR TITLE
Fix compilation for cuda 9 by setting correct compute capabilities

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ if not torch.cuda.is_available():
           'export TORCH_CUDA_ARCH_LIST="compute capability" before running setup.py.\n')
     if os.environ.get("TORCH_CUDA_ARCH_LIST", None) is None:
         _, bare_metal_major, _ = get_cuda_bare_metal_version(CUDA_HOME)
+        if int(bare_metal_major) == 9:
+            os.environ["TORCH_CUDA_ARCH_LIST"] = "6.0;6.1;6.2;7.0"
         if int(bare_metal_major) == 11:
             os.environ["TORCH_CUDA_ARCH_LIST"] = "6.0;6.1;6.2;7.0;7.5;8.0"
         else:


### PR DESCRIPTION
I was trying to compile w/ pytorch 1.6.0 and CUDA 9.2 and was getting error:

```
nvcc fatal : Unsupported gpu architecture 'compute_75'
```

Cuda 9 does not support compute_75, hence specify only versions below this. 