### PR TITLE
[FusedRMSNorm doc] document where epsilon is added

### DIFF
--- a/apex/normalization/fused_layer_norm.py
+++ b/apex/normalization/fused_layer_norm.py
@@ -310,7 +310,7 @@ class FusedRMSNorm(torch.nn.Module):
     :attr:`normalized_shape`.
     :math:`\gamma` is a learnable affine transform parameter of
     :attr:`normalized_shape` if :attr:`elementwise_affine` is ``True``.
-    `epsilon` is added before the root of the mean-square is taken.
+    `epsilon` is added to the mean-square, then the root of the sum is taken.
 
     .. note::
         Unlike Batch Normalization and Instance Normalization, which applies

--- a/apex/normalization/fused_layer_norm.py
+++ b/apex/normalization/fused_layer_norm.py
@@ -303,7 +303,7 @@ class FusedRMSNorm(torch.nn.Module):
     Currently only runs on cuda() tensors.
 
     .. math::
-        y = \frac{x}{\mathrm{RMS}[x]} * \gamma
+        y = \frac{x}{\mathrm{RMS}[x] + \epsilon} * \gamma
 
     The root-mean-square is calculated separately over the last
     certain number dimensions which have to be of the shape specified by

--- a/apex/normalization/fused_layer_norm.py
+++ b/apex/normalization/fused_layer_norm.py
@@ -303,13 +303,14 @@ class FusedRMSNorm(torch.nn.Module):
     Currently only runs on cuda() tensors.
 
     .. math::
-        y = \frac{x}{\mathrm{RMS}[x] + \epsilon} * \gamma
+        y = \frac{x}{\mathrm{RMS}[x]} * \gamma
 
     The root-mean-square is calculated separately over the last
     certain number dimensions which have to be of the shape specified by
     :attr:`normalized_shape`.
     :math:`\gamma` is a learnable affine transform parameter of
     :attr:`normalized_shape` if :attr:`elementwise_affine` is ``True``.
+    `epsilon` is added before the root of the mean-square is taken.
 
     .. note::
         Unlike Batch Normalization and Instance Normalization, which applies


### PR DESCRIPTION
This PR adds the the missing epsilon to formula to match the code


------------

It's actually very unlikely that the denominator will ever be zero in this class - unless each input is zero, since this is the root of sum of squares of numbers.

I don't know if it's faster to add epsilon than to check if all inputs are zero, since the output will be zero then.

@eqy 