### PR TITLE
Remove `custom_fwd`/`custom_bwd` from fused softmax

### DIFF
--- a/apex/transformer/functional/fused_softmax.py
+++ b/apex/transformer/functional/fused_softmax.py
@@ -37,7 +37,6 @@ class ScaledUpperTriangMaskedSoftmax(torch.autograd.Function):
         return softmax_results
 
     @staticmethod
-    @torch.cuda.amp.custom_bwd
     def backward(ctx, output_grads):
         import scaled_upper_triang_masked_softmax_cuda
 
@@ -68,7 +67,6 @@ def scaled_upper_triang_masked_softmax(inputs, _, scale):
 class ScaledMaskedSoftmax(torch.autograd.Function):
 
     @staticmethod
-    @torch.cuda.amp.custom_fwd(cast_inputs=torch.half)
     def forward(ctx, inputs, mask, scale):
         import scaled_masked_softmax_cuda
         scale_t = torch.tensor([scale])
@@ -78,7 +76,6 @@ class ScaledMaskedSoftmax(torch.autograd.Function):
         return softmax_results
 
     @staticmethod
-    @torch.cuda.amp.custom_bwd
     def backward(ctx, output_grads):
         import scaled_masked_softmax_cuda
 


### PR DESCRIPTION
Unpaired `custom_bwd` causes the failure in the below.

While inputs to some fused kernels that support both bfloat16 and float16 are manually casted if autocast is enabled, but I forgot to remove custom_bwd from fused softmax.
 
```
    @functools.wraps(bwd)
    def decorate_bwd(*args, **kwargs):
>       with autocast(args[0]._fwd_used_autocast):
E       AttributeError: 'ScaledUpperTriangMaskedSoftmaxBackward' object has no attribute '_fwd_used_autocast'
```
