### PR TITLE
fix race in `cuApplyLayerNorm`

### DIFF
--- a/csrc/layer_norm_cuda_kernel.cu
+++ b/csrc/layer_norm_cuda_kernel.cu
@@ -318,6 +318,7 @@ void cuApplyLayerNorm_(
       mean[i1] = mu;
       invvar[i1] = c_invvar;
     }
+    __syncthreads();
   }
 }
 


### PR DESCRIPTION
Add a `__syncthreads` to prevent loop iterations from clashing with each other then broadcasting `mu` and `sigma2` via `ubuf[0]` and `ubuf[1]`.
Compute sanitizer reported a race in `cuApplyLayerNorm`:
https://github.com/NVIDIA/Megatron-LM/blob/5ac5571ba0265af4c491ee0af1508ca7589450c6/megatron/fused_kernels/layer_norm_cuda_kernel.cu#L291
I believe the race is due to this read https://github.com/NVIDIA/Megatron-LM/blob/5ac5571ba0265af4c491ee0af1508ca7589450c6/megatron/fused_kernels/layer_norm_cuda_kernel.cu#L240 potentially getting a stale value on the next iteration of the loop, where cuWelfordMuSigma2 is called again and writes here:
https://github.com/NVIDIA/Megatron-LM/blob/5ac5571ba0265af4c491ee0af1508ca7589450c6/megatron/fused_kernels/layer_norm_cuda_kernel.cu#L220

CC @ptrblck @crcrpar