### PR TITLE
Handle len(cached_x.grad_fn.next_functions) == 1 in cached_cast

### DIFF
--- a/apex/amp/utils.py
+++ b/apex/amp/utils.py
@@ -92,9 +92,12 @@ def cached_cast(cast_fn, x, cache):
         return type(x)([cached_cast(y) for y in x])
     if x in cache:
         cached_x = cache[x]
+        next_functions_available = False
         if x.requires_grad and cached_x.requires_grad:
+            if len(cached_x.grad_fn.next_functions) > 1:
+                next_functions_available = True
             # Make sure x is actually cached_x's autograd parent.
-            if cached_x.grad_fn.next_functions[1][0].variable is not x:
+            if next_functions_available and cached_x.grad_fn.next_functions[1][0].variable is not x:
                 raise RuntimeError("x and cache[x] both require grad, but x is not "
                                    "cache[x]'s parent.  This is likely an error.")
         # During eval, it's possible to end up caching casted weights with
@@ -113,6 +116,8 @@ def cached_cast(cast_fn, x, cache):
         # match.  During eval, we don't care that there's no autograd-graph
         # connection between x and cached_x.
         if torch.is_grad_enabled() and x.requires_grad != cached_x.requires_grad:
+            del cache[x]
+        elif x.requires_grad and cached_x.requires_grad and not next_functions_available:
             del cache[x]
         else:
             return cached_x


### PR DESCRIPTION
Using apex for mix precision training, and find one case when `if x.requires_grad and cached_x.requires_grad:`, the tuple `cached_x.grad_fn.next_functions` contains only one element. In this case, we see the error:
```python
    if cached_x.grad_fn.next_functions[1][0].variable is not x:
IndexError: tuple index out of range
```
This PR deals with this corner case.
