### PR TITLE
remove `THCNumerics.h` includes 

### DIFF
--- a/apex/contrib/csrc/groupbn/batch_norm.cu
+++ b/apex/contrib/csrc/groupbn/batch_norm.cu
@@ -1,6 +1,5 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <THC/THCNumerics.cuh>
 #include <c10/cuda/CUDACachingAllocator.h>
 
 #include "THC/THC.h"

--- a/apex/contrib/csrc/groupbn/batch_norm_add_relu.cu
+++ b/apex/contrib/csrc/groupbn/batch_norm_add_relu.cu
@@ -1,6 +1,5 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <THC/THCNumerics.cuh>
 #include <c10/cuda/CUDACachingAllocator.h>
 
 #include "THC/THC.h"

--- a/apex/contrib/csrc/groupbn/ipc.cu
+++ b/apex/contrib/csrc/groupbn/ipc.cu
@@ -1,6 +1,5 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <THC/THCNumerics.cuh>
 
 #include "THC/THC.h"
 


### PR DESCRIPTION
Upstream PyTorch will soon remove this header, and it looks like it is not really used:
https://github.com/pytorch/pytorch/pull/66388


CC @ptrblck 