### PR TITLE
Check size of minibatch in `get_kth_microbatch`

### DIFF
--- a/apex/transformer/pipeline_parallel/utils.py
+++ b/apex/transformer/pipeline_parallel/utils.py
@@ -126,7 +126,15 @@ def get_kth_microbatch(batch: List[torch.Tensor], k: int) -> List[torch.Tensor]:
     `a local minibatch` consists of `global_batch_size / data_parallel_size` samples.
     """
     micro_batch_size = get_micro_batch_size()
-    return [x[k * micro_batch_size:(k + 1) * micro_batch_size] for x in batch]
+    start = k * micro_batch_size
+    end = start + micro_batch_size
+    microbatch = list()
+    for x in batch:
+        size = x.size(0)
+        assert size > start and size >= end
+        microbatch.append(x[start:end])
+    assert len(microbatch) > 0
+    return microbatch
 
 
 def get_autoresume():

--- a/tests/L0/run_transformer/run_dynamic_batchsize_test.py
+++ b/tests/L0/run_transformer/run_dynamic_batchsize_test.py
@@ -31,7 +31,7 @@ _logger = get_transformer_logger("pipeline_parallel_test")
 # note(mkozuki): To see if local batch size increases, uncomment the line below
 # _logger.setLevel("INFO")
 global_vars.set_global_variables(
-    args_defaults={"global_batch_size": 512, "rampup_batch_size": [32, 32, 1000],},
+    args_defaults={"global_batch_size": 512, "rampup_batch_size": [64, 64, 1000],},
     ignore_unknown_args=True,
 )
 


### PR DESCRIPTION
We've seen many bugs due to `get_kth_microbatch` stepping past the number of elements in a minibatch silently. This PR changes the behavior to fire an assert when this happens and fixes a few bugs in tests uncovered by this change.

The batch size increase in the dynamic batch size is to support machines with 16 processes (GPUs), as there seems to be a limitation when the number of pipeline stages (16 GPU * 2 virtual) reaches the number of items in a microbatch (32).

CC @crcrpar @ptrblck 