### PR TITLE
Peer memory halo exchange

### DIFF
--- a/apex/contrib/bottleneck/__init__.py
+++ b/apex/contrib/bottleneck/__init__.py
@@ -1,2 +1,2 @@
 from .bottleneck import Bottleneck, SpatialBottleneck
-from .halo_exchangers import HaloExchangerNoComm, HaloExchangerAllGather, HaloExchangerSendRecv
+from .halo_exchangers import HaloExchangerNoComm, HaloExchangerAllGather, HaloExchangerSendRecv, HaloExchangerPeer

--- a/apex/contrib/bottleneck/__init__.py
+++ b/apex/contrib/bottleneck/__init__.py
@@ -1,1 +1,2 @@
 from .bottleneck import Bottleneck, SpatialBottleneck
+from .halo_exchangers import HaloExchangerNoComm, HaloExchangerAllGather, HaloExchangerSendRecv

--- a/apex/contrib/bottleneck/bottleneck.py
+++ b/apex/contrib/bottleneck/bottleneck.py
@@ -1,13 +1,15 @@
 import torch
 import torch.distributed as dist
 from torch import nn
-import fast_bottleneck
+from maskrcnn_benchmark.utils.registry import Registry
+import maskrcnn_benchmark.SpatialBottleneck as fast_bottleneck
+import nccl_p2p as inc
 
 def kaiming_uniform_(tensor, a=0, mode='fan_in', nonlinearity='leaky_relu'):
     weight_tensor_nchw = tensor
     nn.init.kaiming_uniform_(weight_tensor_nchw, a=a, mode=mode, nonlinearity=nonlinearity)
 
-class FrozenBatchNorm2d(torch.nn.Module):
+class FrozenBatchNorm2d(torch.jit.ScriptModule):
     """
     BatchNorm2d where the batch statistics and the affine parameters are fixed
     """
@@ -18,7 +20,9 @@ class FrozenBatchNorm2d(torch.nn.Module):
         self.register_buffer("running_mean", torch.zeros(n))
         self.register_buffer("running_var", torch.ones(n))
 
-    def get_scale_bias(self, nhwc=False):
+    @torch.jit.script_method
+    def get_scale_bias(self, nhwc):
+        # type: (bool) -> List[torch.Tensor]
         scale = self.weight * self.running_var.rsqrt()
         bias = self.bias - self.running_mean * scale
         if nhwc:
@@ -29,10 +33,10 @@ class FrozenBatchNorm2d(torch.nn.Module):
             bias = bias.reshape(1, -1, 1, 1)
         return scale, bias
 
+    @torch.jit.script_method
     def forward(self, x):
-        scale, bias = self.get_scale_bias()
+        scale, bias = self.get_scale_bias(False)
         return x * scale + bias
-
 
 @torch.jit.script
 def drelu_dscale1(grad_o, output, scale1):
@@ -217,7 +221,11 @@ class Bottleneck(torch.nn.Module):
 
 class SpatialBottleneckFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, spatial_group_size, local_rank, comm, stream1, nhwc, stride_1x1, scale, bias, x, *conv):
+    def forward(ctx, spatial_group_size, spatial_group_rank, spatial_communicator, spatial_halo_exchanger, spatial_stream, nhwc, stride_1x1, scale, bias, x, *conv):
+        if spatial_group_size > 1:
+            stream1 = spatial_halo_exchanger.stream1
+            stream2 = spatial_halo_exchanger.stream2
+
         # TODO: clean up order of tensors
         args = [x, *conv[0:3], *scale[0:3], *bias[0:3]]
         ctx.downsample = len(conv) > 3
@@ -232,38 +240,38 @@ class SpatialBottleneckFunction(torch.autograd.Function):
         outputs = fast_bottleneck.forward_init(nhwc, stride_1x1, args)
         fast_bottleneck.forward_out1(nhwc, stride_1x1, args, outputs)
 
-        fast_bottleneck.forward_out2(nhwc, stride_1x1, args, outputs)
-
         # do halo exchange for outputs[0] (out1)
-        # compute halo cells for outputs[1]
         if spatial_group_size > 1:
             out1 = outputs[0]
             N,Hs,W,C = list(out1.shape)
             stream1.wait_stream(torch.cuda.current_stream())
             with torch.cuda.stream(stream1):
-                # copy halos to send buffer
-                send_halos = torch.empty((N,2,W,C),dtype=out1.dtype,device=out1.device)
-                send_halos[:,:1,:,:].copy_(out1[:,:1,:,:])
-                send_halos[:,1:,:,:].copy_(out1[:,Hs-1:,:,:])
-                all_halos = torch.empty((N,2*spatial_group_size,W,C),dtype=out1.dtype,device=out1.device)
-                all_halos = [all_halos[:,i*2:(i+1)*2,:,:] for i in range(spatial_group_size)]
-                dist.all_gather(all_halos,send_halos,group=comm)
-                fat_halo = torch.empty((N,3,W,C),dtype=out1.dtype,device=out1.device)
-                top_out1_halo = all_halos[(spatial_group_size+local_rank-1)%spatial_group_size][:,1:,:,:]
-                if local_rank > 0:
-                    fat_halo[:,:1,:,:].copy_(top_out1_halo)
-                    fat_halo[:,1:3,:,:].copy_(out1[:,:2,:,:])
-                    top_out2 = fast_bottleneck.forward_out2_halo(nhwc, fat_halo, args)
-                btm_out1_halo = all_halos[(local_rank+1)%spatial_group_size][:,:1,:,:]
-                if local_rank < spatial_group_size-1:
-                    fat_halo[:,0:2,:,:].copy_(out1[:,Hs-2:,:,:])
-                    fat_halo[:,2:,:,:].copy_(btm_out1_halo)
-                    btm_out2 = fast_bottleneck.forward_out2_halo(nhwc, fat_halo, args)
-            torch.cuda.current_stream().wait_stream(stream1)
+                top_out1_halo, btm_out1_halo = spatial_halo_exchanger.left_right_halo_exchange(out1[:,:1,:,:], out1[:,Hs-1:,:,:])
+            if spatial_group_rank < spatial_group_size-1:
+                stream2.wait_stream(stream1)
+                with torch.cuda.stream(stream2):
+                    btm_fat_halo = torch.empty((N,3,W,C),dtype=out1.dtype,device=out1.device)
+                    btm_fat_halo[:,0:2,:,:].copy_(out1[:,Hs-2:,:,:])
+                    btm_fat_halo[:,2:,:,:].copy_(btm_out1_halo)
+                    btm_out2 = fast_bottleneck.forward_out2_halo(nhwc, btm_fat_halo, args)
+            if spatial_group_rank > 0:
+                with torch.cuda.stream(stream1):
+                    top_fat_halo = torch.empty((N,3,W,C),dtype=out1.dtype,device=out1.device)
+                    top_fat_halo[:,:1,:,:].copy_(top_out1_halo)
+                    top_fat_halo[:,1:3,:,:].copy_(out1[:,:2,:,:])
+                    top_out2 = fast_bottleneck.forward_out2_halo(nhwc, top_fat_halo, args)
+            inc.add_delay(10)
+
+        fast_bottleneck.forward_out2(nhwc, stride_1x1, args, outputs)
+
+        # compute halo cells for outputs[1] (out2)
+        if spatial_group_size > 1:
             out2 = outputs[1]
-            if local_rank > 0:
+            if spatial_group_rank > 0:
+                torch.cuda.current_stream().wait_stream(stream1)
                 out2[:,:1,:,:].copy_(top_out2)
-            if local_rank < spatial_group_size-1:
+            if spatial_group_rank < spatial_group_size-1:
+                torch.cuda.current_stream().wait_stream(stream2)
                 out2[:,Hs-1:,:,:].copy_(btm_out2)
             
         fast_bottleneck.forward_rest(nhwc, stride_1x1, args, outputs)
@@ -276,9 +284,11 @@ class SpatialBottleneckFunction(torch.autograd.Function):
         ctx.nhwc = nhwc
         ctx.stride_1x1 = stride_1x1
         ctx.spatial_group_size = spatial_group_size
-        ctx.local_rank = local_rank
-        ctx.comm = comm
-        ctx.stream1 = stream1
+        if spatial_group_size > 1:
+            ctx.spatial_group_rank = spatial_group_rank
+            ctx.spatial_halo_exchanger = spatial_halo_exchanger
+            ctx.stream1 = stream1
+            ctx.stream2 = stream2
         return outputs[2]
 
     # backward relu is not exposed, MUL with mask used now
@@ -312,53 +322,51 @@ class SpatialBottleneckFunction(torch.autograd.Function):
 
         grads = fast_bottleneck.backward_init(ctx.nhwc, ctx.stride_1x1, t_list)
         grad_out2 = fast_bottleneck.backward_grad_out2(ctx.nhwc, ctx.stride_1x1, t_list, grads)
+        # do halo exchange of grad_out2 here
+        # compute halo cells for grad_out1
+        if ctx.spatial_group_size > 1:
+            N,Hs,W,C = list(grad_out2.shape)
+            relu1 = t_list[12]
+            ctx.stream1.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(ctx.stream1):
+                top_halo, btm_halo = ctx.spatial_halo_exchanger.left_right_halo_exchange(grad_out2[:,:1,:,:], grad_out2[:,Hs-1:,:,:])
+                # copy halos to send buffer
+            if ctx.spatial_group_rank < ctx.spatial_group_size-1:
+                ctx.stream2.wait_stream(ctx.stream1)
+                with torch.cuda.stream(ctx.stream2):
+                    btm_fat_halo = torch.empty((N,3,W,C),dtype=grad_out2.dtype,device=grad_out2.device)
+                    btm_relu_halo = torch.empty((N,3,W,C),dtype=grad_out2.dtype,device=grad_out2.device)
+                    btm_fat_halo[:,:2,:,:].copy_(grad_out2[:,Hs-2:,:,:])
+                    btm_fat_halo[:,2:,:,:].copy_(btm_halo)
+                    btm_relu_halo[:,:2,:,:].copy_(relu1[:,Hs-2:,:,:])
+                    btm_relu_halo[:,2:,:,:].zero_()
+                    btm_grad_out1_halo = fast_bottleneck.backward_grad_out1_halo(ctx.nhwc, ctx.stride_1x1, t_list, grads, btm_fat_halo, btm_relu_halo)
+                    btm_grad_out1_halo = btm_grad_out1_halo[:,1:2,:,:]
+            if ctx.spatial_group_rank > 0:
+                with torch.cuda.stream(ctx.stream1):
+                    top_fat_halo = torch.empty((N,3,W,C),dtype=grad_out2.dtype,device=grad_out2.device)
+                    top_relu_halo = torch.empty((N,3,W,C),dtype=grad_out2.dtype,device=grad_out2.device)
+                    top_fat_halo[:,:1,:,:].copy_(top_halo)
+                    top_fat_halo[:,1:,:,:].copy_(grad_out2[:,:2,:,:])
+                    top_relu_halo[:,:1,:,:].zero_()
+                    top_relu_halo[:,1:,:,:].copy_(relu1[:,:2,:,:])
+                    top_grad_out1_halo = fast_bottleneck.backward_grad_out1_halo(ctx.nhwc, ctx.stride_1x1, t_list, grads, top_fat_halo, top_relu_halo)
+                    top_grad_out1_halo = top_grad_out1_halo[:,1:2,:,:]
+            inc.add_delay(10)
 
         # compute wgrad2 for internal cells
         wgrad2 = fast_bottleneck.backward_wgrad2(ctx.nhwc, ctx.stride_1x1, t_list, grads, grad_out2)
 
         # apply wgrad2 halos
         if ctx.spatial_group_size > 1:
-            if ctx.local_rank > 0:
+            if ctx.spatial_group_rank > 0:
                 top_grad2_halo = grad_out2[:,:1,:,:]
                 top_wgrad2_halo = fast_bottleneck.backward_wgrad2_halo(ctx.nhwc, ctx.stride_1x1, t_list, grads, top_out1_halo, top_grad2_halo)
                 wgrad2[:,:1,:,:].add_(top_wgrad2_halo)
-            if ctx.local_rank < ctx.spatial_group_size-1:
+            if ctx.spatial_group_rank < ctx.spatial_group_size-1:
                 btm_grad2_halo = grad_out2[:,-1:,:,:]
                 btm_wgrad2_halo = fast_bottleneck.backward_wgrad2_halo(ctx.nhwc, ctx.stride_1x1, t_list, grads, btm_out1_halo, btm_grad2_halo)
                 wgrad2[:,-1:,:,:].add_(btm_wgrad2_halo)
-
-        # do halo exchange of grad_out2 here
-        # compute halo cells for grad_out1
-        if ctx.spatial_group_size > 1:
-            N,Hs,W,C = list(grad_out2.shape)
-            ctx.stream1.wait_stream(torch.cuda.current_stream())
-            with torch.cuda.stream(ctx.stream1):
-                # copy halos to send buffer
-                send_halos = torch.empty((N,2,W,C),dtype=grad_out2.dtype,device=grad_out2.device)
-                send_halos[:,:1,:,:].copy_(grad_out2[:,:1,:,:])
-                send_halos[:,1:,:,:].copy_(grad_out2[:,Hs-1:,:,:])
-                all_halos = torch.empty((N,2*ctx.spatial_group_size,W,C),dtype=grad_out2.dtype,device=grad_out2.device)
-                all_halos = [all_halos[:,i*2:(i+1)*2,:,:] for i in range(ctx.spatial_group_size)]
-                dist.all_gather(all_halos,send_halos,group=ctx.comm)
-                relu1 = t_list[12]
-                fat_halo = torch.empty((N,3,W,C),dtype=grad_out2.dtype,device=grad_out2.device)
-                relu_halo = torch.empty((N,3,W,C),dtype=grad_out2.dtype,device=grad_out2.device)
-                if ctx.local_rank > 0:
-                    top_halo = all_halos[ctx.local_rank-1][:,1:,:,:]
-                    fat_halo[:,:1,:,:].copy_(top_halo)
-                    fat_halo[:,1:,:,:].copy_(grad_out2[:,:2,:,:])
-                    relu_halo[:,:1,:,:].zero_()
-                    relu_halo[:,1:,:,:].copy_(relu1[:,:2,:,:])
-                    top_grad_out1_halo = fast_bottleneck.backward_grad_out1_halo(ctx.nhwc, ctx.stride_1x1, t_list, grads, fat_halo, relu_halo)
-                    top_grad_out1_halo = top_grad_out1_halo[:,1:2,:,:]
-                if ctx.local_rank < ctx.spatial_group_size-1:
-                    btm_halo = all_halos[ctx.local_rank+1][:,:1,:,:]
-                    fat_halo[:,:2,:,:].copy_(grad_out2[:,Hs-2:,:,:])
-                    fat_halo[:,2:,:,:].copy_(btm_halo)
-                    relu_halo[:,:2,:,:].copy_(relu1[:,Hs-2:,:,:])
-                    relu_halo[:,2:,:,:].zero_()
-                    btm_grad_out1_halo = fast_bottleneck.backward_grad_out1_halo(ctx.nhwc, ctx.stride_1x1, t_list, grads, fat_halo, relu_halo)
-                    btm_grad_out1_halo = btm_grad_out1_halo[:,1:2,:,:]
 
         # compute grad_out1 for internal cells
         grad_out1 = fast_bottleneck.backward_grad_out1(ctx.nhwc, ctx.stride_1x1, t_list, grads, grad_out2)
@@ -369,19 +377,69 @@ class SpatialBottleneckFunction(torch.autograd.Function):
             z = t_list[4]
             relu1 = t_list[12]
             #print("w.shape = %s, z.shape = %s, relu1.shape = %s" % (str(list(w.shape)), str(list(z.shape)), str(list(relu1.shape))))
-            torch.cuda.current_stream().wait_stream(ctx.stream1)
-            if ctx.local_rank > 0:
+            if ctx.spatial_group_rank > 0:
+                torch.cuda.current_stream().wait_stream(ctx.stream1)
                 grad_out1[:,:1,:,:].copy_(top_grad_out1_halo)
-                #print("ctx.local_rank = %d, apply grad_out1 top halo (grad_out1.shape = %s)" % (ctx.local_rank, str(list(grad_out1.shape))))
-            if ctx.local_rank < ctx.spatial_group_size-1:
+                #print("ctx.spatial_group_rank = %d, apply grad_out1 top halo (grad_out1.shape = %s)" % (ctx.spatial_group_rank, str(list(grad_out1.shape))))
+            if ctx.spatial_group_rank < ctx.spatial_group_size-1:
+                torch.cuda.current_stream().wait_stream(ctx.stream2)
                 grad_out1[:,Hs-1:,:,:].copy_(btm_grad_out1_halo)
-                #print("ctx.local_rank = %d, apply grad_out1 btm halo (grad_out1.shape = %s)" % (ctx.local_rank, str(list(grad_out1.shape))))
+                #print("ctx.spatial_group_rank = %d, apply grad_out1 btm halo (grad_out1.shape = %s)" % (ctx.spatial_group_rank, str(list(grad_out1.shape))))
 
         fast_bottleneck.backward_rest(ctx.nhwc, ctx.stride_1x1, t_list, grads, grad_out2, grad_out1, wgrad2)
 
-        return (None, None, None, None, None, None, None, None, *grads)
+        return (None, None, None, None, None, None, None, None, None, *grads)
 
 spatial_bottleneck_function = SpatialBottleneckFunction.apply
+
+# Communication free halo exchanger.
+# NB! This halo exchanger does not exchange halos with neighbors as it should, it merely swaps the inputs
+# NB! This is only useful for performance testing.
+# NB! Do not use for actual production runs
+class HaloExchanger(object):
+    def __init__(self):
+        self.stream1 = torch.cuda.Stream()
+        self.stream2 = torch.cuda.Stream()
+
+class HaloExchangerNoComm(HaloExchanger):
+    def __init__(self, world_size, spatial_group_size, rank, comm):
+        super(HaloExchangerNoComm, self).__init__()
+
+    def left_right_halo_exchange(self, left_output_halo, right_output_halo):
+        return right_output_halo, left_output_halo
+
+class HaloExchangerAllGather(HaloExchanger):
+    def __init__(self, world_size, spatial_group_size, rank, comm):
+        super(HaloExchangerAllGather, self).__init__()
+        self.spatial_group_size = spatial_group_size
+        self.local_rank = rank % spatial_group_size
+        self.comm = comm
+
+    def left_right_halo_exchange(self, left_output_halo, right_output_halo):
+        N,Hh,W,C = list(left_output_halo.shape)
+        send_halos = torch.empty((N,2*Hh,W,C),dtype=left_output_halo.dtype,device=left_output_halo.device)
+        send_halos[:,:Hh,:,:].copy_(left_output_halo)
+        send_halos[:,Hh:,:,:].copy_(right_output_halo)
+        all_halos = torch.empty((N,2*Hh*self.spatial_group_size,W,C),dtype=left_output_halo.dtype,device=left_output_halo.device)
+        all_halos = [all_halos[:,i*2*Hh:(i+1)*2*Hh,:,:] for i in range(self.spatial_group_size)]
+        torch.distributed.all_gather(all_halos,send_halos,group=self.comm,no_copy=True)
+        left_input_halo = all_halos[(self.spatial_group_size+self.local_rank-1)%self.spatial_group_size][:,Hh:,:,:]
+        right_input_halo = all_halos[(self.local_rank+1)%self.spatial_group_size][:,:Hh,:,:]
+        return left_input_halo, right_input_halo
+
+class HaloExchangerSendRecv(HaloExchanger):
+    def __init__(self, world_size, spatial_group_size, rank, comm):
+        super(HaloExchangerSendRecv, self).__init__()
+        self.world_size = world_size
+        self.spatial_group_size = spatial_group_size
+        nccl_id = inc.get_unique_nccl_id(1).cuda()
+        torch.distributed.broadcast(nccl_id, 0)
+        nccl_id = nccl_id.cpu()
+        self.handle = inc.init_nccl_comm(nccl_id, rank, world_size)
+
+    def left_right_halo_exchange(self, left_output_halo, right_output_halo):
+        left_input_halo, right_input_halo = inc.left_right_halo_exchange(self.handle, left_output_halo, right_output_halo, self.spatial_group_size)
+        return left_input_halo, right_input_halo
 
 class SpatialBottleneck(torch.nn.Module):
     # Bottleneck in torchvision places the stride for downsampling at 3x3 convolution(self.conv2)
@@ -393,7 +451,7 @@ class SpatialBottleneck(torch.nn.Module):
 
     def __init__(self, in_channels, bottleneck_channels, out_channels, stride=1, groups=1,
                  dilation=1, norm_func=None, use_cudnn=False, explicit_nhwc=False, 
-                 spatial_group_size=1, communicator=None):
+                 spatial_parallel_args=None):
         super(SpatialBottleneck, self).__init__()
         if groups != 1:
             raise RuntimeError('Only support groups == 1')
@@ -447,26 +505,10 @@ class SpatialBottleneck(torch.nn.Module):
                     p.data = p.data.permute(0,2,3,1).contiguous()
 
         # spatial communicator
-        self.spatial_group_size = spatial_group_size
-        if spatial_group_size > 1:
-            world_size = dist.get_world_size()
-            num_groups = world_size // spatial_group_size
-            assert(num_groups*spatial_group_size == world_size), "torch.distributed.get_world_size() must be multiple of group_size"
-            rank = dist.get_rank()
-            self.local_rank = rank % spatial_group_size
-            if communicator is None:
-                for group in range(num_groups):
-                    ranks = list(range(group*spatial_group_size,(group+1)*spatial_group_size))
-                    comm = torch.distributed.new_group(ranks=ranks)
-                    if rank in ranks:
-                        self.communicator = comm
-            else:
-                self.communicator = communicator
-            self.stream1 = torch.cuda.Stream()
-            self.spatial_args = self.spatial_group_size, self.local_rank, self.communicator, self.stream1
+        if spatial_parallel_args is None:
+            self.spatial_parallel_args = (1, 0, None, None, None)
         else:
-            self.spatial_args = 1, 0, None, None
-
+            self.spatial_parallel_args = spatial_parallel_args
         return
 
     def forward(self, x):
@@ -483,7 +525,7 @@ class SpatialBottleneck(torch.nn.Module):
                 w_scale.append(s4)
                 w_bias.append(b4)
 
-            out = spatial_bottleneck_function(*self.spatial_args, self.explicit_nhwc, self.stride, w_scale, w_bias, x, *self.w_conv)
+            out = spatial_bottleneck_function(*self.spatial_parallel_args, self.explicit_nhwc, self.stride, w_scale, w_bias, x, *self.w_conv)
             return out
 
         if self.explicit_nhwc:
@@ -510,3 +552,10 @@ class SpatialBottleneck(torch.nn.Module):
         out = self.relu(out)
 
         return out
+
+_HALO_EXCHANGERS = Registry({
+    "HaloExchangerNoComm": HaloExchangerNoComm,
+    "HaloExchangerAllGather": HaloExchangerAllGather,
+    "HaloExchangerSendRecv": HaloExchangerSendRecv,
+})
+

--- a/apex/contrib/bottleneck/bottleneck.py
+++ b/apex/contrib/bottleneck/bottleneck.py
@@ -330,6 +330,7 @@ class SpatialBottleneckFunction(torch.autograd.Function):
                 # the first kernel of _forward_rest can launch.
                 # At least we can overlap the two halo correction kernels.
                 if spatial_group_rank < spatial_group_size-1:
+                    stream2.wait_stream(stream1) # wait for halo transfers to finish
                     stream2.wait_stream(torch.cuda.current_stream()) # wait for *_out2_mask to finish
                     with torch.cuda.stream(stream2):
                         w1by3 = args[2][:,2:3,:,:].clone()

--- a/apex/contrib/bottleneck/bottleneck.py
+++ b/apex/contrib/bottleneck/bottleneck.py
@@ -508,7 +508,7 @@ class SpatialBottleneckFunction(torch.autograd.Function):
                         btm_relu_halo = relu1[:,:,Hs-1:,:].clone()
                         btm_grad_out1 = grad_out1[:,:,Hs-1:,:]
                     w1by3 = w[:,:1,:,:].clone()
-                    ctx.stream1.wait_stream(ctx.stream2) # wait for halo transfers to finish
+                    ctx.stream2.wait_stream(ctx.stream1) # wait for halo transfers to finish
                     ctx.stream2.wait_stream(torch.cuda.current_stream()) # wait for backward_grad_out1_mask to finish before launching halo correction kernel
                     with torch.cuda.stream(ctx.stream1):
                         btm_grad_out1_halo = fast_bottleneck.backward_grad_out1_halo_corr(ctx.explicit_nhwc, ctx.stride_1x1, t_list, w1by3, grads, btm_halo, btm_relu_halo, btm_grad_out1.clone())

--- a/apex/contrib/bottleneck/bottleneck.py
+++ b/apex/contrib/bottleneck/bottleneck.py
@@ -510,7 +510,7 @@ class SpatialBottleneckFunction(torch.autograd.Function):
                     w1by3 = w[:,:1,:,:].clone()
                     ctx.stream2.wait_stream(ctx.stream1) # wait for halo transfers to finish
                     ctx.stream2.wait_stream(torch.cuda.current_stream()) # wait for backward_grad_out1_mask to finish before launching halo correction kernel
-                    with torch.cuda.stream(ctx.stream1):
+                    with torch.cuda.stream(ctx.stream2):
                         btm_grad_out1_halo = fast_bottleneck.backward_grad_out1_halo_corr(ctx.explicit_nhwc, ctx.stride_1x1, t_list, w1by3, grads, btm_halo, btm_relu_halo, btm_grad_out1.clone())
                         btm_grad_out1.copy_(btm_grad_out1_halo)
                 if ctx.spatial_group_rank > 0:

--- a/apex/contrib/bottleneck/bottleneck.py
+++ b/apex/contrib/bottleneck/bottleneck.py
@@ -2,7 +2,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 import fast_bottleneck
-import nccl_p2p as inc
+import nccl_p2p_cuda as inc
 
 def kaiming_uniform_(tensor, a=0, mode='fan_in', nonlinearity='leaky_relu'):
     weight_tensor_nchw = tensor

--- a/apex/contrib/bottleneck/bottleneck.py
+++ b/apex/contrib/bottleneck/bottleneck.py
@@ -289,11 +289,6 @@ class SpatialBottleneckFunction(torch.autograd.Function):
                 out1_pad = torch.empty([N,C,Hs+2,W], dtype=out1.dtype, device='cuda', memory_format=memory_format)
             stream1.wait_stream(torch.cuda.current_stream())
             if spatial_method != 2: stream3.wait_stream(torch.cuda.current_stream())
-            with torch.cuda.stream(stream3):
-                if explicit_nhwc:
-                    out1_pad[:,1:Hs+1,:,:].copy_(out1)
-                else:
-                    out1_pad[:,:,1:Hs+1,:].copy_(out1)
             with torch.cuda.stream(stream1):
                 if explicit_nhwc:
                     top_out1_halo = out1_pad[:,:1,:,:]
@@ -343,11 +338,11 @@ class SpatialBottleneckFunction(torch.autograd.Function):
                     out1_pad[:,:,1:Hs+1,:].copy_(out1)
         elif spatial_method == 2:
             # wait for halo transfer to finish before doing a full convolution of padded x
-            torch.cuda.current_stream().wait_stream(stream1)
             if explicit_nhwc:
                 out1_pad[:,1:Hs+1,:,:].copy_(out1)
             else:
                 out1_pad[:,:,1:Hs+1,:].copy_(out1)
+            torch.cuda.current_stream().wait_stream(stream1)
             fast_bottleneck.forward_out2_pad(explicit_nhwc, stride_1x1, args, outputs, out1_pad)
         elif spatial_method == 3:
             fast_bottleneck.forward_out2_mask(explicit_nhwc, stride_1x1, args, outputs, thresholdTop, thresholdBottom)
@@ -705,8 +700,6 @@ class SpatialBottleneck(torch.nn.Module):
                     s4, b4 = self.downsample[1].get_scale_bias(self.explicit_nhwc)
                     w_scale.append(s4)
                     w_bias.append(b4)
-                self.w_scale = w_scale
-                self.w_bias = w_bias
                 out = spatial_bottleneck_function(*self.spatial_parallel_args, self.explicit_nhwc, self.stride, w_scale, w_bias, self.thresholdTop, self.thresholdBottom, x, *self.w_conv)
             else:
                 out = spatial_bottleneck_function(*self.spatial_parallel_args, self.explicit_nhwc, self.stride, self.w_scale, self.w_bias, self.thresholdTop, self.thresholdBottom, x, *self.w_conv)

--- a/apex/contrib/bottleneck/bottleneck.py
+++ b/apex/contrib/bottleneck/bottleneck.py
@@ -1,8 +1,7 @@
 import torch
 import torch.distributed as dist
 from torch import nn
-from maskrcnn_benchmark.utils.registry import Registry
-import maskrcnn_benchmark.SpatialBottleneck as fast_bottleneck
+import fast_bottleneck
 import nccl_p2p as inc
 
 def kaiming_uniform_(tensor, a=0, mode='fan_in', nonlinearity='leaky_relu'):
@@ -392,55 +391,6 @@ class SpatialBottleneckFunction(torch.autograd.Function):
 
 spatial_bottleneck_function = SpatialBottleneckFunction.apply
 
-# Communication free halo exchanger.
-# NB! This halo exchanger does not exchange halos with neighbors as it should, it merely swaps the inputs
-# NB! This is only useful for performance testing.
-# NB! Do not use for actual production runs
-class HaloExchanger(object):
-    def __init__(self):
-        self.stream1 = torch.cuda.Stream()
-        self.stream2 = torch.cuda.Stream()
-
-class HaloExchangerNoComm(HaloExchanger):
-    def __init__(self, world_size, spatial_group_size, rank, comm):
-        super(HaloExchangerNoComm, self).__init__()
-
-    def left_right_halo_exchange(self, left_output_halo, right_output_halo):
-        return right_output_halo, left_output_halo
-
-class HaloExchangerAllGather(HaloExchanger):
-    def __init__(self, world_size, spatial_group_size, rank, comm):
-        super(HaloExchangerAllGather, self).__init__()
-        self.spatial_group_size = spatial_group_size
-        self.local_rank = rank % spatial_group_size
-        self.comm = comm
-
-    def left_right_halo_exchange(self, left_output_halo, right_output_halo):
-        N,Hh,W,C = list(left_output_halo.shape)
-        send_halos = torch.empty((N,2*Hh,W,C),dtype=left_output_halo.dtype,device=left_output_halo.device)
-        send_halos[:,:Hh,:,:].copy_(left_output_halo)
-        send_halos[:,Hh:,:,:].copy_(right_output_halo)
-        all_halos = torch.empty((N,2*Hh*self.spatial_group_size,W,C),dtype=left_output_halo.dtype,device=left_output_halo.device)
-        all_halos = [all_halos[:,i*2*Hh:(i+1)*2*Hh,:,:] for i in range(self.spatial_group_size)]
-        torch.distributed.all_gather(all_halos,send_halos,group=self.comm,no_copy=True)
-        left_input_halo = all_halos[(self.spatial_group_size+self.local_rank-1)%self.spatial_group_size][:,Hh:,:,:]
-        right_input_halo = all_halos[(self.local_rank+1)%self.spatial_group_size][:,:Hh,:,:]
-        return left_input_halo, right_input_halo
-
-class HaloExchangerSendRecv(HaloExchanger):
-    def __init__(self, world_size, spatial_group_size, rank, comm):
-        super(HaloExchangerSendRecv, self).__init__()
-        self.world_size = world_size
-        self.spatial_group_size = spatial_group_size
-        nccl_id = inc.get_unique_nccl_id(1).cuda()
-        torch.distributed.broadcast(nccl_id, 0)
-        nccl_id = nccl_id.cpu()
-        self.handle = inc.init_nccl_comm(nccl_id, rank, world_size)
-
-    def left_right_halo_exchange(self, left_output_halo, right_output_halo):
-        left_input_halo, right_input_halo = inc.left_right_halo_exchange(self.handle, left_output_halo, right_output_halo, self.spatial_group_size)
-        return left_input_halo, right_input_halo
-
 class SpatialBottleneck(torch.nn.Module):
     # Bottleneck in torchvision places the stride for downsampling at 3x3 convolution(self.conv2)
     # while original implementation places the stride at the first 1x1 convolution(self.conv1)
@@ -552,10 +502,4 @@ class SpatialBottleneck(torch.nn.Module):
         out = self.relu(out)
 
         return out
-
-_HALO_EXCHANGERS = Registry({
-    "HaloExchangerNoComm": HaloExchangerNoComm,
-    "HaloExchangerAllGather": HaloExchangerAllGather,
-    "HaloExchangerSendRecv": HaloExchangerSendRecv,
-})
 

--- a/apex/contrib/bottleneck/bottleneck_module_test.py
+++ b/apex/contrib/bottleneck/bottleneck_module_test.py
@@ -1,271 +1,226 @@
-import os
 import torch
-from maskrcnn_benchmark.modeling.backbone.resnet import Bottleneck
-from maskrcnn_benchmark.layers.nhwc import nhwc_to_nchw_transform, nchw_to_nhwc_transform
-from maskrcnn_benchmark.layers.nhwc.batch_norm import FrozenBatchNorm2d_NHWC
-from apex.contrib.bottleneck import Bottleneck as FastBottleneck
-from apex.contrib.bottleneck import SpatialBottleneck
+from apex.contrib.bottleneck import Bottleneck, SpatialBottleneck
+from apex.contrib.bottleneck import HaloExchangerNoComm, HaloExchangerAllGather, HaloExchangerSendRecv, HaloExchangerPeer
+from apex.contrib.peer_memory import PeerMemoryPool
 
 
-def single_module_test(ref, rank, world_size, numtype, device, shape, fast, spatial_group_size, in_channels, bottleneck_channels, out_channels, num_groups, stride_in_1x1, stride, dilation, norm_func, nhwc):
-    # inputs + modules
+def ground_truth_bottleneck(C, dtype, explicit_nhwc):
+    bottleneck = Bottleneck(C,C,C,use_cudnn=True,explicit_nhwc=explicit_nhwc)
+    bottleneck.to(dtype=dtype, device='cuda')
+    for p in bottleneck.parameters():
+        torch.distributed.broadcast(p, 0)
+    for b in bottleneck.buffers():
+        torch.distributed.broadcast(b, 0)
+    return bottleneck
+
+
+def print_bottleneck_p_and_b(bottleneck):
     with torch.no_grad():
-        input_shape = [1, in_channels] + list(shape)
-        x = torch.randn(input_shape, dtype=numtype, device=device)
-        if nhwc:
-            x = nchw_to_nhwc_transform(x).contiguous()
-        x.requires_grad = True
-        print(x.shape, x.stride())
-
-        #if spatial_group_size > 1:
-        #    fast = False # hack so fast bottleneck can be run against distributed bottleneck
-        #if spatial_group_size == 1:
-        #    fast = False
-
-        if fast:
-            if spatial_group_size == 1:
-                bottleneck = FastBottleneck(
-                    in_channels=in_channels,
-                    bottleneck_channels=bottleneck_channels,
-                    out_channels=out_channels,
-                    stride=stride,
-                    dilation=dilation,
-                    explicit_nhwc=nhwc,
-                    use_cudnn=True)
-            else:
-                bottleneck = SpatialBottleneck(
-                    in_channels=in_channels,
-                    bottleneck_channels=bottleneck_channels,
-                    out_channels=out_channels,
-                    stride=stride,
-                    dilation=dilation,
-                    explicit_nhwc=nhwc,
-                    use_cudnn=True,
-                    spatial_group_size=spatial_group_size)
-        else:
-            bottleneck = Bottleneck(
-                in_channels,
-                bottleneck_channels,
-                out_channels,
-                num_groups,
-                stride_in_1x1,
-                stride,
-                dilation,
-                norm_func,
-                nhwc,
-                spatial_group_size)
-        bottleneck = bottleneck.to(dtype=numtype,device=device)
-        weights = dict(bottleneck.named_parameters())
-
-        if ref is not None:
-            ref_x, _, ref_weights = ref
-            Hs,H = x.shape[1], ref_x.shape[1]
-            assert(Hs*spatial_group_size == H), "Hs not a multiple of H"
-            ref_x = ref_x[:,rank*Hs:(rank+1)*Hs,:,:]
-            x.copy_(ref_x)
-            assert(len(weights) == len(ref_weights)), "Reference weights and weights don't match"
-            for k in weights.keys():
-                weights[k].copy_(ref_weights[k])
-
-    # forward
-    out = bottleneck(x)
-    
-    # gradient output
-    with torch.no_grad():
-        grad_out = torch.randn_like(out)
-        if ref is not None:
-            _, ref_grad_out, _ = ref
-            Hs,H = grad_out.shape[1], ref_grad_out.shape[1]
-            assert(Hs*spatial_group_size == H), "Hs not a multiple of H"
-            ref_grad_out = ref_grad_out[:,rank*Hs:(rank+1)*Hs,:,:]
-            grad_out.copy_(ref_grad_out)
-
-    # backward
-    out.backward(grad_out)
-
-    with torch.no_grad():
-        dgrad = x.grad.detach()
-        
-        wgrad = {}
         for n,p in bottleneck.named_parameters():
-            wgrad[n] = p.grad.detach()
+            print("%s :: %s" % (n, str(p.norm(p=2,dtype=torch.float32))))
+        for n,p in bottleneck.named_buffers():
+            print("%s :: %s" % (n, str(p.norm(p=2,dtype=torch.float32))))
 
-    if world_size > 1:
-        if spatial_group_size == 1:
-            # broadcast x, grad_out and weights from rank 0
-            with torch.no_grad():
-                torch.distributed.broadcast(x,0)
-                torch.distributed.broadcast(grad_out,0)
-                for k in weights.keys():
-                    torch.distributed.broadcast(weights[k],0)
+
+def has_nan(x):
+    if isinstance(x, list) or isinstance(x, tuple):
+        for xx in x:
+            if torch.any(torch.isnan(xx)):
+                return True
+        return False
+    elif isinstance(x, dict):
+        for k,v in x.items():
+            if torch.any(torch.isnan(v)):
+                return True
+    else:
+        return torch.any(torch.isnan(x))
+
+
+def rel_diff_t(xx1, xx2):
+    return ((xx1 - xx2).norm(p=2,dtype=torch.float32) / (xx1 + xx2).norm(p=2,dtype=torch.float32)).item()
+
+
+def rel_diff(x1, x2):
+    if isinstance(x1, list) or isinstance(x1, tuple):
+        return [rel_diff_t(xx1,xx2) for xx1,xx2 in zip(x1,x2)]
+    elif isinstance(x1, dict):
+        return [rel_diff_t(xx1, xx2) for (k1,xx1), (k2,xx2) in zip(x1.items(),x2.items())]
+    else:
+        return rel_diff_t(x1,x2)
+
+
+def fprop_and_bprop(x, bottleneck, dy=None):
+    with torch.no_grad():
+        x = x.clone()
+        x.grad = None
+        x.requires_grad = True
+    y = bottleneck(x)
+    if dy is None:
+        with torch.no_grad():
+            dy = torch.randn_like(y) / 1e2
+            torch.distributed.broadcast(dy, 0)
+    y.backward(dy)
+    dgrad = x.grad.detach()
+    wgrad = {}
+    for n,p in bottleneck.named_parameters():
+        wgrad[n] = p.grad.detach()
+    return x, y, dy, dgrad, wgrad
+
+
+def ground_truth(N, C, H, W, dtype, memory_format, bottleneck):
+    if memory_format == 1:
+        # 1 -> explicit nhwc
+        explicit_nhwc = True
+        with torch.no_grad():
+            x = torch.randn([N,H,W,C], dtype=dtype, device='cuda')
+            torch.distributed.broadcast(x, 0)
+        return fprop_and_bprop(x, bottleneck)
+    else:
+        # 2 -> native nhwc
+        # 3 -> nchw
+        explicit_nhwc = False
+        assert(False), "Not implemented yet"
+
+
+def print_ground_truth(gt):
+    x, y, dy, dgrad, wgrad = gt
+    if has_nan(y) or has_nan(dgrad) or has_nan(wgrad):
+        print("Error! Ground truth has NAN")
+    else:
+        print("Ok! No NAN found in ground truth")
+
+
+def apply_to_different_bottleneck(gt, bottleneck):
+    with torch.no_grad():
+        x, y, dy, dgrad, wgrad = gt
+        x = x.clone()
+        x.requires_grad = True
+        dy = dy.clone()
+    return fprop_and_bprop(x, bottleneck, dy)
+
+
+def compare_single_field(results, f1, f2, l0, l1, l2):
+    if has_nan(f1) and has_nan(f2):
+        results[l0] = "both NAN"
+    elif has_nan(f1):
+        results[l0] = "%s.%s NAN" % (l1, l0)
+    elif has_nan(f2):
+        results[l0] = "%s.%s NAN" % (l2, l0)
+    else:
+        results[l0] = "%s" % (str(rel_diff(f1,f2)))
+
+
+def compare(gt, bt):
+    x1, y1, dy1, dgrad1, wgrad1 = gt
+    x2, y2, dy2, dgrad2, wgrad2 = bt
+    results = {}
+    compare_single_field(results, y1, y2, "y", "gt", "bt")
+    compare_single_field(results, dy1, dy2, "dy", "gt", "bt")
+    compare_single_field(results, dgrad1, dgrad2, "dgrad", "gt", "bt")
+    compare_single_field(results, wgrad1, wgrad2, "wgrad", "gt", "bt")
+    for i in range(torch.distributed.get_world_size()):
+        if i == torch.distributed.get_rank():
+            print(i,results)
+        torch.distributed.barrier()
+
+
+def spatial_parallel_bottleneck(C, dtype, explicit_nhwc, gt_bottleneck, spatial_parallel_args):
+    spatial_bottleneck = SpatialBottleneck(C,C,C,use_cudnn=True,explicit_nhwc=explicit_nhwc,spatial_parallel_args=spatial_parallel_args)
+    spatial_bottleneck.to(dtype=dtype, device='cuda')
+    with torch.no_grad():
+        sp = {}
+        for n,p in spatial_bottleneck.named_parameters():
+            sp[n] = p
+        for n,p in gt_bottleneck.named_parameters():
+            sp[n].copy_(p)
+        sb = {}
+        for n,b in spatial_bottleneck.named_buffers():
+            sb[n] = b
+        for n,b in gt_bottleneck.named_buffers():
+            sb[n].copy_(b)
+    return spatial_bottleneck
+
+
+#class HaloExchangerNoComm(HaloExchanger):
+#    def __init__(self, world_size, spatial_group_size, rank, comm):
+#class HaloExchangerAllGather(HaloExchanger):
+#    def __init__(self, world_size, spatial_group_size, rank, comm):
+#class HaloExchangerSendRecv(HaloExchanger):
+#    def __init__(self, world_size, spatial_group_size, rank, comm):
+#class HaloExchangerPeer(HaloExchanger):
+#    def __init__(self, world_size, spatial_group_size, rank, comm, peer_pool, explicit_nhwc, numSM=1):
+
+def n_way_spatial(halex, gt_bottleneck, gt, explicit_nhwc, world_size, rank, fp32_reduce=False):
+    assert(explicit_nhwc), "Only tested for explicit nhwc"
+
+    x, _, dy, _, _ = gt
+    N, H, W, C = list(x.shape) # Tensor is already shaped properly for n-way parallel
+    dtype = x.dtype
+
+    spatial_group_size = world_size
+    spatial_group_rank = rank
+    spatial_communicator = None
+    spatial_halo_exchanger = halex
+    spatial_stream = None # Not in use
+    spatial_parallel_args = (spatial_group_size, spatial_group_rank, spatial_communicator, spatial_halo_exchanger, spatial_stream)
+    spatial_bottleneck = spatial_parallel_bottleneck(C, dtype, explicit_nhwc, gt_bottleneck, spatial_parallel_args)
+
+    with torch.no_grad():
+        Hs = H // spatial_group_size
+        xs = x[:,spatial_group_rank*Hs:(spatial_group_rank+1)*Hs,:,:]
+        dys = dy[:,spatial_group_rank*Hs:(spatial_group_rank+1)*Hs,:,:]
+    _, y, _, dgrad, wgrad = fprop_and_bprop(xs, spatial_bottleneck, dys)
+    # gather output pieces
+    for n,p in wgrad.items():
+        if fp32_reduce:
+            p32 = p.float()
+            torch.distributed.all_reduce(p32)
+            p.copy_(p32.half())
         else:
-            # gather dgrad (x.grad), sum wgrad (weights) and out
-            N,Hs,W,C = dgrad.shape
-            H = Hs * spatial_group_size
-            dgrad_gathered = torch.empty((N,H,W,C),dtype=dgrad.dtype,device=dgrad.device)
-            dgrad_tensors = [dgrad_gathered[:,i*Hs:(i+1)*Hs,:,:] for i in range(spatial_group_size)]
-            torch.distributed.all_gather(dgrad_tensors, dgrad)
-            dgrad = dgrad_gathered
-            N,Hs,W,C = list(out.shape)
-            H = Hs * spatial_group_size
-            out_gathered = torch.empty((N,H,W,C),dtype=dgrad.dtype,device=dgrad.device)
-            out_tensors= [out_gathered[:,i*Hs:(i+1)*Hs,:,:] for i in range(spatial_group_size)]
-            torch.distributed.all_gather(out_tensors, out)
-            out = out_gathered
-            for k in wgrad.keys():
-                w = wgrad[k].to(dtype=torch.float64)
-                torch.distributed.all_reduce(w)
-                wgrad[k].copy_(w.to(dtype=wgrad[k].dtype))
-                #torch.distributed.all_reduce(wgrad[k])
-
-    return x, out, grad_out, weights, dgrad, wgrad
-
-
-def module_tests(rank, world_size, numtype, device, fast, spatial_group_sizes, init_args):
-    r = []
-    for ia in init_args:
-        shape = ia[0:4]
-        args = ia[4:]
-        rr = []
-        ref = None
-        for spatial_group_size in spatial_group_sizes:
-            N,H,W,C = shape
-            H = H//spatial_group_size
-            x, out, grad_out, weights, dgrad, wgrad = single_module_test(ref, rank, world_size, numtype, device, [H,W], fast, spatial_group_size, *args)
-            if ref is None:
-                assert(spatial_group_size == 1), "Wrong reference weights"
-                ref = x, grad_out, weights
-            if rank == 0:
-                rr.append( (out, dgrad, wgrad) )
-            if world_size > 1: torch.distributed.barrier()
-        r.append(rr)
-    return r
+            torch.distributed.all_reduce(p)
+    ys = [torch.empty_like(y) for _ in range(spatial_group_size)]
+    torch.distributed.all_gather(ys,y)
+    y = torch.cat(ys,dim=1)
+    dgrads = [torch.empty_like(dgrad) for _ in range(spatial_group_size)]
+    torch.distributed.all_gather(dgrads,dgrad)
+    dgrad = torch.cat(dgrads,dim=1)
+    return x, y, dy, dgrad, wgrad
 
 
 def main():
-    total_num_gpus = int(os.environ["WORLD_SIZE"]) if "WORLD_SIZE" in os.environ else 1
-    distributed = total_num_gpus > 1
-    ngpus = torch.cuda.device_count()
-
-    if distributed:
-        torch.distributed.init_process_group("nccl")
-        rank, world_size = torch.distributed.get_rank(), torch.distributed.get_world_size()
-        is_master = True if rank == 0 else False
-        local_rank = rank % ngpus
-        torch.cuda.set_device(local_rank)
-        spatial_group_size = total_num_gpus
-    else:
-        rank, local_rank, is_master, world_size, spatial_group_size = 0, 0, True, 1, 1
-
     torch.use_deterministic_algorithms(True)
-    torch.backends.cudnn.benchmark = False
-    torch.backends.cudnn.deterministic = True
-    torch.backends.cuda.matmul.allow_tf32 = False
-    torch.backends.cudnn.allow_tf32 = False
 
-    norm_func = FrozenBatchNorm2d_NHWC
+    torch.distributed.init_process_group("nccl")
+    rank = torch.distributed.get_rank()
+    world_size = torch.distributed.get_world_size()
+    torch.cuda.set_device(rank)
 
-    init_args = [
-        (1, 200, 336, 64, 64, 64, 256, 1, True, 1, 1, norm_func, True),
-        (1, 200, 336, 256, 256, 64, 256, 1, True, 1, 1, norm_func, True),
-        (1, 200, 336, 256, 256, 128, 512, 1, True, 2, 1, norm_func, True),
-        (1, 100, 168, 512, 512, 128, 512, 1, True, 1, 1, norm_func, True),
-        (1, 100, 168, 512, 512, 256, 1024, 1, True, 2, 1, norm_func, True),
-        (1, 50, 84, 1024, 1024, 256, 1024, 1, True, 1, 1, norm_func, True),
-        (1, 50, 84, 1024, 1024, 512, 2048, 1, True, 2, 1, norm_func, True),
-        (1, 25, 42, 2048, 2048, 512, 2048, 1, True, 1, 1, norm_func, True),
-        (1, 336, 200, 64, 64, 64, 256, 1, True, 1, 1, norm_func, True),
-        (1, 336, 200, 256, 256, 64, 256, 1, True, 1, 1, norm_func, True),
-        (1, 336, 200, 256, 256, 128, 512, 1, True, 2, 1, norm_func, True),
-        (1, 168, 100, 512, 512, 128, 512, 1, True, 1, 1, norm_func, True),
-        (1, 168, 100, 512, 512, 256, 1024, 1, True, 2, 1, norm_func, True),
-        (1, 84, 50, 1024, 1024, 256, 1024, 1, True, 1, 1, norm_func, True),
-        (1, 84, 50, 1024, 1024, 512, 2048, 1, True, 2, 1, norm_func, True),
-        (1, 42, 25, 2048, 2048, 512, 2048, 1, True, 1, 1, norm_func, True),
-        ]
-    init_args = init_args[0:1]
+    explicit_nhwc = True
 
-    # pad H to account for spatial distribution 
-    padded_init_args = []
-    for ia in init_args:
-        N,H,W,C = ia[0:4]
-        m = spatial_group_size * H // (25 if H < W else 42)
-        H = ((H + m - 1) // m) * m
-        args = tuple( [N,H,W,C] + list(ia[4:]) )
-        padded_init_args.append(args)
-    init_args = padded_init_args
-    if rank == 0:
-        for ia in init_args:
-            print(ia)
+    dtype = torch.float16
+    N, C, H, W = 1, 64, 200, 336
+    Hs = ((H+8*world_size-1) // (8*world_size)) * 8
+    H = Hs*world_size
+    gt_bottleneck = ground_truth_bottleneck(C, dtype, explicit_nhwc)
+    gt = ground_truth(N, C, H, W, dtype, 1, gt_bottleneck)
 
-    spatial_group_sizes = [1]
-    if spatial_group_size > 1:
-        spatial_group_sizes.append(spatial_group_size)
+    # verify that spatial bottleneck with group_size 1 produces same results as ground truth bottleneck
+    spatial_bottleneck = spatial_parallel_bottleneck(C, dtype, explicit_nhwc, gt_bottleneck, None)
+    bt = apply_to_different_bottleneck(gt, spatial_bottleneck)
+    compare(gt, bt)
+    #print_bottleneck_p_and_b(gt_bottleneck)
+    #print_bottleneck_p_and_b(spatial_bottleneck)
 
-    numtype, device, fast = torch.float16, 'cuda', True
-    r = module_tests(rank, world_size, numtype, device, fast, spatial_group_sizes, init_args)
-    if world_size > 1: torch.distributed.barrier()
-    if rank == 0:
-        for rr in r:
-            print("***")
-            for out, dgrad, wgrad in rr:
-                gr = [("out",out.norm(p=2,dtype=torch.float64).item())]
-                gr = gr + [("dgrad",dgrad.norm(p=2,dtype=torch.float64).item())]
-                gr = gr + [(k+".wgrad",wgrad[k].norm(p=2,dtype=torch.float64).item()) for k in wgrad.keys()]
-                print(gr)
-            if len(rr) == 2:
-                out1, dgrad1, wgrad1 = rr[0]
-                out2, dgrad2, wgrad2 = rr[1]
+    spatial_group_size = world_size
+    spatial_communicator = None
 
-                rtol = 1e-1
-                out_atol = out1.abs().max().item() * rtol
-                dgrad_atol = dgrad1.abs().max().item() * rtol
-                wgrad_atol = {}
-                for k in wgrad1.keys():
-                    wgrad_atol[k] = wgrad1[k].abs().max().item() * rtol
+    peer_pool = PeerMemoryPool(rank, world_size, spatial_group_size, 64*1024*1024, 2*1024*1024)
 
-                gr = [("out",torch.allclose(out1,out2,rtol,out_atol,equal_nan=True))]
-                gr = gr + [("dgrad",torch.allclose(dgrad1,dgrad2,rtol,dgrad_atol,equal_nan=True))]
-                gr = gr + [(k+".wgrad",torch.allclose(wgrad1[k],wgrad2[k],rtol,wgrad_atol[k],equal_nan=True)) for k in wgrad1.keys()]
-                print(gr)
-
-                gr = [("out",(out1-out2).norm(p=2,dtype=torch.float64).item())]
-                gr = gr + [("dgrad",(dgrad1-dgrad2).norm(p=2,dtype=torch.float64).item())]
-                gr = gr + [(k+".wgrad",(wgrad1[k]-wgrad2[k]).norm(p=2,dtype=torch.float64).item()) for k in wgrad1.keys()]
-                print(gr)
-
-                N,H,W,C = out1.shape
-                Hs = H // spatial_group_size
-                Ht = Hs-2
-                print("out1@%d:%d=%s" % (Ht,H,str(out1[0,Ht,:8,:5])))
-                print("out2@%d:%d=%s" % (Ht,H,str(out2[0,Ht,:8,:5])))
-                Ht = Hs-1
-                print("out1@%d:%d=%s" % (Ht,H,str(out1[0,Ht,:8,:5])))
-                print("out2@%d:%d=%s" % (Ht,H,str(out2[0,Ht,:8,:5])))
-                Ht = Hs
-                print("out1@%d:%d=%s" % (Ht,H,str(out1[0,Ht,:8,:5])))
-                print("out2@%d:%d=%s" % (Ht,H,str(out2[0,Ht,:8,:5])))
-                Ht = Hs+1
-                print("out1@%d:%d=%s" % (Ht,H,str(out1[0,Ht,:8,:5])))
-                print("out2@%d:%d=%s" % (Ht,H,str(out2[0,Ht,:8,:5])))
-
-                N,H,W,C = dgrad1.shape
-                Hs = H // spatial_group_size
-                Ht = Hs-2
-                print("dgrad1@%d:%d=%s" % (Ht,H,str(dgrad1[0,Ht,:8,:5])))
-                print("dgrad2@%d:%d=%s" % (Ht,H,str(dgrad2[0,Ht,:8,:5])))
-                Ht = Hs-1
-                print("dgrad1@%d:%d=%s" % (Ht,H,str(dgrad1[0,Ht,:8,:5])))
-                print("dgrad2@%d:%d=%s" % (Ht,H,str(dgrad2[0,Ht,:8,:5])))
-                Ht = Hs
-                print("dgrad1@%d:%d=%s" % (Ht,H,str(dgrad1[0,Ht,:8,:5])))
-                print("dgrad2@%d:%d=%s" % (Ht,H,str(dgrad2[0,Ht,:8,:5])))
-                Ht = Hs+1
-                print("dgrad1@%d:%d=%s" % (Ht,H,str(dgrad1[0,Ht,:8,:5])))
-                print("dgrad2@%d:%d=%s" % (Ht,H,str(dgrad2[0,Ht,:8,:5])))
-
-
-    if world_size > 1: torch.distributed.barrier()
+    #halex = HaloExchangerAllGather(world_size, spatial_group_size, rank, spatial_communicator)
+    #halex = HaloExchangerSendRecv(world_size, spatial_group_size, rank, spatial_communicator)
+    halex = HaloExchangerPeer(world_size, spatial_group_size, rank, spatial_communicator, peer_pool, explicit_nhwc, numSM=1)
+    bt2 = n_way_spatial(halex, gt_bottleneck, gt, explicit_nhwc, world_size, rank, fp32_reduce=True)
+    compare(gt, bt2)
 
 
 if __name__ == "__main__":

--- a/apex/contrib/bottleneck/bottleneck_module_test.py
+++ b/apex/contrib/bottleneck/bottleneck_module_test.py
@@ -161,7 +161,7 @@ def n_way_spatial(halex, gt_bottleneck, gt, explicit_nhwc, world_size, rank, fp3
     spatial_group_rank = rank
     spatial_communicator = None
     spatial_halo_exchanger = halex
-    spatial_method = 2 # 1 -> overlap halo and main conv, 2 -> wait for halo, conv on padded x
+    spatial_method = 3 # 1 -> overlap halo and main conv, 2 -> wait for halo, conv on padded x
     spatial_parallel_args = (spatial_group_size, spatial_group_rank, spatial_communicator, spatial_halo_exchanger, spatial_method)
     spatial_bottleneck = spatial_parallel_bottleneck(C, dtype, explicit_nhwc, gt_bottleneck, spatial_parallel_args)
 

--- a/apex/contrib/bottleneck/halo_exchangers.py
+++ b/apex/contrib/bottleneck/halo_exchangers.py
@@ -1,7 +1,7 @@
 import torch
 import torch.distributed as dist
 from torch import nn
-import nccl_p2p as inc
+import nccl_p2p_cuda as inc
 import peer_memory_cuda as pm
 
 # Communication free halo exchanger.

--- a/apex/contrib/bottleneck/halo_exchangers.py
+++ b/apex/contrib/bottleneck/halo_exchangers.py
@@ -2,7 +2,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 import nccl_p2p as inc
-import peer_memory as pm
+import peer_memory_cuda as pm
 
 # Communication free halo exchanger.
 # NB! This halo exchanger does not exchange halos with neighbors as it should, it merely swaps the inputs

--- a/apex/contrib/bottleneck/halo_exchangers.py
+++ b/apex/contrib/bottleneck/halo_exchangers.py
@@ -1,0 +1,53 @@
+import torch
+import torch.distributed as dist
+from torch import nn
+import nccl_p2p as inc
+
+# Communication free halo exchanger.
+# NB! This halo exchanger does not exchange halos with neighbors as it should, it merely swaps the inputs
+# NB! This is only useful for performance testing.
+# NB! Do not use for actual production runs
+class HaloExchanger(object):
+    def __init__(self):
+        self.stream1 = torch.cuda.Stream()
+        self.stream2 = torch.cuda.Stream()
+
+class HaloExchangerNoComm(HaloExchanger):
+    def __init__(self, world_size, spatial_group_size, rank, comm):
+        super(HaloExchangerNoComm, self).__init__()
+
+    def left_right_halo_exchange(self, left_output_halo, right_output_halo):
+        return right_output_halo, left_output_halo
+
+class HaloExchangerAllGather(HaloExchanger):
+    def __init__(self, world_size, spatial_group_size, rank, comm):
+        super(HaloExchangerAllGather, self).__init__()
+        self.spatial_group_size = spatial_group_size
+        self.local_rank = rank % spatial_group_size
+        self.comm = comm
+
+    def left_right_halo_exchange(self, left_output_halo, right_output_halo):
+        N,Hh,W,C = list(left_output_halo.shape)
+        send_halos = torch.empty((N,2*Hh,W,C),dtype=left_output_halo.dtype,device=left_output_halo.device)
+        send_halos[:,:Hh,:,:].copy_(left_output_halo)
+        send_halos[:,Hh:,:,:].copy_(right_output_halo)
+        all_halos = torch.empty((N,2*Hh*self.spatial_group_size,W,C),dtype=left_output_halo.dtype,device=left_output_halo.device)
+        all_halos = [all_halos[:,i*2*Hh:(i+1)*2*Hh,:,:] for i in range(self.spatial_group_size)]
+        torch.distributed.all_gather(all_halos,send_halos,group=self.comm,no_copy=True)
+        left_input_halo = all_halos[(self.spatial_group_size+self.local_rank-1)%self.spatial_group_size][:,Hh:,:,:]
+        right_input_halo = all_halos[(self.local_rank+1)%self.spatial_group_size][:,:Hh,:,:]
+        return left_input_halo, right_input_halo
+
+class HaloExchangerSendRecv(HaloExchanger):
+    def __init__(self, world_size, spatial_group_size, rank, comm):
+        super(HaloExchangerSendRecv, self).__init__()
+        self.world_size = world_size
+        self.spatial_group_size = spatial_group_size
+        nccl_id = inc.get_unique_nccl_id(1).cuda()
+        torch.distributed.broadcast(nccl_id, 0)
+        nccl_id = nccl_id.cpu()
+        self.handle = inc.init_nccl_comm(nccl_id, rank, world_size)
+
+    def left_right_halo_exchange(self, left_output_halo, right_output_halo):
+        left_input_halo, right_input_halo = inc.left_right_halo_exchange(self.handle, left_output_halo, right_output_halo, self.spatial_group_size)
+        return left_input_halo, right_input_halo

--- a/apex/contrib/bottleneck/halo_exchangers.py
+++ b/apex/contrib/bottleneck/halo_exchangers.py
@@ -12,6 +12,7 @@ class HaloExchanger(object):
     def __init__(self):
         self.stream1 = torch.cuda.Stream()
         self.stream2 = torch.cuda.Stream()
+        self.stream3 = torch.cuda.Stream()
 
 class HaloExchangerNoComm(HaloExchanger):
     def __init__(self, world_size, spatial_group_size, rank, comm):

--- a/apex/contrib/csrc/bottleneck/bottleneck.cpp
+++ b/apex/contrib/csrc/bottleneck/bottleneck.cpp
@@ -102,13 +102,6 @@ enum {
     AFTERCONV_TENSOR,
     OPTIONAL,
     AFTEROPT_TENSOR,
-    AFTERACT_TENSOR,
-    GEN_INDEX_TENSOR,
-    MASK_TOP_TENSOR,
-    MASK_BOTTOM_TENSOR,
-    MASK_TENSOR,
-    THRESHOLD_TOP_TENSOR,
-    THRESHOLD_BOTTOM_TENSOR,
 };
 
 using common_conv_descriptors =
@@ -180,11 +173,11 @@ using common_convbias_descriptors = std::tuple<cudnn_frontend::Tensor,
 common_convbias_descriptors
 create_conv_bias_add_act_descriptors(int64_t* x_dim_padded,
                                      int64_t* padA,
-				     int64_t* convstrideA,
-				     int64_t* dilationA,
-				     int64_t* w_dim_padded,
-				     int64_t* y_dim_padded,
-				     cudnnDataType_t dataType) {
+                                     int64_t* convstrideA,
+                                     int64_t* dilationA,
+                                     int64_t* w_dim_padded,
+                                     int64_t* y_dim_padded,
+                                     cudnnDataType_t dataType) {
     const int convDim = 2;
 
     int64_t b_dim_padded[4];
@@ -279,183 +272,6 @@ create_conv_bias_add_act_descriptors(int64_t* x_dim_padded,
                                            .build());
 }
 
-using masked_convbias_descriptors = std::tuple<cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor,
-                                               cudnn_frontend::Tensor>;
-
-masked_convbias_descriptors
-create_conv_bias_add_act_mask_descriptors(int64_t* x_dim_padded,
-                                          int64_t* padA,
-					  int64_t* convstrideA,
-					  int64_t* dilationA,
-					  int64_t* w_dim_padded,
-					  int64_t* y_dim_padded,
-					  int64_t* threshold_dim,
-					  cudnnDataType_t dataType) {
-    const int convDim = 2;
-
-    int64_t b_dim_padded[4];
-    b_dim_padded[0] = 1;
-    b_dim_padded[1] = y_dim_padded[1];
-    b_dim_padded[2] = 1;
-    b_dim_padded[3] = 1;
-
-    int64_t x_stride_padded[4];
-    int64_t y_stride_padded[4];
-    int64_t w_stride_padded[4];
-    int64_t b_stride_padded[4];
-    int64_t threshold_stride[4];
-
-    generateStrides(w_dim_padded, w_stride_padded, 4, CUDNN_TENSOR_NHWC);
-    generateStrides(x_dim_padded, x_stride_padded, 4, CUDNN_TENSOR_NHWC);
-    generateStrides(y_dim_padded, y_stride_padded, 4, CUDNN_TENSOR_NHWC);
-    generateStrides(b_dim_padded, b_stride_padded, 4, CUDNN_TENSOR_NHWC);
-    generateStrides(threshold_dim, threshold_stride, 4, CUDNN_TENSOR_NHWC);
-
-    return masked_convbias_descriptors(cudnn_frontend::TensorBuilder()
-                                           .setDim(4, x_dim_padded)
-                                           .setStrides(4, x_stride_padded)
-                                           .setId('x')
-                                           .setAlignment(16)
-                                           .setDataType(dataType)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, y_dim_padded)
-                                           .setStrides(4, y_stride_padded)
-                                           .setId('y')
-                                           .setAlignment(16)
-                                           .setDataType(dataType)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, w_dim_padded)
-                                           .setStrides(4, w_stride_padded)
-                                           .setId('w')
-                                           .setAlignment(16)
-                                           .setDataType(dataType)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, b_dim_padded)
-                                           .setStrides(4, b_stride_padded)
-                                           .setId('z')
-                                           .setAlignment(16)
-                                           .setDataType(dataType)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, b_dim_padded)
-                                           .setStrides(4, b_stride_padded)
-                                           .setId('b')
-                                           .setAlignment(16)
-                                           .setDataType(dataType)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, y_dim_padded)
-                                           .setStrides(4, y_stride_padded)
-                                           .setVirtual()
-                                           .setId('A')  // after add
-                                           .setAlignment(16)
-                                           .setDataType(CUDNN_DATA_FLOAT)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, y_dim_padded)
-                                           .setStrides(4, y_stride_padded)
-                                           .setVirtual()
-                                           .setId('B')  // after bias
-                                           .setAlignment(16)
-                                           .setDataType(CUDNN_DATA_FLOAT)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, y_dim_padded)
-                                           .setStrides(4, y_stride_padded)
-                                           .setId('C')  // after conv
-                                           .setAlignment(16)
-                                           .setVirtual()
-                                           .setDataType(CUDNN_DATA_FLOAT)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, y_dim_padded)
-                                           .setStrides(4, y_stride_padded)
-                                           .setId('i')
-                                           .setAlignment(16)
-                                           .setDataType(dataType)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, y_dim_padded)
-                                           .setStrides(4, y_stride_padded)
-                                           .setId('D')  // after optional add
-                                           .setAlignment(16)
-                                           .setVirtual()
-                                           .setDataType(CUDNN_DATA_FLOAT)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, y_dim_padded)
-                                           .setStrides(4, y_stride_padded)
-                                           .setId('E')  // after act for masked
-                                           .setAlignment(16)
-                                           .setVirtual()
-                                           .setDataType(CUDNN_DATA_FLOAT)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, y_dim_padded)
-                                           .setStrides(4, y_stride_padded)
-                                           .setId('I')  // output of the gen index operation
-                                           .setAlignment(16)
-                                           .setVirtual()
-                                           .setDataType(CUDNN_DATA_INT32)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, y_dim_padded)
-                                           .setStrides(4, y_stride_padded)
-                                           .setId('m')  // top half of the mask created after the less than
-                                           .setAlignment(16)
-                                           .setVirtual()
-                                           .setDataType(CUDNN_DATA_BOOLEAN)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, y_dim_padded)
-                                           .setStrides(4, y_stride_padded)
-                                           .setId('n')  // bottom half of the mask
-                                           .setAlignment(16)
-                                           .setVirtual()
-                                           .setDataType(CUDNN_DATA_BOOLEAN)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, y_dim_padded)
-                                           .setStrides(4, y_stride_padded)
-                                           .setId('M')  // OR of the top and bottom masks
-                                           .setAlignment(16)
-                                           .setVirtual()
-                                           .setDataType(CUDNN_DATA_BOOLEAN)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, threshold_dim)
-                                           .setStrides(4, threshold_stride)
-                                           .setId('t')  // threshold for creating the top mask
-                                           .setAlignment(16)
-                                           .setDataType(CUDNN_DATA_INT32)
-                                           .build(),
-                                       cudnn_frontend::TensorBuilder()
-                                           .setDim(4, threshold_dim)
-                                           .setStrides(4, threshold_stride)
-                                           .setId('u')  // threshold for creating the bottom mask
-                                           .setAlignment(16)
-                                           .setDataType(CUDNN_DATA_INT32)
-                                           .build());
-}
-
 // tensor descriptors used for dgrad
 enum {
     X_OR_DX_TENSOR,
@@ -465,19 +281,9 @@ enum {
     RELU_TENSOR,
     AFTER_DCONV_TENSOR,
     AFTER_DRELU_TENSOR,
-    DGRAD_INPUT_TENSOR,
-    DGRAD_OPTIONAL_TENSOR,
-    DGRAD_GEN_INDEX_TENSOR,
-    DGRAD_MASK_TOP_TENSOR,
-    DGRAD_MASK_BOTTOM_TENSOR,
-    DGRAD_MASK_TENSOR,
-    DGRAD_THRESHOLD_TOP_TENSOR,
-    DGRAD_THRESHOLD_BOTTOM_TENSOR,
 };
 
 using dconv_descriptors = std::tuple<cudnn_frontend::Tensor,
-                                     cudnn_frontend::Tensor,
-                                     cudnn_frontend::Tensor,
                                      cudnn_frontend::Tensor,
                                      cudnn_frontend::Tensor,
                                      cudnn_frontend::Tensor,
@@ -561,181 +367,7 @@ create_dconv_descriptors(int64_t* x_dim_padded,
                              .setId('B')  // after drelu
                              .setAlignment(16)
                              .setDataType(CUDNN_DATA_FLOAT)
-                             .build(),
-                             cudnn_frontend::TensorBuilder()
-                             .setDim(4, y_dim_padded)
-			     .setStrides(4, y_stride_padded)
-			     .setId('i')
-			     .setAlignment(16)
-			     .setDataType(dataType)
-			     .build(),
-                             cudnn_frontend::TensorBuilder()
-                             .setDim(4, y_dim_padded)
-			     .setStrides(4, y_stride_padded)
-			     .setId('D')  // after optional add
-			     .setAlignment(16)
-			     .setVirtual()
-			     .setDataType(CUDNN_DATA_FLOAT)
-			     .build());
-}
-
-using dconv_mask_descriptors = std::tuple<cudnn_frontend::Tensor,
-                                          cudnn_frontend::Tensor,
-					  cudnn_frontend::Tensor,
-					  cudnn_frontend::Tensor,
-					  cudnn_frontend::Tensor,
-					  cudnn_frontend::Tensor,
-					  cudnn_frontend::Tensor,
-					  cudnn_frontend::Tensor,
-					  cudnn_frontend::Tensor,
-					  cudnn_frontend::Tensor,
-					  cudnn_frontend::Tensor,
-					  cudnn_frontend::Tensor,
-					  cudnn_frontend::Tensor,
-					  cudnn_frontend::Tensor,
-					  cudnn_frontend::Tensor>;
-
-dconv_mask_descriptors
-create_dconv_mask_descriptors(int64_t* x_dim_padded,
-                              int64_t* padA,
-			      int64_t* convstrideA,
-			      int64_t* dilationA,
-			      int64_t* w_dim_padded,
-			      int64_t* y_dim_padded,
-			      int64_t* threshold_dim,
-			      cudnnDataType_t dataType) {
-    const int convDim = 2;
-
-    int64_t b_dim_padded[4];
-    b_dim_padded[0] = 1;
-    b_dim_padded[1] = x_dim_padded[1];
-    b_dim_padded[2] = 1;
-    b_dim_padded[3] = 1;
-
-    int64_t x_stride_padded[4];
-    int64_t y_stride_padded[4];
-    int64_t w_stride_padded[4];
-    int64_t b_stride_padded[4];
-    int64_t threshold_stride[4];
-
-    generateStrides(w_dim_padded, w_stride_padded, 4, CUDNN_TENSOR_NHWC);
-    generateStrides(x_dim_padded, x_stride_padded, 4, CUDNN_TENSOR_NHWC);
-    generateStrides(y_dim_padded, y_stride_padded, 4, CUDNN_TENSOR_NHWC);
-    generateStrides(b_dim_padded, b_stride_padded, 4, CUDNN_TENSOR_NHWC);
-    generateStrides(threshold_dim, threshold_stride, 4, CUDNN_TENSOR_NHWC);
-
-    return dconv_mask_descriptors(cudnn_frontend::TensorBuilder()
-                             .setDim(4, x_dim_padded)
-                             .setStrides(4, x_stride_padded)
-                             .setId('x')
-                             .setAlignment(16)
-                             .setDataType(dataType)
-                             .build(),
-                             cudnn_frontend::TensorBuilder()
-                             .setDim(4, y_dim_padded)
-                             .setStrides(4, y_stride_padded)
-                             .setId('y')
-                             .setAlignment(16)
-                             .setDataType(dataType)
-                             .build(),
-                             cudnn_frontend::TensorBuilder()
-                             .setDim(4, w_dim_padded)
-                             .setStrides(4, w_stride_padded)
-                             .setId('w')
-                             .setAlignment(16)
-                             .setDataType(dataType)
-                             .build(),
-                             cudnn_frontend::TensorBuilder()
-                             .setDim(4, b_dim_padded)
-                             .setStrides(4, b_stride_padded)
-                             .setId('s')
-                             .setAlignment(16)
-                             .setDataType(dataType)
-                             .build(),
-                             cudnn_frontend::TensorBuilder()
-                             .setDim(4, x_dim_padded)
-                             .setStrides(4, x_stride_padded)
-                             .setId('r')
-                             .setAlignment(16)
-                             .setDataType(dataType)
-                             .build(),
-                             cudnn_frontend::TensorBuilder()
-                             .setDim(4, x_dim_padded)
-                             .setStrides(4, x_stride_padded)
-                             .setVirtual()
-                             .setId('A')  // after dconv
-                             .setAlignment(16)
-                             .setDataType(CUDNN_DATA_FLOAT)
-                             .build(),
-                             cudnn_frontend::TensorBuilder()
-                             .setDim(4, x_dim_padded)
-                             .setStrides(4, x_stride_padded)
-                             .setVirtual()
-                             .setId('B')  // after drelu
-                             .setAlignment(16)
-                             .setDataType(CUDNN_DATA_FLOAT)
-                             .build(),
-                             cudnn_frontend::TensorBuilder()
-                             .setDim(4, y_dim_padded)
-			     .setStrides(4, y_stride_padded)
-			     .setId('i')
-			     .setAlignment(16)
-			     .setDataType(dataType)
-			     .build(),
-                             cudnn_frontend::TensorBuilder()
-                             .setDim(4, y_dim_padded)
-			     .setStrides(4, y_stride_padded)
-			     .setId('D')  // after optional add
-			     .setAlignment(16)
-			     .setVirtual()
-			     .setDataType(CUDNN_DATA_FLOAT)
-			     .build(),
-			     cudnn_frontend::TensorBuilder()
-			     .setDim(4, y_dim_padded)
-			     .setStrides(4, y_stride_padded)
-			     .setId('I')  // output of the gen index operation
-			     .setAlignment(16)
-			     .setVirtual()
-			     .setDataType(CUDNN_DATA_INT32)
-			     .build(),
-			     cudnn_frontend::TensorBuilder()
-			     .setDim(4, y_dim_padded)
-			     .setStrides(4, y_stride_padded)
-			     .setId('m')  // top half of the mask created after the less than
-			     .setAlignment(16)
-			     .setVirtual()
-			     .setDataType(CUDNN_DATA_BOOLEAN)
-			     .build(),
-			     cudnn_frontend::TensorBuilder()
-			     .setDim(4, y_dim_padded)
-			     .setStrides(4, y_stride_padded)
-			     .setId('n')  // bottom half of the mask
-			     .setAlignment(16)
-			     .setVirtual()
-			     .setDataType(CUDNN_DATA_BOOLEAN)
-			     .build(),
-			     cudnn_frontend::TensorBuilder()
-			     .setDim(4, y_dim_padded)
-			     .setStrides(4, y_stride_padded)
-			     .setId('M')  // OR of the top and bottom masks
-			     .setAlignment(16)
-			     .setVirtual()
-			     .setDataType(CUDNN_DATA_BOOLEAN)
-			     .build(),
-			     cudnn_frontend::TensorBuilder()
-			     .setDim(4, threshold_dim)
-			     .setStrides(4, threshold_stride)
-			     .setId('t')  // threshold for creating the top mask
-			     .setAlignment(16)
-			     .setDataType(CUDNN_DATA_INT32)
-			     .build(),
-			     cudnn_frontend::TensorBuilder()
-			     .setDim(4, threshold_dim)
-			     .setStrides(4, threshold_stride)
-			     .setId('u')  // threshold for creating the bottom mask
-			     .setAlignment(16)
-			     .setDataType(CUDNN_DATA_INT32)
-			     .build());
+                             .build());
 }
 
 // create a cache for plan
@@ -961,7 +593,7 @@ run_conv_scale_bias_add_activation(int64_t* x_dim_padded,
 
         auto opGraph = cudnn_frontend::OperationGraphBuilder()
           .setHandle(handle_)
-          .setOperationGraph(devPtrI ? ops.size() : ops.size() - 1, ops.data())
+          .setOperationGraph(devPtrI ? ops.size() : 4, ops.data())
           .build();
 
         // Create string encoding for plan caching
@@ -990,458 +622,6 @@ run_conv_scale_bias_add_activation(int64_t* x_dim_padded,
         cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
         checkCudnnErr(status);
         cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
-    } catch (cudnn_frontend::cudnnException e) {
-      std::cout << log_buf.str() << "[ERROR] Exception " << e.what() << std::endl;
-    }
-}
-
-void
-run_conv_add_scale_bias_activation(int64_t* x_dim_padded,
-                                   int64_t* pad,
-				   int64_t* convstride,
-				   int64_t* dilation,
-				   int64_t* w_dim_padded,
-				   int64_t* y_dim_padded,
-				   cudnnDataType_t dataType,
-				   at::Half* devPtrX,
-				   at::Half* devPtrW,
-				   at::Half* devPtrY,
-				   at::Half* devPtrZ,
-				   at::Half* devPtrB,
-				   at::Half* devPtrI) {
-    cudnnHandle_t handle_ = torch::native::getCudnnHandle();
-    std::stringstream log_buf;
-    try {
-        int convDim = 2;
-
-        // Creates the necessary tensor descriptors
-        common_convbias_descriptors tensors = create_conv_bias_add_act_descriptors(
-            x_dim_padded, pad, convstride, dilation, w_dim_padded, y_dim_padded, dataType);
-        DEBUG_CUDNN_MSG(log_buf, std::get<X_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<Y_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<W_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<Z_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<B_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<AFTERADD_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<AFTERBIAS_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<AFTERCONV_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<OPTIONAL>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<AFTEROPT_TENSOR>(tensors).describe());
-
-        // Define the add operation
-        auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
-                           .setMode(CUDNN_POINTWISE_MUL)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, scaleDesc.describe());
-
-        // Define the bias operation
-        auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
-                            .setMode(CUDNN_POINTWISE_ADD)
-                            .setMathPrecision(CUDNN_DATA_FLOAT)
-                            .build();
-        DEBUG_CUDNN_MSG(log_buf, biasDesc.describe());
-
-        // optional add
-        auto addDesc = cudnn_frontend::PointWiseDescBuilder()
-                            .setMode(CUDNN_POINTWISE_ADD)
-                            .setMathPrecision(CUDNN_DATA_FLOAT)
-                            .build();
-        DEBUG_CUDNN_MSG(log_buf, addDesc.describe());
-
-        // Define the activation operation
-        auto actDesc = cudnn_frontend::PointWiseDescBuilder()
-                           .setMode(CUDNN_POINTWISE_RELU_FWD)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, actDesc.describe());
-
-        // Define the convolution problem
-        auto convDesc = cudnn_frontend::ConvDescBuilder()
-                            .setDataType(CUDNN_DATA_FLOAT)
-                            .setMathMode(CUDNN_CROSS_CORRELATION)
-                            .setNDims(convDim)
-                            .setStrides(convDim, convstride)
-                            .setPrePadding(convDim, pad)
-                            .setPostPadding(convDim, pad)
-                            .setDilation(convDim, dilation)
-                            .build();
-        DEBUG_CUDNN_MSG(log_buf, convDesc.describe());
-
-        float alpha  = 1.0f;
-        float beta   = 0.0f;
-
-        // Create a convolution Node
-        auto conv_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
-                           .setxDesc(std::get<X_TENSOR>(tensors))
-                           .setwDesc(std::get<W_TENSOR>(tensors))
-                           .setyDesc(std::get<AFTERCONV_TENSOR>(tensors))
-                           .setcDesc(convDesc)
-                           .setAlpha(alpha)
-                           .setBeta(beta)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, conv_op.describe());
-
-        // create an add node.
-        auto add_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                           .setxDesc(conv_op.getOutputTensor())
-                           .setbDesc(std::get<OPTIONAL>(tensors))
-                           .setyDesc(std::get<AFTEROPT_TENSOR>(tensors))
-                           .setpwDesc(addDesc)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, add_op.describe());
-
-        // Create a Add Node with scaling parameters.
-        auto scale_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                           .setxDesc(add_op.getOutputTensor())
-                           .setbDesc(std::get<Z_TENSOR>(tensors))
-                           .setyDesc(std::get<AFTERADD_TENSOR>(tensors))
-                           .setpwDesc(scaleDesc)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, scale_op.describe());
-
-        // Create a Bias Node.
-        auto bias_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                           .setxDesc(scale_op.getOutputTensor())
-                           .setbDesc(std::get<B_TENSOR>(tensors))
-                           .setyDesc(std::get<AFTERBIAS_TENSOR>(tensors))
-                           .setpwDesc(biasDesc)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, bias_op.describe());
-
-        // Create an Activation Node.
-        auto act_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                           .setxDesc(bias_op.getOutputTensor())
-                           .setyDesc(std::get<Y_TENSOR>(tensors))
-                           .setpwDesc(actDesc)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, act_op.describe());
-
-        // Create an Operation Graph. In this case it is convolution add bias activation
-        std::array<cudnn_frontend::Operation const*, 5> ops = {&conv_op, &add_op, &scale_op, &bias_op, &act_op};
-
-        auto opGraph = cudnn_frontend::OperationGraphBuilder()
-          .setHandle(handle_)
-          .setOperationGraph(ops.size(), ops.data())
-          .build();
-
-        // Create string encoding for plan caching
-        auto cache_string = getConvFusionString(x_dim_padded, pad, convstride, dilation, w_dim_padded, dataType, opGraph.getTag());
-        DEBUG_CUDNN_MSG(log_buf, "[convstring] " << cache_string);
-
-        auto& plan = getOrCreatePlan(handle_, log_buf, opGraph, cache_string);
-        DEBUG_CUDNN_MSG(log_buf, "Plan tag: " << plan.getTag());
-
-        auto workspace_size = plan.getWorkspaceSize();
-        DEBUG_CUDNN_MSG(log_buf, plan.describe() << " requires workspace " << workspace_size);
-
-        void* workspace_ptr = nullptr;
-        auto workspace_tensor = at::empty({(workspace_size+3)/4}, at::TensorOptions(at::kCUDA).dtype(at::kFloat));
-        if (workspace_size > 0) {
-          workspace_ptr = workspace_tensor.data_ptr<float>();
-        }
-        void* data_ptrs[] = {devPtrX, devPtrY, devPtrW, devPtrZ, devPtrB, devPtrI};
-        int64_t uids[]    = {'x', 'y', 'w', 'z', 'b', 'i'};
-        auto variantPack  = cudnn_frontend::VariantPackBuilder()
-                               .setWorkspacePointer(workspace_ptr)
-                               .setDataPointers(6, data_ptrs)
-                               .setUids(6, uids)
-                               .build();
-        DEBUG_CUDNN_MSG(log_buf, "variantPack " << variantPack.describe());
-        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
-        checkCudnnErr(status);
-        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
-    } catch (cudnn_frontend::cudnnException e) {
-      std::cout << log_buf.str() << "[ERROR] Exception " << e.what() << std::endl;
-    }
-}
-
-void
-run_conv_scale_bias_add_activation_mask(int64_t* x_dim_padded,
-                                        int64_t* pad,
-                                        int64_t* convstride,
-					int64_t* dilation,
-					int64_t* w_dim_padded,
-					int64_t* y_dim_padded,
-					int64_t* threshold_dim,
-					cudnnDataType_t dataType,
-					at::Half* devPtrX,
-					at::Half* devPtrW,
-					at::Half* devPtrY,
-					at::Half* devPtrZ,
-					at::Half* devPtrB,
-					at::Half* devPtrI,
-					int* devPtrT,
-					int* devPtrU,
-					int axis) {
-    cudnnHandle_t handle_ = torch::native::getCudnnHandle();
-    std::stringstream log_buf;
-    try {
-        int convDim = 2;
-
-        // Creates the necessary tensor descriptors
-        masked_convbias_descriptors tensors = create_conv_bias_add_act_mask_descriptors(
-            x_dim_padded, pad, convstride, dilation, w_dim_padded, y_dim_padded, threshold_dim, dataType);
-        DEBUG_CUDNN_MSG(log_buf, std::get<X_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<Y_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<W_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<Z_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<B_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<AFTERADD_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<AFTERBIAS_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<AFTERCONV_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<OPTIONAL>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<AFTERACT_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<GEN_INDEX_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<MASK_TOP_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<MASK_BOTTOM_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<MASK_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<THRESHOLD_TOP_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<THRESHOLD_BOTTOM_TENSOR>(tensors).describe());
-
-        // Define the add operation
-        auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
-                           .setMode(CUDNN_POINTWISE_MUL)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, scaleDesc.describe());
-
-        // Define the bias operation
-        auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
-                            .setMode(CUDNN_POINTWISE_ADD)
-                            .setMathPrecision(CUDNN_DATA_FLOAT)
-                            .build();
-        DEBUG_CUDNN_MSG(log_buf, biasDesc.describe());
-
-        // optional add
-        auto addDesc = cudnn_frontend::PointWiseDescBuilder()
-                            .setMode(CUDNN_POINTWISE_ADD)
-                            .setMathPrecision(CUDNN_DATA_FLOAT)
-                            .build();
-        DEBUG_CUDNN_MSG(log_buf, addDesc.describe());
-
-        // Define the activation operation
-        auto actDesc = cudnn_frontend::PointWiseDescBuilder()
-                           .setMode(CUDNN_POINTWISE_RELU_FWD)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, actDesc.describe());
-
-        // Define the convolution problem
-        auto convDesc = cudnn_frontend::ConvDescBuilder()
-                            .setDataType(CUDNN_DATA_FLOAT)
-                            .setMathMode(CUDNN_CROSS_CORRELATION)
-                            .setNDims(convDim)
-                            .setStrides(convDim, convstride)
-                            .setPrePadding(convDim, pad)
-                            .setPostPadding(convDim, pad)
-                            .setDilation(convDim, dilation)
-                            .build();
-        DEBUG_CUDNN_MSG(log_buf, convDesc.describe());
-
-        // Define the genIndex descriptor
-        auto genIndexDesc = cudnn_frontend::PointWiseDescBuilder()
-                           .setMode(CUDNN_POINTWISE_GEN_INDEX)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
-                           .setAxis(axis)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, genIndexDesc.describe());
-
-        // Define the lessThan descriptor
-        auto lessThanDesc = cudnn_frontend::PointWiseDescBuilder()
-                           .setMode(CUDNN_POINTWISE_CMP_LT)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, lessThanDesc.describe());
-
-        // Define the greaterThan descriptor
-        auto greaterThanDesc = cudnn_frontend::PointWiseDescBuilder()
-                           .setMode(CUDNN_POINTWISE_CMP_GT)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, greaterThanDesc.describe());
-
-        // Define the logical_or descriptor
-        auto logicalOrDesc = cudnn_frontend::PointWiseDescBuilder()
-                           .setMode(CUDNN_POINTWISE_LOGICAL_OR)
-                           .setMathPrecision(CUDNN_DATA_BOOLEAN)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, logicalOrDesc.describe());
-
-        // Define the binary_selection descriptor
-        auto selectionDesc = cudnn_frontend::PointWiseDescBuilder()
-                           .setMode(CUDNN_POINTWISE_BINARY_SELECT)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, selectionDesc.describe());
-
-        float alpha  = 1.0f;
-        float beta   = 0.0f;
-
-        // Create a convolution Node
-        auto conv_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
-                           .setxDesc(std::get<X_TENSOR>(tensors))
-                           .setwDesc(std::get<W_TENSOR>(tensors))
-                           .setyDesc(std::get<AFTERCONV_TENSOR>(tensors))
-                           .setcDesc(convDesc)
-                           .setAlpha(alpha)
-                           .setBeta(beta)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, conv_op.describe());
-
-        // Create a Add Node with scaling parameters.
-        auto scale_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                           .setxDesc(conv_op.getOutputTensor())
-                           .setbDesc(std::get<Z_TENSOR>(tensors))
-                           .setyDesc(std::get<AFTERADD_TENSOR>(tensors))
-                           .setpwDesc(scaleDesc)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, scale_op.describe());
-
-        // Create a Bias Node.
-        auto bias_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                           .setxDesc(scale_op.getOutputTensor())
-                           .setbDesc(std::get<B_TENSOR>(tensors))
-                           .setyDesc(std::get<AFTERBIAS_TENSOR>(tensors))
-                           .setpwDesc(biasDesc)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, bias_op.describe());
-
-        // Create a optional add Node.
-        auto add_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                           .setxDesc(bias_op.getOutputTensor())
-                           .setbDesc(std::get<OPTIONAL>(tensors))
-                           .setyDesc(std::get<AFTEROPT_TENSOR>(tensors))
-                           .setpwDesc(addDesc)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, add_op.describe());
-
-
-        // Create an Activation Node.
-        auto act_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-          .setxDesc(devPtrI ? add_op.getOutputTensor() : bias_op.getOutputTensor())
-                          .setyDesc(std::get<AFTERACT_TENSOR>(tensors))
-                          .setpwDesc(actDesc)
-                          .build();
-        DEBUG_CUDNN_MSG(log_buf, act_op.describe());
-
-        // Create a Gen_Index Node.
-        auto genIndex_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                          .setxDesc(std::get<AFTERACT_TENSOR>(tensors))
-                          .setyDesc(std::get<GEN_INDEX_TENSOR>(tensors))
-                          .setpwDesc(genIndexDesc)
-                          .build();
-        DEBUG_CUDNN_MSG(log_buf, genIndex_op.describe());
-
-        // Create a LessThan Node.
-        auto lessThan_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                          .setxDesc(std::get<GEN_INDEX_TENSOR>(tensors))
-                          .setbDesc(std::get<THRESHOLD_TOP_TENSOR>(tensors))
-                          .setyDesc(std::get<MASK_TOP_TENSOR>(tensors))
-                          .setpwDesc(lessThanDesc)
-                          .build();
-        DEBUG_CUDNN_MSG(log_buf, lessThan_op.describe());
-
-        // Create a GreaterThan Node.
-        auto greaterThan_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                          .setxDesc(std::get<GEN_INDEX_TENSOR>(tensors))
-                          .setbDesc(std::get<THRESHOLD_BOTTOM_TENSOR>(tensors))
-                          .setyDesc(std::get<MASK_BOTTOM_TENSOR>(tensors))
-                          .setpwDesc(greaterThanDesc)
-                          .build();
-        DEBUG_CUDNN_MSG(log_buf, greaterThan_op.describe());
-
-        // Create a LogicalOr Node.
-        auto logicalOr_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                          .setxDesc(std::get<MASK_TOP_TENSOR>(tensors))
-                          .setbDesc(std::get<MASK_BOTTOM_TENSOR>(tensors))
-                          .setyDesc(std::get<MASK_TENSOR>(tensors))
-                          .setpwDesc(logicalOrDesc)
-                          .build();
-        DEBUG_CUDNN_MSG(log_buf, logicalOr_op.describe());
-
-        // Create a Binary_Selection Node.
-        auto selection_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                          .setxDesc(std::get<AFTERCONV_TENSOR>(tensors))
-                          .setbDesc(std::get<AFTERACT_TENSOR>(tensors))
-                          .settDesc(std::get<MASK_TENSOR>(tensors))
-                          .setyDesc(std::get<Y_TENSOR>(tensors))
-                          .setpwDesc(selectionDesc)
-                          .build();
-        DEBUG_CUDNN_MSG(log_buf, selection_op.describe());
-
-        // Create an Operation Graph. In this case it is convolution add bias activation
-	if (devPtrI) {
-
-	  std::array<cudnn_frontend::Operation const*, 10> ops = {&conv_op, &scale_op, &bias_op, &add_op, &act_op, &genIndex_op, &lessThan_op, &greaterThan_op, &logicalOr_op, &selection_op};
-
-	  auto opGraph = cudnn_frontend::OperationGraphBuilder()
-            .setHandle(handle_)
-            .setOperationGraph(ops.size(), ops.data())
-            .build();
-
-	  // Create string encoding for plan caching
-	  auto cache_string = getConvFusionString(x_dim_padded, pad, convstride, dilation, w_dim_padded, dataType, opGraph.getTag());
-	  DEBUG_CUDNN_MSG(log_buf, "[convstring] " << cache_string);
-
-	  auto& plan = getOrCreatePlan(handle_, log_buf, opGraph, cache_string);
-	  DEBUG_CUDNN_MSG(log_buf, "Plan tag: " << plan.getTag());
-
-	  auto workspace_size = plan.getWorkspaceSize();
-	  DEBUG_CUDNN_MSG(log_buf, plan.describe() << " requires workspace " << workspace_size);
-
-	  void* workspace_ptr = nullptr;
-	  auto workspace_tensor = at::empty({(workspace_size+3)/4}, at::TensorOptions(at::kCUDA).dtype(at::kFloat));
-	  if (workspace_size > 0) {
-	    workspace_ptr = workspace_tensor.data_ptr<float>();
-	  }
-	  void* data_ptrs[] = {devPtrX, devPtrY, devPtrW, devPtrZ, devPtrB, devPtrI, devPtrT, devPtrU};
-	  int64_t uids[]    = {'x', 'y', 'w', 'z', 'b', 'i', 't', 'u'};
-	  auto variantPack  = cudnn_frontend::VariantPackBuilder()
-	    .setWorkspacePointer(workspace_ptr)
-	    .setDataPointers(8, data_ptrs)
-	    .setUids(8, uids)
-	    .build();
-	  DEBUG_CUDNN_MSG(log_buf, "variantPack " << variantPack.describe());
-	  cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
-	  checkCudnnErr(status);
-	  cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
-	} else {
-
-	  std::array<cudnn_frontend::Operation const*, 9> ops = {&conv_op, &scale_op, &bias_op, &act_op, &genIndex_op, &lessThan_op, &greaterThan_op, &logicalOr_op, &selection_op};
-
-	  auto opGraph = cudnn_frontend::OperationGraphBuilder()
-            .setHandle(handle_)
-            .setOperationGraph(ops.size(), ops.data())
-            .build();
-
-	  // Create string encoding for plan caching
-	  auto cache_string = getConvFusionString(x_dim_padded, pad, convstride, dilation, w_dim_padded, dataType, opGraph.getTag());
-	  DEBUG_CUDNN_MSG(log_buf, "[convstring] " << cache_string);
-
-	  auto& plan = getOrCreatePlan(handle_, log_buf, opGraph, cache_string);
-	  DEBUG_CUDNN_MSG(log_buf, "Plan tag: " << plan.getTag());
-
-	  auto workspace_size = plan.getWorkspaceSize();
-	  DEBUG_CUDNN_MSG(log_buf, plan.describe() << " requires workspace " << workspace_size);
-
-	  void* workspace_ptr = nullptr;
-	  auto workspace_tensor = at::empty({(workspace_size+3)/4}, at::TensorOptions(at::kCUDA).dtype(at::kFloat));
-	  if (workspace_size > 0) {
-	    workspace_ptr = workspace_tensor.data_ptr<float>();
-	  }
-	  void* data_ptrs[] = {devPtrX, devPtrY, devPtrW, devPtrZ, devPtrB, devPtrT, devPtrU};
-	  int64_t uids[]    = {'x', 'y', 'w', 'z', 'b', 't', 'u'};
-	  auto variantPack  = cudnn_frontend::VariantPackBuilder()
-	    .setWorkspacePointer(workspace_ptr)
-	    .setDataPointers(7, data_ptrs)
-	    .setUids(7, uids)
-	    .build();
-	  DEBUG_CUDNN_MSG(log_buf, "variantPack " << variantPack.describe());
-	  cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
-	  checkCudnnErr(status);
-	  cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
-	}
     } catch (cudnn_frontend::cudnnException e) {
       std::cout << log_buf.str() << "[ERROR] Exception " << e.what() << std::endl;
     }
@@ -1693,371 +873,6 @@ run_dconv_drelu_dscale(int64_t* x_dim_padded,
           .setWorkspacePointer(workspace_ptr)
           .setDataPointers(5, data_ptrs)
           .setUids(5, uids)
-          .build();
-        DEBUG_CUDNN_MSG(log_buf, "variantPack " << variantPack.describe());
-        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
-        checkCudnnErr(status);
-        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
-    } catch (cudnn_frontend::cudnnException e) {
-      std::cout << log_buf.str() << "[ERROR] Exception " << e.what() << std::endl;
-    }
-}
-
-void
-run_dconv_add_drelu_dscale(int64_t* x_dim_padded,
-                       int64_t* pad,
-                       int64_t* convstride,
-                       int64_t* dilation,
-                       int64_t* w_dim_padded,
-                       int64_t* y_dim_padded,
-                       cudnnDataType_t dataType,
-                       at::Half* devPtrX,
-                       at::Half* devPtrW,
-                       at::Half* devPtrY,
-                       at::Half* devPtrZ,
-                       at::Half* devPtrR,
-		       at::Half* devPtrI) {
-    cudnnHandle_t handle_ = torch::native::getCudnnHandle();
-    std::stringstream log_buf;
-    try {
-        int convDim = 2;
-
-        // Creates the necessary tensor descriptors
-        dconv_descriptors tensors = create_dconv_descriptors(
-            x_dim_padded, pad, convstride, dilation, w_dim_padded, y_dim_padded, dataType);
-        DEBUG_CUDNN_MSG(log_buf, std::get<X_OR_DX_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<DY_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<W_OR_DW_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<SCALE_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<RELU_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<AFTER_DCONV_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<AFTER_DRELU_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_INPUT_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_OPTIONAL_TENSOR>(tensors).describe());
-
-        // Define the convolution problem
-        auto convDesc = cudnn_frontend::ConvDescBuilder()
-                            .setDataType(CUDNN_DATA_FLOAT)
-                            .setMathMode(CUDNN_CROSS_CORRELATION)
-                            .setNDims(convDim)
-                            .setStrides(convDim, convstride)
-                            .setPrePadding(convDim, pad)
-                            .setPostPadding(convDim, pad)
-                            .setDilation(convDim, dilation)
-                            .build();
-        DEBUG_CUDNN_MSG(log_buf, convDesc.describe());
-
-        // optional add
-        auto addDesc = cudnn_frontend::PointWiseDescBuilder()
-                            .setMode(CUDNN_POINTWISE_ADD)
-                            .setMathPrecision(CUDNN_DATA_FLOAT)
-                            .build();
-        DEBUG_CUDNN_MSG(log_buf, addDesc.describe());
-
-        // Define the activation backward operation
-        auto actDesc = cudnn_frontend::PointWiseDescBuilder()
-          .setMode(CUDNN_POINTWISE_RELU_BWD)
-          .setMathPrecision(CUDNN_DATA_FLOAT)
-          .build();
-        DEBUG_CUDNN_MSG(log_buf, actDesc.describe());
-
-        // Define the scale backward operation
-        auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
-          .setMode(CUDNN_POINTWISE_MUL)
-          .setMathPrecision(CUDNN_DATA_FLOAT)
-          .build();
-        DEBUG_CUDNN_MSG(log_buf, scaleDesc.describe());
-
-        float alpha  = 1.0f;
-        float beta   = 0.0f;
-
-        // Create a convolution Node
-        auto conv_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_DATA_DESCRIPTOR)
-          .setdxDesc(std::get<AFTER_DCONV_TENSOR>(tensors))
-          .setwDesc(std::get<W_OR_DW_TENSOR>(tensors))
-          .setdyDesc(std::get<DY_TENSOR>(tensors))
-          .setcDesc(convDesc)
-          .setAlpha(alpha)
-          .setBeta(beta)
-          .build();
-        DEBUG_CUDNN_MSG(log_buf, conv_op.describe());
-
-        // Create add Node.
-        auto add_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                           .setxDesc(std::get<AFTER_DCONV_TENSOR>(tensors))
-                           .setbDesc(std::get<DGRAD_INPUT_TENSOR>(tensors))
-                           .setyDesc(std::get<DGRAD_OPTIONAL_TENSOR>(tensors))
-                           .setpwDesc(addDesc)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, add_op.describe());
-
-        // TODO: do we need getOutputTensor(), and what it returns in backward case?
-        // Create an relu backward Node.
-        auto act_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-          .setdyDesc(std::get<DGRAD_OPTIONAL_TENSOR>(tensors))
-          .setxDesc(std::get<RELU_TENSOR>(tensors))
-          .setdxDesc(std::get<AFTER_DRELU_TENSOR>(tensors))
-          .setpwDesc(actDesc)
-          .build();
-        DEBUG_CUDNN_MSG(log_buf, act_op.describe());
-
-        // Create a Scale Node.
-        auto scale_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-          .setxDesc(std::get<AFTER_DRELU_TENSOR>(tensors))
-          .setbDesc(std::get<SCALE_TENSOR>(tensors))
-          .setyDesc(std::get<X_OR_DX_TENSOR>(tensors))
-          .setpwDesc(scaleDesc)
-          .build();
-        DEBUG_CUDNN_MSG(log_buf, scale_op.describe());
-
-        // Create an Operation Graph. In this case it is convolution add bias activation
-        std::array<cudnn_frontend::Operation const*, 4> ops = {&conv_op, &add_op, &act_op, &scale_op};
-
-        auto opGraph = cudnn_frontend::OperationGraphBuilder()
-          .setHandle(handle_)
-          .setOperationGraph(ops.size(), ops.data())
-          .build();
-
-        // Create string encoding for plan caching
-        auto cache_string = getConvFusionString(x_dim_padded, pad, convstride, dilation, w_dim_padded, dataType, opGraph.getTag());
-        DEBUG_CUDNN_MSG(log_buf, "[convstring] " << cache_string);
-
-        auto& plan = getOrCreatePlan(handle_, log_buf, opGraph, cache_string);
-        DEBUG_CUDNN_MSG(log_buf, "Plan tag: " << plan.getTag());
-
-        auto workspace_size = plan.getWorkspaceSize();
-        DEBUG_CUDNN_MSG(log_buf, plan.describe() << " requires workspace " << workspace_size);
-
-        void* workspace_ptr = nullptr;
-        auto workspace_tensor = at::empty({(workspace_size+3)/4}, at::TensorOptions(at::kCUDA).dtype(at::kFloat));
-        if (workspace_size > 0) {
-          workspace_ptr = workspace_tensor.data_ptr<float>();
-        }
-        void* data_ptrs[] = {devPtrX, devPtrY, devPtrW, devPtrZ, devPtrR, devPtrI};
-        int64_t uids[]    = {'x', 'y', 'w', 's', 'r', 'i'};
-        auto variantPack  = cudnn_frontend::VariantPackBuilder()
-          .setWorkspacePointer(workspace_ptr)
-          .setDataPointers(6, data_ptrs)
-          .setUids(6, uids)
-          .build();
-        DEBUG_CUDNN_MSG(log_buf, "variantPack " << variantPack.describe());
-        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
-        checkCudnnErr(status);
-        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
-    } catch (cudnn_frontend::cudnnException e) {
-      std::cout << log_buf.str() << "[ERROR] Exception " << e.what() << std::endl;
-    }
-}
-
-void
-run_dconv_drelu_dscale_mask(int64_t* x_dim_padded,
-                            int64_t* pad,
-			    int64_t* convstride,
-			    int64_t* dilation,
-			    int64_t* w_dim_padded,
-			    int64_t* y_dim_padded,
-			    int64_t* threshold_dim,
-			    cudnnDataType_t dataType,
-			    at::Half* devPtrX,
-			    at::Half* devPtrW,
-			    at::Half* devPtrY,
-			    at::Half* devPtrZ,
-			    at::Half* devPtrR,
-			    int* devPtrT,
-			    int* devPtrU,
-			    int axis) {
-    cudnnHandle_t handle_ = torch::native::getCudnnHandle();
-    std::stringstream log_buf;
-    try {
-        int convDim = 2;
-
-        // Creates the necessary tensor descriptors
-        dconv_mask_descriptors tensors = create_dconv_mask_descriptors(
-            x_dim_padded, pad, convstride, dilation, w_dim_padded, y_dim_padded, threshold_dim, dataType);
-        DEBUG_CUDNN_MSG(log_buf, std::get<X_OR_DX_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<DY_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<W_OR_DW_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<SCALE_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<RELU_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<AFTER_DCONV_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<AFTER_DRELU_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_OPTIONAL_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_GEN_INDEX_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_MASK_TOP_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_MASK_BOTTOM_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_MASK_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_THRESHOLD_TOP_TENSOR>(tensors).describe());
-        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_THRESHOLD_BOTTOM_TENSOR>(tensors).describe());
-
-        // Define the convolution problem
-        auto convDesc = cudnn_frontend::ConvDescBuilder()
-                            .setDataType(CUDNN_DATA_FLOAT)
-                            .setMathMode(CUDNN_CROSS_CORRELATION)
-                            .setNDims(convDim)
-                            .setStrides(convDim, convstride)
-                            .setPrePadding(convDim, pad)
-                            .setPostPadding(convDim, pad)
-                            .setDilation(convDim, dilation)
-                            .build();
-        DEBUG_CUDNN_MSG(log_buf, convDesc.describe());
-
-        // Define the activation backward operation
-        auto actDesc = cudnn_frontend::PointWiseDescBuilder()
-          .setMode(CUDNN_POINTWISE_RELU_BWD)
-          .setMathPrecision(CUDNN_DATA_FLOAT)
-          .build();
-        DEBUG_CUDNN_MSG(log_buf, actDesc.describe());
-
-        // Define the scale backward operation
-        auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
-          .setMode(CUDNN_POINTWISE_MUL)
-          .setMathPrecision(CUDNN_DATA_FLOAT)
-          .build();
-        DEBUG_CUDNN_MSG(log_buf, scaleDesc.describe());
-
-        // Define the genIndex descriptor
-        auto genIndexDesc = cudnn_frontend::PointWiseDescBuilder()
-                           .setMode(CUDNN_POINTWISE_GEN_INDEX)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
-                           .setAxis(axis)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, genIndexDesc.describe());
-
-        // Define the lessThan descriptor
-        auto lessThanDesc = cudnn_frontend::PointWiseDescBuilder()
-                           .setMode(CUDNN_POINTWISE_CMP_LT)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, lessThanDesc.describe());
-
-        // Define the greaterThan descriptor
-        auto greaterThanDesc = cudnn_frontend::PointWiseDescBuilder()
-                           .setMode(CUDNN_POINTWISE_CMP_GT)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, greaterThanDesc.describe());
-
-        // Define the logical_or descriptor
-        auto logicalOrDesc = cudnn_frontend::PointWiseDescBuilder()
-                           .setMode(CUDNN_POINTWISE_LOGICAL_OR)
-                           .setMathPrecision(CUDNN_DATA_BOOLEAN)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, logicalOrDesc.describe());
-
-        // Define the binary_selection descriptor
-        auto selectionDesc = cudnn_frontend::PointWiseDescBuilder()
-                           .setMode(CUDNN_POINTWISE_BINARY_SELECT)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
-                           .build();
-        DEBUG_CUDNN_MSG(log_buf, selectionDesc.describe());
-
-        float alpha  = 1.0f;
-        float beta   = 0.0f;
-
-        // Create a convolution Node
-        auto conv_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_DATA_DESCRIPTOR)
-          .setdxDesc(std::get<AFTER_DCONV_TENSOR>(tensors))
-          .setwDesc(std::get<W_OR_DW_TENSOR>(tensors))
-          .setdyDesc(std::get<DY_TENSOR>(tensors))
-          .setcDesc(convDesc)
-          .setAlpha(alpha)
-          .setBeta(beta)
-          .build();
-        DEBUG_CUDNN_MSG(log_buf, conv_op.describe());
-
-        // TODO: do we need getOutputTensor(), and what it returns in backward case?
-        // Create an relu backward Node.
-        auto act_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-          .setdyDesc(std::get<AFTER_DCONV_TENSOR>(tensors))
-          .setxDesc(std::get<RELU_TENSOR>(tensors))
-          .setdxDesc(std::get<AFTER_DRELU_TENSOR>(tensors))
-          .setpwDesc(actDesc)
-          .build();
-        DEBUG_CUDNN_MSG(log_buf, act_op.describe());
-
-        // Create a Scale Node.
-        auto scale_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-          .setxDesc(std::get<AFTER_DRELU_TENSOR>(tensors))
-          .setbDesc(std::get<SCALE_TENSOR>(tensors))
-          .setyDesc(std::get<DGRAD_OPTIONAL_TENSOR>(tensors))
-          .setpwDesc(scaleDesc)
-          .build();
-        DEBUG_CUDNN_MSG(log_buf, scale_op.describe());
-
-        // Create a Gen_Index Node.
-        auto genIndex_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                          .setxDesc(std::get<DGRAD_OPTIONAL_TENSOR>(tensors))
-                          .setyDesc(std::get<DGRAD_GEN_INDEX_TENSOR>(tensors))
-                          .setpwDesc(genIndexDesc)
-                          .build();
-        DEBUG_CUDNN_MSG(log_buf, genIndex_op.describe());
-
-        // Create a LessThan Node.
-        auto lessThan_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                          .setxDesc(std::get<DGRAD_GEN_INDEX_TENSOR>(tensors))
-                          .setbDesc(std::get<DGRAD_THRESHOLD_TOP_TENSOR>(tensors))
-                          .setyDesc(std::get<DGRAD_MASK_TOP_TENSOR>(tensors))
-                          .setpwDesc(lessThanDesc)
-                          .build();
-        DEBUG_CUDNN_MSG(log_buf, lessThan_op.describe());
-
-        // Create a GreaterThan Node.
-        auto greaterThan_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                          .setxDesc(std::get<DGRAD_GEN_INDEX_TENSOR>(tensors))
-                          .setbDesc(std::get<DGRAD_THRESHOLD_BOTTOM_TENSOR>(tensors))
-                          .setyDesc(std::get<DGRAD_MASK_BOTTOM_TENSOR>(tensors))
-                          .setpwDesc(greaterThanDesc)
-                          .build();
-        DEBUG_CUDNN_MSG(log_buf, greaterThan_op.describe());
-
-        // Create a LogicalOr Node.
-        auto logicalOr_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                          .setxDesc(std::get<DGRAD_MASK_TOP_TENSOR>(tensors))
-                          .setbDesc(std::get<DGRAD_MASK_BOTTOM_TENSOR>(tensors))
-                          .setyDesc(std::get<DGRAD_MASK_TENSOR>(tensors))
-                          .setpwDesc(logicalOrDesc)
-                          .build();
-        DEBUG_CUDNN_MSG(log_buf, logicalOr_op.describe());
-
-        // Create a Binary_Selection Node.
-        auto selection_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                          .setxDesc(std::get<AFTER_DCONV_TENSOR>(tensors))
-                          .setbDesc(std::get<DGRAD_OPTIONAL_TENSOR>(tensors))
-                          .settDesc(std::get<DGRAD_MASK_TENSOR>(tensors))
-                          .setyDesc(std::get<X_OR_DX_TENSOR>(tensors))
-                          .setpwDesc(selectionDesc)
-                          .build();
-        DEBUG_CUDNN_MSG(log_buf, selection_op.describe());
-
-        // Create an Operation Graph. In this case it is convolution add bias activation
-        std::array<cudnn_frontend::Operation const*, 8> ops = {&conv_op, &act_op, &scale_op, &genIndex_op, &lessThan_op, &greaterThan_op, &logicalOr_op, &selection_op};
-
-        auto opGraph = cudnn_frontend::OperationGraphBuilder()
-          .setHandle(handle_)
-          .setOperationGraph(ops.size(), ops.data())
-          .build();
-
-        // Create string encoding for plan caching
-        auto cache_string = getConvFusionString(x_dim_padded, pad, convstride, dilation, w_dim_padded, dataType, opGraph.getTag());
-        DEBUG_CUDNN_MSG(log_buf, "[convstring] " << cache_string);
-
-        auto& plan = getOrCreatePlan(handle_, log_buf, opGraph, cache_string);
-        DEBUG_CUDNN_MSG(log_buf, "Plan tag: " << plan.getTag());
-
-        auto workspace_size = plan.getWorkspaceSize();
-        DEBUG_CUDNN_MSG(log_buf, plan.describe() << " requires workspace " << workspace_size);
-
-        void* workspace_ptr = nullptr;
-        auto workspace_tensor = at::empty({(workspace_size+3)/4}, at::TensorOptions(at::kCUDA).dtype(at::kFloat));
-        if (workspace_size > 0) {
-          workspace_ptr = workspace_tensor.data_ptr<float>();
-        }
-        void* data_ptrs[] = {devPtrX, devPtrY, devPtrW, devPtrZ, devPtrR, devPtrT, devPtrU};
-        int64_t uids[]    = {'x', 'y', 'w', 's', 'r', 't', 'u'};
-        auto variantPack  = cudnn_frontend::VariantPackBuilder()
-          .setWorkspacePointer(workspace_ptr)
-          .setDataPointers(7, data_ptrs)
-          .setUids(7, uids)
           .build();
         DEBUG_CUDNN_MSG(log_buf, "variantPack " << variantPack.describe());
         cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
@@ -2792,6 +1607,1302 @@ std::vector<at::Tensor> bottleneck_backward(bool explicit_nhwc, int stride_1X1, 
 }
 
 namespace {
+
+enum {
+    X_TENSOR,
+    Y_TENSOR,
+    W_TENSOR,
+    Z_TENSOR,
+    B_TENSOR,
+    AFTERADD_TENSOR,
+    AFTERBIAS_TENSOR,
+    AFTERCONV_TENSOR,
+    OPTIONAL,
+    AFTEROPT_TENSOR,
+    AFTERACT_TENSOR,
+    GEN_INDEX_TENSOR,
+    MASK_TOP_TENSOR,
+    MASK_BOTTOM_TENSOR,
+    MASK_TENSOR,
+    THRESHOLD_TOP_TENSOR,
+    THRESHOLD_BOTTOM_TENSOR,
+};
+
+using masked_convbias_descriptors = std::tuple<cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor,
+                                               cudnn_frontend::Tensor>;
+
+masked_convbias_descriptors
+create_conv_bias_add_act_mask_descriptors(int64_t* x_dim_padded,
+                                          int64_t* padA,
+					  int64_t* convstrideA,
+					  int64_t* dilationA,
+					  int64_t* w_dim_padded,
+					  int64_t* y_dim_padded,
+					  int64_t* threshold_dim,
+					  cudnnDataType_t dataType) {
+    const int convDim = 2;
+
+    int64_t b_dim_padded[4];
+    b_dim_padded[0] = 1;
+    b_dim_padded[1] = y_dim_padded[1];
+    b_dim_padded[2] = 1;
+    b_dim_padded[3] = 1;
+
+    int64_t x_stride_padded[4];
+    int64_t y_stride_padded[4];
+    int64_t w_stride_padded[4];
+    int64_t b_stride_padded[4];
+    int64_t threshold_stride[4];
+
+    generateStrides(w_dim_padded, w_stride_padded, 4, CUDNN_TENSOR_NHWC);
+    generateStrides(x_dim_padded, x_stride_padded, 4, CUDNN_TENSOR_NHWC);
+    generateStrides(y_dim_padded, y_stride_padded, 4, CUDNN_TENSOR_NHWC);
+    generateStrides(b_dim_padded, b_stride_padded, 4, CUDNN_TENSOR_NHWC);
+    generateStrides(threshold_dim, threshold_stride, 4, CUDNN_TENSOR_NHWC);
+
+    return masked_convbias_descriptors(cudnn_frontend::TensorBuilder()
+                                           .setDim(4, x_dim_padded)
+                                           .setStrides(4, x_stride_padded)
+                                           .setId('x')
+                                           .setAlignment(16)
+                                           .setDataType(dataType)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, y_dim_padded)
+                                           .setStrides(4, y_stride_padded)
+                                           .setId('y')
+                                           .setAlignment(16)
+                                           .setDataType(dataType)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, w_dim_padded)
+                                           .setStrides(4, w_stride_padded)
+                                           .setId('w')
+                                           .setAlignment(16)
+                                           .setDataType(dataType)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, b_dim_padded)
+                                           .setStrides(4, b_stride_padded)
+                                           .setId('z')
+                                           .setAlignment(16)
+                                           .setDataType(dataType)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, b_dim_padded)
+                                           .setStrides(4, b_stride_padded)
+                                           .setId('b')
+                                           .setAlignment(16)
+                                           .setDataType(dataType)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, y_dim_padded)
+                                           .setStrides(4, y_stride_padded)
+                                           .setVirtual()
+                                           .setId('A')  // after add
+                                           .setAlignment(16)
+                                           .setDataType(CUDNN_DATA_FLOAT)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, y_dim_padded)
+                                           .setStrides(4, y_stride_padded)
+                                           .setVirtual()
+                                           .setId('B')  // after bias
+                                           .setAlignment(16)
+                                           .setDataType(CUDNN_DATA_FLOAT)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, y_dim_padded)
+                                           .setStrides(4, y_stride_padded)
+                                           .setId('C')  // after conv
+                                           .setAlignment(16)
+                                           .setVirtual()
+                                           .setDataType(CUDNN_DATA_FLOAT)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, y_dim_padded)
+                                           .setStrides(4, y_stride_padded)
+                                           .setId('i')
+                                           .setAlignment(16)
+                                           .setDataType(dataType)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, y_dim_padded)
+                                           .setStrides(4, y_stride_padded)
+                                           .setId('D')  // after optional add
+                                           .setAlignment(16)
+                                           .setVirtual()
+                                           .setDataType(CUDNN_DATA_FLOAT)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, y_dim_padded)
+                                           .setStrides(4, y_stride_padded)
+                                           .setId('E')  // after act for masked
+                                           .setAlignment(16)
+                                           .setVirtual()
+                                           .setDataType(CUDNN_DATA_FLOAT)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, y_dim_padded)
+                                           .setStrides(4, y_stride_padded)
+                                           .setId('I')  // output of the gen index operation
+                                           .setAlignment(16)
+                                           .setVirtual()
+                                           .setDataType(CUDNN_DATA_INT32)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, y_dim_padded)
+                                           .setStrides(4, y_stride_padded)
+                                           .setId('m')  // top half of the mask created after the less than
+                                           .setAlignment(16)
+                                           .setVirtual()
+                                           .setDataType(CUDNN_DATA_BOOLEAN)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, y_dim_padded)
+                                           .setStrides(4, y_stride_padded)
+                                           .setId('n')  // bottom half of the mask
+                                           .setAlignment(16)
+                                           .setVirtual()
+                                           .setDataType(CUDNN_DATA_BOOLEAN)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, y_dim_padded)
+                                           .setStrides(4, y_stride_padded)
+                                           .setId('M')  // OR of the top and bottom masks
+                                           .setAlignment(16)
+                                           .setVirtual()
+                                           .setDataType(CUDNN_DATA_BOOLEAN)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, threshold_dim)
+                                           .setStrides(4, threshold_stride)
+                                           .setId('t')  // threshold for creating the top mask
+                                           .setAlignment(16)
+                                           .setDataType(CUDNN_DATA_INT32)
+                                           .build(),
+                                       cudnn_frontend::TensorBuilder()
+                                           .setDim(4, threshold_dim)
+                                           .setStrides(4, threshold_stride)
+                                           .setId('u')  // threshold for creating the bottom mask
+                                           .setAlignment(16)
+                                           .setDataType(CUDNN_DATA_INT32)
+                                           .build());
+}
+
+// tensor descriptors used for dgrad
+enum {
+    X_OR_DX_TENSOR,
+    DY_TENSOR,
+    W_OR_DW_TENSOR,
+    SCALE_TENSOR,
+    RELU_TENSOR,
+    AFTER_DCONV_TENSOR,
+    AFTER_DRELU_TENSOR,
+    DGRAD_INPUT_TENSOR,
+    DGRAD_OPTIONAL_TENSOR,
+    DGRAD_GEN_INDEX_TENSOR,
+    DGRAD_MASK_TOP_TENSOR,
+    DGRAD_MASK_BOTTOM_TENSOR,
+    DGRAD_MASK_TENSOR,
+    DGRAD_THRESHOLD_TOP_TENSOR,
+    DGRAD_THRESHOLD_BOTTOM_TENSOR,
+};
+
+using dconv_add_descriptors = std::tuple<cudnn_frontend::Tensor,
+                                         cudnn_frontend::Tensor,
+                                         cudnn_frontend::Tensor,
+                                         cudnn_frontend::Tensor,
+                                         cudnn_frontend::Tensor,
+                                         cudnn_frontend::Tensor,
+                                         cudnn_frontend::Tensor,
+                                         cudnn_frontend::Tensor,
+                                         cudnn_frontend::Tensor>;
+
+dconv_add_descriptors
+create_dconv_add_descriptors(int64_t* x_dim_padded,
+                             int64_t* padA,
+                             int64_t* convstrideA,
+                             int64_t* dilationA,
+                             int64_t* w_dim_padded,
+                             int64_t* y_dim_padded,
+                             cudnnDataType_t dataType) {
+    const int convDim = 2;
+
+    int64_t b_dim_padded[4];
+    b_dim_padded[0] = 1;
+    b_dim_padded[1] = x_dim_padded[1];
+    b_dim_padded[2] = 1;
+    b_dim_padded[3] = 1;
+
+    int64_t x_stride_padded[4];
+    int64_t y_stride_padded[4];
+    int64_t w_stride_padded[4];
+    int64_t b_stride_padded[4];
+
+    generateStrides(w_dim_padded, w_stride_padded, 4, CUDNN_TENSOR_NHWC);
+    generateStrides(x_dim_padded, x_stride_padded, 4, CUDNN_TENSOR_NHWC);
+    generateStrides(y_dim_padded, y_stride_padded, 4, CUDNN_TENSOR_NHWC);
+    generateStrides(b_dim_padded, b_stride_padded, 4, CUDNN_TENSOR_NHWC);
+
+    return dconv_add_descriptors(cudnn_frontend::TensorBuilder()
+                             .setDim(4, x_dim_padded)
+                             .setStrides(4, x_stride_padded)
+                             .setId('x')
+                             .setAlignment(16)
+                             .setDataType(dataType)
+                             .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, y_dim_padded)
+                             .setStrides(4, y_stride_padded)
+                             .setId('y')
+                             .setAlignment(16)
+                             .setDataType(dataType)
+                             .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, w_dim_padded)
+                             .setStrides(4, w_stride_padded)
+                             .setId('w')
+                             .setAlignment(16)
+                             .setDataType(dataType)
+                             .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, b_dim_padded)
+                             .setStrides(4, b_stride_padded)
+                             .setId('s')
+                             .setAlignment(16)
+                             .setDataType(dataType)
+                             .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, x_dim_padded)
+                             .setStrides(4, x_stride_padded)
+                             .setId('r')
+                             .setAlignment(16)
+                             .setDataType(dataType)
+                             .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, x_dim_padded)
+                             .setStrides(4, x_stride_padded)
+                             .setVirtual()
+                             .setId('A')  // after dconv
+                             .setAlignment(16)
+                             .setDataType(CUDNN_DATA_FLOAT)
+                             .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, x_dim_padded)
+                             .setStrides(4, x_stride_padded)
+                             .setVirtual()
+                             .setId('B')  // after drelu
+                             .setAlignment(16)
+                             .setDataType(CUDNN_DATA_FLOAT)
+                             .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, y_dim_padded)
+			     .setStrides(4, y_stride_padded)
+			     .setId('i')
+			     .setAlignment(16)
+			     .setDataType(dataType)
+			     .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, y_dim_padded)
+			     .setStrides(4, y_stride_padded)
+			     .setId('D')  // after optional add
+			     .setAlignment(16)
+			     .setVirtual()
+			     .setDataType(CUDNN_DATA_FLOAT)
+			     .build());
+}
+
+using dconv_mask_descriptors = std::tuple<cudnn_frontend::Tensor,
+                                          cudnn_frontend::Tensor,
+					  cudnn_frontend::Tensor,
+					  cudnn_frontend::Tensor,
+					  cudnn_frontend::Tensor,
+					  cudnn_frontend::Tensor,
+					  cudnn_frontend::Tensor,
+					  cudnn_frontend::Tensor,
+					  cudnn_frontend::Tensor,
+					  cudnn_frontend::Tensor,
+					  cudnn_frontend::Tensor,
+					  cudnn_frontend::Tensor,
+					  cudnn_frontend::Tensor,
+					  cudnn_frontend::Tensor,
+					  cudnn_frontend::Tensor>;
+
+dconv_mask_descriptors
+create_dconv_mask_descriptors(int64_t* x_dim_padded,
+                              int64_t* padA,
+			      int64_t* convstrideA,
+			      int64_t* dilationA,
+			      int64_t* w_dim_padded,
+			      int64_t* y_dim_padded,
+			      int64_t* threshold_dim,
+			      cudnnDataType_t dataType) {
+    const int convDim = 2;
+
+    int64_t b_dim_padded[4];
+    b_dim_padded[0] = 1;
+    b_dim_padded[1] = x_dim_padded[1];
+    b_dim_padded[2] = 1;
+    b_dim_padded[3] = 1;
+
+    int64_t x_stride_padded[4];
+    int64_t y_stride_padded[4];
+    int64_t w_stride_padded[4];
+    int64_t b_stride_padded[4];
+    int64_t threshold_stride[4];
+
+    generateStrides(w_dim_padded, w_stride_padded, 4, CUDNN_TENSOR_NHWC);
+    generateStrides(x_dim_padded, x_stride_padded, 4, CUDNN_TENSOR_NHWC);
+    generateStrides(y_dim_padded, y_stride_padded, 4, CUDNN_TENSOR_NHWC);
+    generateStrides(b_dim_padded, b_stride_padded, 4, CUDNN_TENSOR_NHWC);
+    generateStrides(threshold_dim, threshold_stride, 4, CUDNN_TENSOR_NHWC);
+
+    return dconv_mask_descriptors(cudnn_frontend::TensorBuilder()
+                             .setDim(4, x_dim_padded)
+                             .setStrides(4, x_stride_padded)
+                             .setId('x')
+                             .setAlignment(16)
+                             .setDataType(dataType)
+                             .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, y_dim_padded)
+                             .setStrides(4, y_stride_padded)
+                             .setId('y')
+                             .setAlignment(16)
+                             .setDataType(dataType)
+                             .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, w_dim_padded)
+                             .setStrides(4, w_stride_padded)
+                             .setId('w')
+                             .setAlignment(16)
+                             .setDataType(dataType)
+                             .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, b_dim_padded)
+                             .setStrides(4, b_stride_padded)
+                             .setId('s')
+                             .setAlignment(16)
+                             .setDataType(dataType)
+                             .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, x_dim_padded)
+                             .setStrides(4, x_stride_padded)
+                             .setId('r')
+                             .setAlignment(16)
+                             .setDataType(dataType)
+                             .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, x_dim_padded)
+                             .setStrides(4, x_stride_padded)
+                             .setVirtual()
+                             .setId('A')  // after dconv
+                             .setAlignment(16)
+                             .setDataType(CUDNN_DATA_FLOAT)
+                             .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, x_dim_padded)
+                             .setStrides(4, x_stride_padded)
+                             .setVirtual()
+                             .setId('B')  // after drelu
+                             .setAlignment(16)
+                             .setDataType(CUDNN_DATA_FLOAT)
+                             .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, y_dim_padded)
+			     .setStrides(4, y_stride_padded)
+			     .setId('i')
+			     .setAlignment(16)
+			     .setDataType(dataType)
+			     .build(),
+                             cudnn_frontend::TensorBuilder()
+                             .setDim(4, y_dim_padded)
+			     .setStrides(4, y_stride_padded)
+			     .setId('D')  // after optional add
+			     .setAlignment(16)
+			     .setVirtual()
+			     .setDataType(CUDNN_DATA_FLOAT)
+			     .build(),
+			     cudnn_frontend::TensorBuilder()
+			     .setDim(4, y_dim_padded)
+			     .setStrides(4, y_stride_padded)
+			     .setId('I')  // output of the gen index operation
+			     .setAlignment(16)
+			     .setVirtual()
+			     .setDataType(CUDNN_DATA_INT32)
+			     .build(),
+			     cudnn_frontend::TensorBuilder()
+			     .setDim(4, y_dim_padded)
+			     .setStrides(4, y_stride_padded)
+			     .setId('m')  // top half of the mask created after the less than
+			     .setAlignment(16)
+			     .setVirtual()
+			     .setDataType(CUDNN_DATA_BOOLEAN)
+			     .build(),
+			     cudnn_frontend::TensorBuilder()
+			     .setDim(4, y_dim_padded)
+			     .setStrides(4, y_stride_padded)
+			     .setId('n')  // bottom half of the mask
+			     .setAlignment(16)
+			     .setVirtual()
+			     .setDataType(CUDNN_DATA_BOOLEAN)
+			     .build(),
+			     cudnn_frontend::TensorBuilder()
+			     .setDim(4, y_dim_padded)
+			     .setStrides(4, y_stride_padded)
+			     .setId('M')  // OR of the top and bottom masks
+			     .setAlignment(16)
+			     .setVirtual()
+			     .setDataType(CUDNN_DATA_BOOLEAN)
+			     .build(),
+			     cudnn_frontend::TensorBuilder()
+			     .setDim(4, threshold_dim)
+			     .setStrides(4, threshold_stride)
+			     .setId('t')  // threshold for creating the top mask
+			     .setAlignment(16)
+			     .setDataType(CUDNN_DATA_INT32)
+			     .build(),
+			     cudnn_frontend::TensorBuilder()
+			     .setDim(4, threshold_dim)
+			     .setStrides(4, threshold_stride)
+			     .setId('u')  // threshold for creating the bottom mask
+			     .setAlignment(16)
+			     .setDataType(CUDNN_DATA_INT32)
+			     .build());
+}
+
+void
+run_conv_add_scale_bias_activation(int64_t* x_dim_padded,
+                                   int64_t* pad,
+				   int64_t* convstride,
+				   int64_t* dilation,
+				   int64_t* w_dim_padded,
+				   int64_t* y_dim_padded,
+				   cudnnDataType_t dataType,
+				   at::Half* devPtrX,
+				   at::Half* devPtrW,
+				   at::Half* devPtrY,
+				   at::Half* devPtrZ,
+				   at::Half* devPtrB,
+				   at::Half* devPtrI) {
+    cudnnHandle_t handle_ = torch::native::getCudnnHandle();
+    std::stringstream log_buf;
+    try {
+        int convDim = 2;
+
+        // Creates the necessary tensor descriptors
+        common_convbias_descriptors tensors = create_conv_bias_add_act_descriptors(
+            x_dim_padded, pad, convstride, dilation, w_dim_padded, y_dim_padded, dataType);
+        DEBUG_CUDNN_MSG(log_buf, std::get<X_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<Y_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<W_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<Z_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<B_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<AFTERADD_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<AFTERBIAS_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<AFTERCONV_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<OPTIONAL>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<AFTEROPT_TENSOR>(tensors).describe());
+
+        // Define the add operation
+        auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_MUL)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, scaleDesc.describe());
+
+        // Define the bias operation
+        auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
+                            .setMode(CUDNN_POINTWISE_ADD)
+                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .build();
+        DEBUG_CUDNN_MSG(log_buf, biasDesc.describe());
+
+        // optional add
+        auto addDesc = cudnn_frontend::PointWiseDescBuilder()
+                            .setMode(CUDNN_POINTWISE_ADD)
+                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .build();
+        DEBUG_CUDNN_MSG(log_buf, addDesc.describe());
+
+        // Define the activation operation
+        auto actDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_RELU_FWD)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, actDesc.describe());
+
+        // Define the convolution problem
+        auto convDesc = cudnn_frontend::ConvDescBuilder()
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setMathMode(CUDNN_CROSS_CORRELATION)
+                            .setNDims(convDim)
+                            .setStrides(convDim, convstride)
+                            .setPrePadding(convDim, pad)
+                            .setPostPadding(convDim, pad)
+                            .setDilation(convDim, dilation)
+                            .build();
+        DEBUG_CUDNN_MSG(log_buf, convDesc.describe());
+
+        float alpha  = 1.0f;
+        float beta   = 0.0f;
+
+        // Create a convolution Node
+        auto conv_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
+                           .setxDesc(std::get<X_TENSOR>(tensors))
+                           .setwDesc(std::get<W_TENSOR>(tensors))
+                           .setyDesc(std::get<AFTERCONV_TENSOR>(tensors))
+                           .setcDesc(convDesc)
+                           .setAlpha(alpha)
+                           .setBeta(beta)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, conv_op.describe());
+
+        // create an add node.
+        auto add_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(conv_op.getOutputTensor())
+                           .setbDesc(std::get<OPTIONAL>(tensors))
+                           .setyDesc(std::get<AFTEROPT_TENSOR>(tensors))
+                           .setpwDesc(addDesc)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, add_op.describe());
+
+        // Create a Add Node with scaling parameters.
+        auto scale_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(add_op.getOutputTensor())
+                           .setbDesc(std::get<Z_TENSOR>(tensors))
+                           .setyDesc(std::get<AFTERADD_TENSOR>(tensors))
+                           .setpwDesc(scaleDesc)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, scale_op.describe());
+
+        // Create a Bias Node.
+        auto bias_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(scale_op.getOutputTensor())
+                           .setbDesc(std::get<B_TENSOR>(tensors))
+                           .setyDesc(std::get<AFTERBIAS_TENSOR>(tensors))
+                           .setpwDesc(biasDesc)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, bias_op.describe());
+
+        // Create an Activation Node.
+        auto act_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(bias_op.getOutputTensor())
+                           .setyDesc(std::get<Y_TENSOR>(tensors))
+                           .setpwDesc(actDesc)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, act_op.describe());
+
+        // Create an Operation Graph. In this case it is convolution add bias activation
+        std::array<cudnn_frontend::Operation const*, 5> ops = {&conv_op, &add_op, &scale_op, &bias_op, &act_op};
+
+        auto opGraph = cudnn_frontend::OperationGraphBuilder()
+          .setHandle(handle_)
+          .setOperationGraph(ops.size(), ops.data())
+          .build();
+
+        // Create string encoding for plan caching
+        auto cache_string = getConvFusionString(x_dim_padded, pad, convstride, dilation, w_dim_padded, dataType, opGraph.getTag());
+        DEBUG_CUDNN_MSG(log_buf, "[convstring] " << cache_string);
+
+        auto& plan = getOrCreatePlan(handle_, log_buf, opGraph, cache_string);
+        DEBUG_CUDNN_MSG(log_buf, "Plan tag: " << plan.getTag());
+
+        auto workspace_size = plan.getWorkspaceSize();
+        DEBUG_CUDNN_MSG(log_buf, plan.describe() << " requires workspace " << workspace_size);
+
+        void* workspace_ptr = nullptr;
+        auto workspace_tensor = at::empty({(workspace_size+3)/4}, at::TensorOptions(at::kCUDA).dtype(at::kFloat));
+        if (workspace_size > 0) {
+          workspace_ptr = workspace_tensor.data_ptr<float>();
+        }
+        void* data_ptrs[] = {devPtrX, devPtrY, devPtrW, devPtrZ, devPtrB, devPtrI};
+        int64_t uids[]    = {'x', 'y', 'w', 'z', 'b', 'i'};
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(6, data_ptrs)
+                               .setUids(6, uids)
+                               .build();
+        DEBUG_CUDNN_MSG(log_buf, "variantPack " << variantPack.describe());
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        checkCudnnErr(status);
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+    } catch (cudnn_frontend::cudnnException e) {
+      std::cout << log_buf.str() << "[ERROR] Exception " << e.what() << std::endl;
+    }
+}
+
+void
+run_conv_scale_bias_add_activation_mask(int64_t* x_dim_padded,
+                                        int64_t* pad,
+                                        int64_t* convstride,
+					int64_t* dilation,
+					int64_t* w_dim_padded,
+					int64_t* y_dim_padded,
+					int64_t* threshold_dim,
+					cudnnDataType_t dataType,
+					at::Half* devPtrX,
+					at::Half* devPtrW,
+					at::Half* devPtrY,
+					at::Half* devPtrZ,
+					at::Half* devPtrB,
+					at::Half* devPtrI,
+					int* devPtrT,
+					int* devPtrU,
+					int axis) {
+    cudnnHandle_t handle_ = torch::native::getCudnnHandle();
+    std::stringstream log_buf;
+    try {
+        int convDim = 2;
+
+        // Creates the necessary tensor descriptors
+        masked_convbias_descriptors tensors = create_conv_bias_add_act_mask_descriptors(
+            x_dim_padded, pad, convstride, dilation, w_dim_padded, y_dim_padded, threshold_dim, dataType);
+        DEBUG_CUDNN_MSG(log_buf, std::get<X_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<Y_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<W_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<Z_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<B_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<AFTERADD_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<AFTERBIAS_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<AFTERCONV_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<OPTIONAL>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<AFTERACT_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<GEN_INDEX_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<MASK_TOP_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<MASK_BOTTOM_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<MASK_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<THRESHOLD_TOP_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<THRESHOLD_BOTTOM_TENSOR>(tensors).describe());
+
+        // Define the add operation
+        auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_MUL)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, scaleDesc.describe());
+
+        // Define the bias operation
+        auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
+                            .setMode(CUDNN_POINTWISE_ADD)
+                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .build();
+        DEBUG_CUDNN_MSG(log_buf, biasDesc.describe());
+
+        // optional add
+        auto addDesc = cudnn_frontend::PointWiseDescBuilder()
+                            .setMode(CUDNN_POINTWISE_ADD)
+                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .build();
+        DEBUG_CUDNN_MSG(log_buf, addDesc.describe());
+
+        // Define the activation operation
+        auto actDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_RELU_FWD)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, actDesc.describe());
+
+        // Define the convolution problem
+        auto convDesc = cudnn_frontend::ConvDescBuilder()
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setMathMode(CUDNN_CROSS_CORRELATION)
+                            .setNDims(convDim)
+                            .setStrides(convDim, convstride)
+                            .setPrePadding(convDim, pad)
+                            .setPostPadding(convDim, pad)
+                            .setDilation(convDim, dilation)
+                            .build();
+        DEBUG_CUDNN_MSG(log_buf, convDesc.describe());
+
+        // Define the genIndex descriptor
+        auto genIndexDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_GEN_INDEX)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setAxis(axis)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, genIndexDesc.describe());
+
+        // Define the lessThan descriptor
+        auto lessThanDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_CMP_LT)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, lessThanDesc.describe());
+
+        // Define the greaterThan descriptor
+        auto greaterThanDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_CMP_GT)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, greaterThanDesc.describe());
+
+        // Define the logical_or descriptor
+        auto logicalOrDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_LOGICAL_OR)
+                           .setMathPrecision(CUDNN_DATA_BOOLEAN)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, logicalOrDesc.describe());
+
+        // Define the binary_selection descriptor
+        auto selectionDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_BINARY_SELECT)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, selectionDesc.describe());
+
+        float alpha  = 1.0f;
+        float beta   = 0.0f;
+
+        // Create a convolution Node
+        auto conv_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
+                           .setxDesc(std::get<X_TENSOR>(tensors))
+                           .setwDesc(std::get<W_TENSOR>(tensors))
+                           .setyDesc(std::get<AFTERCONV_TENSOR>(tensors))
+                           .setcDesc(convDesc)
+                           .setAlpha(alpha)
+                           .setBeta(beta)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, conv_op.describe());
+
+        // Create a Add Node with scaling parameters.
+        auto scale_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(conv_op.getOutputTensor())
+                           .setbDesc(std::get<Z_TENSOR>(tensors))
+                           .setyDesc(std::get<AFTERADD_TENSOR>(tensors))
+                           .setpwDesc(scaleDesc)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, scale_op.describe());
+
+        // Create a Bias Node.
+        auto bias_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(scale_op.getOutputTensor())
+                           .setbDesc(std::get<B_TENSOR>(tensors))
+                           .setyDesc(std::get<AFTERBIAS_TENSOR>(tensors))
+                           .setpwDesc(biasDesc)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, bias_op.describe());
+
+        // Create a optional add Node.
+        auto add_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(bias_op.getOutputTensor())
+                           .setbDesc(std::get<OPTIONAL>(tensors))
+                           .setyDesc(std::get<AFTEROPT_TENSOR>(tensors))
+                           .setpwDesc(addDesc)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, add_op.describe());
+
+
+        // Create an Activation Node.
+        auto act_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+          .setxDesc(devPtrI ? add_op.getOutputTensor() : bias_op.getOutputTensor())
+                          .setyDesc(std::get<AFTERACT_TENSOR>(tensors))
+                          .setpwDesc(actDesc)
+                          .build();
+        DEBUG_CUDNN_MSG(log_buf, act_op.describe());
+
+        // Create a Gen_Index Node.
+        auto genIndex_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(std::get<AFTERACT_TENSOR>(tensors))
+                          .setyDesc(std::get<GEN_INDEX_TENSOR>(tensors))
+                          .setpwDesc(genIndexDesc)
+                          .build();
+        DEBUG_CUDNN_MSG(log_buf, genIndex_op.describe());
+
+        // Create a LessThan Node.
+        auto lessThan_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(std::get<GEN_INDEX_TENSOR>(tensors))
+                          .setbDesc(std::get<THRESHOLD_TOP_TENSOR>(tensors))
+                          .setyDesc(std::get<MASK_TOP_TENSOR>(tensors))
+                          .setpwDesc(lessThanDesc)
+                          .build();
+        DEBUG_CUDNN_MSG(log_buf, lessThan_op.describe());
+
+        // Create a GreaterThan Node.
+        auto greaterThan_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(std::get<GEN_INDEX_TENSOR>(tensors))
+                          .setbDesc(std::get<THRESHOLD_BOTTOM_TENSOR>(tensors))
+                          .setyDesc(std::get<MASK_BOTTOM_TENSOR>(tensors))
+                          .setpwDesc(greaterThanDesc)
+                          .build();
+        DEBUG_CUDNN_MSG(log_buf, greaterThan_op.describe());
+
+        // Create a LogicalOr Node.
+        auto logicalOr_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(std::get<MASK_TOP_TENSOR>(tensors))
+                          .setbDesc(std::get<MASK_BOTTOM_TENSOR>(tensors))
+                          .setyDesc(std::get<MASK_TENSOR>(tensors))
+                          .setpwDesc(logicalOrDesc)
+                          .build();
+        DEBUG_CUDNN_MSG(log_buf, logicalOr_op.describe());
+
+        // Create a Binary_Selection Node.
+        auto selection_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(std::get<AFTERCONV_TENSOR>(tensors))
+                          .setbDesc(std::get<AFTERACT_TENSOR>(tensors))
+                          .settDesc(std::get<MASK_TENSOR>(tensors))
+                          .setyDesc(std::get<Y_TENSOR>(tensors))
+                          .setpwDesc(selectionDesc)
+                          .build();
+        DEBUG_CUDNN_MSG(log_buf, selection_op.describe());
+
+        // Create an Operation Graph. In this case it is convolution add bias activation
+	if (devPtrI) {
+
+	  std::array<cudnn_frontend::Operation const*, 10> ops = {&conv_op, &scale_op, &bias_op, &add_op, &act_op, &genIndex_op, &lessThan_op, &greaterThan_op, &logicalOr_op, &selection_op};
+
+	  auto opGraph = cudnn_frontend::OperationGraphBuilder()
+            .setHandle(handle_)
+            .setOperationGraph(ops.size(), ops.data())
+            .build();
+
+	  // Create string encoding for plan caching
+	  auto cache_string = getConvFusionString(x_dim_padded, pad, convstride, dilation, w_dim_padded, dataType, opGraph.getTag());
+	  DEBUG_CUDNN_MSG(log_buf, "[convstring] " << cache_string);
+
+	  auto& plan = getOrCreatePlan(handle_, log_buf, opGraph, cache_string);
+	  DEBUG_CUDNN_MSG(log_buf, "Plan tag: " << plan.getTag());
+
+	  auto workspace_size = plan.getWorkspaceSize();
+	  DEBUG_CUDNN_MSG(log_buf, plan.describe() << " requires workspace " << workspace_size);
+
+	  void* workspace_ptr = nullptr;
+	  auto workspace_tensor = at::empty({(workspace_size+3)/4}, at::TensorOptions(at::kCUDA).dtype(at::kFloat));
+	  if (workspace_size > 0) {
+	    workspace_ptr = workspace_tensor.data_ptr<float>();
+	  }
+	  void* data_ptrs[] = {devPtrX, devPtrY, devPtrW, devPtrZ, devPtrB, devPtrI, devPtrT, devPtrU};
+	  int64_t uids[]    = {'x', 'y', 'w', 'z', 'b', 'i', 't', 'u'};
+	  auto variantPack  = cudnn_frontend::VariantPackBuilder()
+	    .setWorkspacePointer(workspace_ptr)
+	    .setDataPointers(8, data_ptrs)
+	    .setUids(8, uids)
+	    .build();
+	  DEBUG_CUDNN_MSG(log_buf, "variantPack " << variantPack.describe());
+	  cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+	  checkCudnnErr(status);
+	  cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+	} else {
+
+	  std::array<cudnn_frontend::Operation const*, 9> ops = {&conv_op, &scale_op, &bias_op, &act_op, &genIndex_op, &lessThan_op, &greaterThan_op, &logicalOr_op, &selection_op};
+
+	  auto opGraph = cudnn_frontend::OperationGraphBuilder()
+            .setHandle(handle_)
+            .setOperationGraph(ops.size(), ops.data())
+            .build();
+
+	  // Create string encoding for plan caching
+	  auto cache_string = getConvFusionString(x_dim_padded, pad, convstride, dilation, w_dim_padded, dataType, opGraph.getTag());
+	  DEBUG_CUDNN_MSG(log_buf, "[convstring] " << cache_string);
+
+	  auto& plan = getOrCreatePlan(handle_, log_buf, opGraph, cache_string);
+	  DEBUG_CUDNN_MSG(log_buf, "Plan tag: " << plan.getTag());
+
+	  auto workspace_size = plan.getWorkspaceSize();
+	  DEBUG_CUDNN_MSG(log_buf, plan.describe() << " requires workspace " << workspace_size);
+
+	  void* workspace_ptr = nullptr;
+	  auto workspace_tensor = at::empty({(workspace_size+3)/4}, at::TensorOptions(at::kCUDA).dtype(at::kFloat));
+	  if (workspace_size > 0) {
+	    workspace_ptr = workspace_tensor.data_ptr<float>();
+	  }
+	  void* data_ptrs[] = {devPtrX, devPtrY, devPtrW, devPtrZ, devPtrB, devPtrT, devPtrU};
+	  int64_t uids[]    = {'x', 'y', 'w', 'z', 'b', 't', 'u'};
+	  auto variantPack  = cudnn_frontend::VariantPackBuilder()
+	    .setWorkspacePointer(workspace_ptr)
+	    .setDataPointers(7, data_ptrs)
+	    .setUids(7, uids)
+	    .build();
+	  DEBUG_CUDNN_MSG(log_buf, "variantPack " << variantPack.describe());
+	  cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+	  checkCudnnErr(status);
+	  cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+	}
+    } catch (cudnn_frontend::cudnnException e) {
+      std::cout << log_buf.str() << "[ERROR] Exception " << e.what() << std::endl;
+    }
+}
+
+void
+run_dconv_add_drelu_dscale(int64_t* x_dim_padded,
+                       int64_t* pad,
+                       int64_t* convstride,
+                       int64_t* dilation,
+                       int64_t* w_dim_padded,
+                       int64_t* y_dim_padded,
+                       cudnnDataType_t dataType,
+                       at::Half* devPtrX,
+                       at::Half* devPtrW,
+                       at::Half* devPtrY,
+                       at::Half* devPtrZ,
+                       at::Half* devPtrR,
+		       at::Half* devPtrI) {
+    cudnnHandle_t handle_ = torch::native::getCudnnHandle();
+    std::stringstream log_buf;
+    try {
+        int convDim = 2;
+
+        // Creates the necessary tensor descriptors
+        dconv_add_descriptors tensors = create_dconv_add_descriptors(
+            x_dim_padded, pad, convstride, dilation, w_dim_padded, y_dim_padded, dataType);
+        DEBUG_CUDNN_MSG(log_buf, std::get<X_OR_DX_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<DY_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<W_OR_DW_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<SCALE_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<RELU_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<AFTER_DCONV_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<AFTER_DRELU_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_INPUT_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_OPTIONAL_TENSOR>(tensors).describe());
+
+        // Define the convolution problem
+        auto convDesc = cudnn_frontend::ConvDescBuilder()
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setMathMode(CUDNN_CROSS_CORRELATION)
+                            .setNDims(convDim)
+                            .setStrides(convDim, convstride)
+                            .setPrePadding(convDim, pad)
+                            .setPostPadding(convDim, pad)
+                            .setDilation(convDim, dilation)
+                            .build();
+        DEBUG_CUDNN_MSG(log_buf, convDesc.describe());
+
+        // optional add
+        auto addDesc = cudnn_frontend::PointWiseDescBuilder()
+                            .setMode(CUDNN_POINTWISE_ADD)
+                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .build();
+        DEBUG_CUDNN_MSG(log_buf, addDesc.describe());
+
+        // Define the activation backward operation
+        auto actDesc = cudnn_frontend::PointWiseDescBuilder()
+          .setMode(CUDNN_POINTWISE_RELU_BWD)
+          .setMathPrecision(CUDNN_DATA_FLOAT)
+          .build();
+        DEBUG_CUDNN_MSG(log_buf, actDesc.describe());
+
+        // Define the scale backward operation
+        auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
+          .setMode(CUDNN_POINTWISE_MUL)
+          .setMathPrecision(CUDNN_DATA_FLOAT)
+          .build();
+        DEBUG_CUDNN_MSG(log_buf, scaleDesc.describe());
+
+        float alpha  = 1.0f;
+        float beta   = 0.0f;
+
+        // Create a convolution Node
+        auto conv_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_DATA_DESCRIPTOR)
+          .setdxDesc(std::get<AFTER_DCONV_TENSOR>(tensors))
+          .setwDesc(std::get<W_OR_DW_TENSOR>(tensors))
+          .setdyDesc(std::get<DY_TENSOR>(tensors))
+          .setcDesc(convDesc)
+          .setAlpha(alpha)
+          .setBeta(beta)
+          .build();
+        DEBUG_CUDNN_MSG(log_buf, conv_op.describe());
+
+        // Create add Node.
+        auto add_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(std::get<AFTER_DCONV_TENSOR>(tensors))
+                           .setbDesc(std::get<DGRAD_INPUT_TENSOR>(tensors))
+                           .setyDesc(std::get<DGRAD_OPTIONAL_TENSOR>(tensors))
+                           .setpwDesc(addDesc)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, add_op.describe());
+
+        // TODO: do we need getOutputTensor(), and what it returns in backward case?
+        // Create an relu backward Node.
+        auto act_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+          .setdyDesc(std::get<DGRAD_OPTIONAL_TENSOR>(tensors))
+          .setxDesc(std::get<RELU_TENSOR>(tensors))
+          .setdxDesc(std::get<AFTER_DRELU_TENSOR>(tensors))
+          .setpwDesc(actDesc)
+          .build();
+        DEBUG_CUDNN_MSG(log_buf, act_op.describe());
+
+        // Create a Scale Node.
+        auto scale_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+          .setxDesc(std::get<AFTER_DRELU_TENSOR>(tensors))
+          .setbDesc(std::get<SCALE_TENSOR>(tensors))
+          .setyDesc(std::get<X_OR_DX_TENSOR>(tensors))
+          .setpwDesc(scaleDesc)
+          .build();
+        DEBUG_CUDNN_MSG(log_buf, scale_op.describe());
+
+        // Create an Operation Graph. In this case it is convolution add bias activation
+        std::array<cudnn_frontend::Operation const*, 4> ops = {&conv_op, &add_op, &act_op, &scale_op};
+
+        auto opGraph = cudnn_frontend::OperationGraphBuilder()
+          .setHandle(handle_)
+          .setOperationGraph(ops.size(), ops.data())
+          .build();
+
+        // Create string encoding for plan caching
+        auto cache_string = getConvFusionString(x_dim_padded, pad, convstride, dilation, w_dim_padded, dataType, opGraph.getTag());
+        DEBUG_CUDNN_MSG(log_buf, "[convstring] " << cache_string);
+
+        auto& plan = getOrCreatePlan(handle_, log_buf, opGraph, cache_string);
+        DEBUG_CUDNN_MSG(log_buf, "Plan tag: " << plan.getTag());
+
+        auto workspace_size = plan.getWorkspaceSize();
+        DEBUG_CUDNN_MSG(log_buf, plan.describe() << " requires workspace " << workspace_size);
+
+        void* workspace_ptr = nullptr;
+        auto workspace_tensor = at::empty({(workspace_size+3)/4}, at::TensorOptions(at::kCUDA).dtype(at::kFloat));
+        if (workspace_size > 0) {
+          workspace_ptr = workspace_tensor.data_ptr<float>();
+        }
+        void* data_ptrs[] = {devPtrX, devPtrY, devPtrW, devPtrZ, devPtrR, devPtrI};
+        int64_t uids[]    = {'x', 'y', 'w', 's', 'r', 'i'};
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+          .setWorkspacePointer(workspace_ptr)
+          .setDataPointers(6, data_ptrs)
+          .setUids(6, uids)
+          .build();
+        DEBUG_CUDNN_MSG(log_buf, "variantPack " << variantPack.describe());
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        checkCudnnErr(status);
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+    } catch (cudnn_frontend::cudnnException e) {
+      std::cout << log_buf.str() << "[ERROR] Exception " << e.what() << std::endl;
+    }
+}
+
+void
+run_dconv_drelu_dscale_mask(int64_t* x_dim_padded,
+                            int64_t* pad,
+			    int64_t* convstride,
+			    int64_t* dilation,
+			    int64_t* w_dim_padded,
+			    int64_t* y_dim_padded,
+			    int64_t* threshold_dim,
+			    cudnnDataType_t dataType,
+			    at::Half* devPtrX,
+			    at::Half* devPtrW,
+			    at::Half* devPtrY,
+			    at::Half* devPtrZ,
+			    at::Half* devPtrR,
+			    int* devPtrT,
+			    int* devPtrU,
+			    int axis) {
+    cudnnHandle_t handle_ = torch::native::getCudnnHandle();
+    std::stringstream log_buf;
+    try {
+        int convDim = 2;
+
+        // Creates the necessary tensor descriptors
+        dconv_mask_descriptors tensors = create_dconv_mask_descriptors(
+            x_dim_padded, pad, convstride, dilation, w_dim_padded, y_dim_padded, threshold_dim, dataType);
+        DEBUG_CUDNN_MSG(log_buf, std::get<X_OR_DX_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<DY_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<W_OR_DW_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<SCALE_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<RELU_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<AFTER_DCONV_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<AFTER_DRELU_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_OPTIONAL_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_GEN_INDEX_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_MASK_TOP_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_MASK_BOTTOM_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_MASK_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_THRESHOLD_TOP_TENSOR>(tensors).describe());
+        DEBUG_CUDNN_MSG(log_buf, std::get<DGRAD_THRESHOLD_BOTTOM_TENSOR>(tensors).describe());
+
+        // Define the convolution problem
+        auto convDesc = cudnn_frontend::ConvDescBuilder()
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setMathMode(CUDNN_CROSS_CORRELATION)
+                            .setNDims(convDim)
+                            .setStrides(convDim, convstride)
+                            .setPrePadding(convDim, pad)
+                            .setPostPadding(convDim, pad)
+                            .setDilation(convDim, dilation)
+                            .build();
+        DEBUG_CUDNN_MSG(log_buf, convDesc.describe());
+
+        // Define the activation backward operation
+        auto actDesc = cudnn_frontend::PointWiseDescBuilder()
+          .setMode(CUDNN_POINTWISE_RELU_BWD)
+          .setMathPrecision(CUDNN_DATA_FLOAT)
+          .build();
+        DEBUG_CUDNN_MSG(log_buf, actDesc.describe());
+
+        // Define the scale backward operation
+        auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
+          .setMode(CUDNN_POINTWISE_MUL)
+          .setMathPrecision(CUDNN_DATA_FLOAT)
+          .build();
+        DEBUG_CUDNN_MSG(log_buf, scaleDesc.describe());
+
+        // Define the genIndex descriptor
+        auto genIndexDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_GEN_INDEX)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setAxis(axis)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, genIndexDesc.describe());
+
+        // Define the lessThan descriptor
+        auto lessThanDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_CMP_LT)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, lessThanDesc.describe());
+
+        // Define the greaterThan descriptor
+        auto greaterThanDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_CMP_GT)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, greaterThanDesc.describe());
+
+        // Define the logical_or descriptor
+        auto logicalOrDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_LOGICAL_OR)
+                           .setMathPrecision(CUDNN_DATA_BOOLEAN)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, logicalOrDesc.describe());
+
+        // Define the binary_selection descriptor
+        auto selectionDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_BINARY_SELECT)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        DEBUG_CUDNN_MSG(log_buf, selectionDesc.describe());
+
+        float alpha  = 1.0f;
+        float beta   = 0.0f;
+
+        // Create a convolution Node
+        auto conv_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_DATA_DESCRIPTOR)
+          .setdxDesc(std::get<AFTER_DCONV_TENSOR>(tensors))
+          .setwDesc(std::get<W_OR_DW_TENSOR>(tensors))
+          .setdyDesc(std::get<DY_TENSOR>(tensors))
+          .setcDesc(convDesc)
+          .setAlpha(alpha)
+          .setBeta(beta)
+          .build();
+        DEBUG_CUDNN_MSG(log_buf, conv_op.describe());
+
+        // TODO: do we need getOutputTensor(), and what it returns in backward case?
+        // Create an relu backward Node.
+        auto act_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+          .setdyDesc(std::get<AFTER_DCONV_TENSOR>(tensors))
+          .setxDesc(std::get<RELU_TENSOR>(tensors))
+          .setdxDesc(std::get<AFTER_DRELU_TENSOR>(tensors))
+          .setpwDesc(actDesc)
+          .build();
+        DEBUG_CUDNN_MSG(log_buf, act_op.describe());
+
+        // Create a Scale Node.
+        auto scale_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+          .setxDesc(std::get<AFTER_DRELU_TENSOR>(tensors))
+          .setbDesc(std::get<SCALE_TENSOR>(tensors))
+          .setyDesc(std::get<DGRAD_OPTIONAL_TENSOR>(tensors))
+          .setpwDesc(scaleDesc)
+          .build();
+        DEBUG_CUDNN_MSG(log_buf, scale_op.describe());
+
+        // Create a Gen_Index Node.
+        auto genIndex_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(std::get<DGRAD_OPTIONAL_TENSOR>(tensors))
+                          .setyDesc(std::get<DGRAD_GEN_INDEX_TENSOR>(tensors))
+                          .setpwDesc(genIndexDesc)
+                          .build();
+        DEBUG_CUDNN_MSG(log_buf, genIndex_op.describe());
+
+        // Create a LessThan Node.
+        auto lessThan_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(std::get<DGRAD_GEN_INDEX_TENSOR>(tensors))
+                          .setbDesc(std::get<DGRAD_THRESHOLD_TOP_TENSOR>(tensors))
+                          .setyDesc(std::get<DGRAD_MASK_TOP_TENSOR>(tensors))
+                          .setpwDesc(lessThanDesc)
+                          .build();
+        DEBUG_CUDNN_MSG(log_buf, lessThan_op.describe());
+
+        // Create a GreaterThan Node.
+        auto greaterThan_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(std::get<DGRAD_GEN_INDEX_TENSOR>(tensors))
+                          .setbDesc(std::get<DGRAD_THRESHOLD_BOTTOM_TENSOR>(tensors))
+                          .setyDesc(std::get<DGRAD_MASK_BOTTOM_TENSOR>(tensors))
+                          .setpwDesc(greaterThanDesc)
+                          .build();
+        DEBUG_CUDNN_MSG(log_buf, greaterThan_op.describe());
+
+        // Create a LogicalOr Node.
+        auto logicalOr_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(std::get<DGRAD_MASK_TOP_TENSOR>(tensors))
+                          .setbDesc(std::get<DGRAD_MASK_BOTTOM_TENSOR>(tensors))
+                          .setyDesc(std::get<DGRAD_MASK_TENSOR>(tensors))
+                          .setpwDesc(logicalOrDesc)
+                          .build();
+        DEBUG_CUDNN_MSG(log_buf, logicalOr_op.describe());
+
+        // Create a Binary_Selection Node.
+        auto selection_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(std::get<AFTER_DCONV_TENSOR>(tensors))
+                          .setbDesc(std::get<DGRAD_OPTIONAL_TENSOR>(tensors))
+                          .settDesc(std::get<DGRAD_MASK_TENSOR>(tensors))
+                          .setyDesc(std::get<X_OR_DX_TENSOR>(tensors))
+                          .setpwDesc(selectionDesc)
+                          .build();
+        DEBUG_CUDNN_MSG(log_buf, selection_op.describe());
+
+        // Create an Operation Graph. In this case it is convolution add bias activation
+        std::array<cudnn_frontend::Operation const*, 8> ops = {&conv_op, &act_op, &scale_op, &genIndex_op, &lessThan_op, &greaterThan_op, &logicalOr_op, &selection_op};
+
+        auto opGraph = cudnn_frontend::OperationGraphBuilder()
+          .setHandle(handle_)
+          .setOperationGraph(ops.size(), ops.data())
+          .build();
+
+        // Create string encoding for plan caching
+        auto cache_string = getConvFusionString(x_dim_padded, pad, convstride, dilation, w_dim_padded, dataType, opGraph.getTag());
+        DEBUG_CUDNN_MSG(log_buf, "[convstring] " << cache_string);
+
+        auto& plan = getOrCreatePlan(handle_, log_buf, opGraph, cache_string);
+        DEBUG_CUDNN_MSG(log_buf, "Plan tag: " << plan.getTag());
+
+        auto workspace_size = plan.getWorkspaceSize();
+        DEBUG_CUDNN_MSG(log_buf, plan.describe() << " requires workspace " << workspace_size);
+
+        void* workspace_ptr = nullptr;
+        auto workspace_tensor = at::empty({(workspace_size+3)/4}, at::TensorOptions(at::kCUDA).dtype(at::kFloat));
+        if (workspace_size > 0) {
+          workspace_ptr = workspace_tensor.data_ptr<float>();
+        }
+        void* data_ptrs[] = {devPtrX, devPtrY, devPtrW, devPtrZ, devPtrR, devPtrT, devPtrU};
+        int64_t uids[]    = {'x', 'y', 'w', 's', 'r', 't', 'u'};
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+          .setWorkspacePointer(workspace_ptr)
+          .setDataPointers(7, data_ptrs)
+          .setUids(7, uids)
+          .build();
+        DEBUG_CUDNN_MSG(log_buf, "variantPack " << variantPack.describe());
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        checkCudnnErr(status);
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+    } catch (cudnn_frontend::cudnnException e) {
+      std::cout << log_buf.str() << "[ERROR] Exception " << e.what() << std::endl;
+    }
+}
 
 struct bottleneck_forward_status {
 

--- a/apex/contrib/csrc/bottleneck/bottleneck.cpp
+++ b/apex/contrib/csrc/bottleneck/bottleneck.cpp
@@ -197,7 +197,6 @@ create_conv_bias_add_act_descriptors(int64_t* x_dim_padded,
     int64_t y_stride_padded[4];
     int64_t w_stride_padded[4];
     int64_t b_stride_padded[4];
-    int64_t threshold_stride[4];
 
     generateStrides(w_dim_padded, w_stride_padded, 4, CUDNN_TENSOR_NHWC);
     generateStrides(x_dim_padded, x_stride_padded, 4, CUDNN_TENSOR_NHWC);

--- a/apex/contrib/csrc/bottleneck/bottleneck.cpp
+++ b/apex/contrib/csrc/bottleneck/bottleneck.cpp
@@ -2129,6 +2129,7 @@ at::Tensor bottleneck_backward_grad_out2(bool explicit_nhwc, int stride_1X1, std
             dw3,
             dy3,
             CUDNN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_FILTER_DESCRIPTOR);
+  DEBUG_MSG("[DEBUG] new wgrad3 : " << wgrad3.to(at::kFloat).sum().item<float>());
 
   // dgrad
   auto grad_out2 = at::empty(backward_state.outdim2, inputs[0].type(), output_format);
@@ -2262,6 +2263,7 @@ at::Tensor bottleneck_backward_wgrad2(bool explicit_nhwc, int stride_1X1, std::v
             dw2,
             dy2,
             CUDNN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_FILTER_DESCRIPTOR);
+  DEBUG_MSG("[DEBUG] new wgrad2 : " << wgrad2.to(at::kFloat).sum().item<float>());
 
   return wgrad2;
 }
@@ -2460,8 +2462,6 @@ void bottleneck_backward_rest(bool explicit_nhwc, int stride_1X1, std::vector<at
 
   DEBUG_MSG("[DEBUG] new dx : " << grad_x.to(at::kFloat).sum().item<float>());
   DEBUG_MSG("[DEBUG] new wgrad1 : " << wgrad1.to(at::kFloat).sum().item<float>());
-  DEBUG_MSG("[DEBUG] new wgrad2 : " << wgrad2.to(at::kFloat).sum().item<float>());
-  DEBUG_MSG("[DEBUG] new wgrad3 : " << wgrad3.to(at::kFloat).sum().item<float>());
 
   if (stride_1X1 != 1 || backward_state.filterdimA3[0] != backward_state.dimA[1]) {
     DEBUG_MSG("[DEBUG] new wgrad4 : " << wgrad4.to(at::kFloat).sum().item<float>());

--- a/apex/contrib/csrc/nccl_p2p/nccl_p2p.cpp
+++ b/apex/contrib/csrc/nccl_p2p/nccl_p2p.cpp
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "nccl_p2p_cuda.cuh"
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("get_unique_nccl_id", &apex::contrib::nccl_p2p::get_unique_nccl_id, "get_unique_nccl_id");
+  m.def("init_nccl_comm", &apex::contrib::nccl_p2p::init_nccl_comm, "init_nccl_comm");
+  m.def("nccl_send", &apex::contrib::nccl_p2p::nccl_send, "nccl_send");
+  m.def("nccl_recv", &apex::contrib::nccl_p2p::nccl_recv, "nccl_recv");
+  m.def("left_right_halo_exchange", &apex::contrib::nccl_p2p::left_right_halo_exchange, "left_right_halo_exchange");
+  m.def("add_delay", &apex::contrib::nccl_p2p::add_delay, "add_delay");
+}

--- a/apex/contrib/csrc/nccl_p2p/nccl_p2p.cpp
+++ b/apex/contrib/csrc/nccl_p2p/nccl_p2p.cpp
@@ -21,6 +21,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("init_nccl_comm", &apex::contrib::nccl_p2p::init_nccl_comm, "init_nccl_comm");
   m.def("nccl_send", &apex::contrib::nccl_p2p::nccl_send, "nccl_send");
   m.def("nccl_recv", &apex::contrib::nccl_p2p::nccl_recv, "nccl_recv");
+  m.def("left_right_halo_exchange_inplace", &apex::contrib::nccl_p2p::left_right_halo_exchange_inplace, "left_right_halo_exchange_inplace");
   m.def("left_right_halo_exchange", &apex::contrib::nccl_p2p::left_right_halo_exchange, "left_right_halo_exchange");
   m.def("add_delay", &apex::contrib::nccl_p2p::add_delay, "add_delay");
 }

--- a/apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cu
+++ b/apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cu
@@ -1,0 +1,207 @@
+#include <torch/extension.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <list>
+#include <cstdio>
+#include <ctime>
+#include <cassert>
+#include "nccl.h"
+
+/*
+ * This file implements a crude but effective mechanism for copying data between tenors owned by different ranks
+ * on the same machine using cudaMemcpyAsync peer-to-peer transfers.
+ */
+
+namespace {
+
+__global__ void AddDelay_kernel(const int delay, int* counter) {
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        // waste time while doing something compiler can't predict, thus preventing it from optimizing away this code.
+        int new_counter = 0;
+        double elapsed = 0;
+        clock_t start = clock();
+        do {
+            clock_t now = clock();
+            elapsed = (double)(now - start)*1e9 / CLOCKS_PER_SEC;
+            ++new_counter;
+        } while (elapsed < (double)delay);
+        *counter = new_counter;
+    }
+}
+
+class NcclCommWrapper
+{
+    private:
+        ncclComm_t comm;
+        int rank, world_size;
+
+        ncclDataType_t get_nccl_type(at::Tensor input)
+        {
+            switch (input.scalar_type())
+            {
+                case at::ScalarType::Half:
+                    return ncclFloat16;
+                case at::ScalarType::Float:
+                    return ncclFloat32;
+                case at::ScalarType::Double:
+                    return ncclFloat64;
+                case at::ScalarType::Byte:
+                    return ncclUint8;
+                case at::ScalarType::Char:
+                    return ncclInt8;
+                case at::ScalarType::Int:
+                    return ncclInt32;
+                case at::ScalarType::Long:
+                    return ncclInt64;
+                case at::ScalarType::BFloat16:
+                    return ncclBfloat16;
+                default:
+                    assert(false);
+            }
+        }
+
+    public:
+        NcclCommWrapper()
+        {
+            memset(&comm, 0, sizeof(ncclComm_t));
+            rank = 0;
+            world_size = 0;
+        }
+        NcclCommWrapper(ncclUniqueId id, int my_rank, int num_ranks)
+        {
+            ncclCommInitRank(&comm, num_ranks, id, my_rank);
+            rank = my_rank;
+            world_size = num_ranks;
+        }
+
+        ~NcclCommWrapper()
+        {
+            printf("ncclCommDestroy()\n");
+            ncclCommDestroy(comm);
+        }
+
+        void send(at::Tensor input, int destination)
+        {
+            ncclDataType_t ncclType = get_nccl_type(input);
+            AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Bool, at::ScalarType::BFloat16, at::ScalarType::Half, input.scalar_type(), "nccl_send", [&]() {
+                size_t count = sizeof(scalar_t) * torch::numel(input);
+                auto input_ptr = input.data_ptr<scalar_t>();
+                ncclSend(input_ptr, count, ncclType, destination, comm, at::cuda::getCurrentCUDAStream());
+            });
+        }
+
+        void recv(at::Tensor input, int sender)
+        {
+            ncclDataType_t ncclType = get_nccl_type(input);
+            AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Bool, at::ScalarType::BFloat16, at::ScalarType::Half, input.scalar_type(), "nccl_send", [&]() {
+                size_t count = sizeof(scalar_t) * torch::numel(input);
+                auto input_ptr = input.data_ptr<scalar_t>();
+                ncclRecv(input_ptr, count, ncclType, sender, comm, at::cuda::getCurrentCUDAStream());
+            });
+        }
+
+        std::vector<at::Tensor> left_right_halo_exchange(at::Tensor left_output_halo, at::Tensor right_output_halo, int group_size)
+        {
+            // after halo exchange:
+            // left_output_halo of rank+1 ends up in right_input_halo of rank
+            // right_output_halo of rank-1 ends up in left_input_halo of rank
+            auto stream = at::cuda::getCurrentCUDAStream();
+            auto right_input_halo = torch::empty_like(left_output_halo);
+            auto left_input_halo = torch::empty_like(right_output_halo);
+            ncclGroupStart();
+            ncclDataType_t ncclType = get_nccl_type(left_output_halo);
+            // we use wrap-around ranks, so left_input_halo of rank 0 has right_output_halo of rank world_size-1 after exchange etc.
+            // this is technically speaking wasteful, but there is no benefit in having the edge ranks do less work than internal ranks.
+            int group_rank = rank % group_size;
+            int group_index = rank / group_size;
+            int prev_rank = (group_rank + group_size - 1) % group_size;
+            int next_rank = (group_rank + 1) % group_size;
+            prev_rank = prev_rank + group_index * group_size;
+            next_rank = next_rank + group_index * group_size;
+            size_t left_n = torch::numel(left_output_halo);
+            size_t right_n = torch::numel(right_output_halo);
+            if (group_rank > 0) {
+                AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Bool, at::ScalarType::BFloat16, at::ScalarType::Half, left_output_halo.scalar_type(), "left_halo_exch", [&]() {
+                    // send left (to my_rank - 1)
+                    ncclSend(left_output_halo.data_ptr<scalar_t>(), left_n, ncclType, prev_rank, comm, stream);
+                    // receive left (from my_rank - 1)
+                    ncclRecv(left_input_halo.data_ptr<scalar_t>(), right_n, ncclType, prev_rank, comm, stream);
+                });
+            }
+            if (group_rank < group_size-1) {
+                AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Bool, at::ScalarType::BFloat16, at::ScalarType::Half, right_output_halo.scalar_type(), "right_halo_exch", [&]() {
+                    // send right (to my_rank + 1 )
+                    ncclSend(right_output_halo.data_ptr<scalar_t>(), right_n, ncclType, next_rank, comm, stream);
+                    // receive right (from my_rank + 1)
+                    ncclRecv(right_input_halo.data_ptr<scalar_t>(), left_n, ncclType, next_rank, comm, stream);
+                });
+            }
+            ncclGroupEnd();
+            return {left_input_halo, right_input_halo};
+        }
+};
+
+std::vector<NcclCommWrapper> nccl_comms;
+
+} // end anonymous namespace
+
+namespace apex { namespace contrib { namespace nccl_p2p {
+
+at::Tensor get_unique_nccl_id(int n)
+{
+    ncclUniqueId id;
+    ncclGetUniqueId(&id);
+    auto id_tensor = torch::empty({n*(int)sizeof(ncclUniqueId)}, torch::dtype(torch::kUInt8).device(torch::kCPU).requires_grad(false));
+    auto id_ptr = id_tensor.data_ptr<uint8_t>();
+    size_t offset = 0;
+    for (int i = 0;  i < n;  ++i)
+    {
+        ncclUniqueId id;
+        ncclGetUniqueId(&id);
+        memcpy(id_ptr+offset, &id, sizeof(ncclUniqueId));
+        offset += sizeof(ncclUniqueId);
+    }
+    return id_tensor;
+}
+
+int init_nccl_comm(at::Tensor unique_nccl_id, int my_rank, int num_ranks)
+{
+    ncclUniqueId id;
+    auto unique_nccl_id_ptr = unique_nccl_id.data_ptr<uint8_t>();
+    memcpy(&id, unique_nccl_id_ptr, sizeof(ncclUniqueId));
+    NcclCommWrapper* comm = new NcclCommWrapper(id, my_rank, num_ranks);
+    int handle = nccl_comms.size();
+    nccl_comms.push_back(*comm);
+    comm = 0L;
+    return handle;
+}
+
+void nccl_send(int handle, at::Tensor input, int destination)
+{
+    assert(handle >= 0 && handle < nccl_comms.size());
+    class NcclCommWrapper communicator = nccl_comms[handle];
+    communicator.send(input, destination);
+}
+
+void nccl_recv(int handle, at::Tensor input, int sender)
+{
+    assert(handle >= 0 && handle < nccl_comms.size());
+    class NcclCommWrapper communicator = nccl_comms[handle];
+    communicator.recv(input, sender);
+}
+
+std::vector<at::Tensor> left_right_halo_exchange(int handle, at::Tensor left_output_halo, at::Tensor right_output_halo, int group_size)
+{
+    assert(handle >= 0 && handle < nccl_comms.size());
+    class NcclCommWrapper& communicator = nccl_comms[handle];
+    return communicator.left_right_halo_exchange(left_output_halo, right_output_halo, group_size);
+}
+
+void add_delay(int delay)
+{
+    auto stream = at::cuda::getCurrentCUDAStream();
+    auto t = torch::empty({1}, torch::dtype(torch::kInt32).device(torch::kCUDA));
+    AddDelay_kernel<<<1,1,0,stream>>>(delay, t.data_ptr<int>());
+}
+
+}}}

--- a/apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cuh
+++ b/apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cuh
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <torch/extension.h>
+#ifndef _nccl_p2p_h_
+#define _nccl_p2p_h_
+
+namespace apex { namespace contrib { namespace nccl_p2p {
+at::Tensor get_unique_nccl_id(int n);
+int init_nccl_comm(
+        at::Tensor unique_nccl_id, 
+        int my_rank, 
+        int num_ranks
+        );
+void nccl_send(
+        int handle, 
+        at::Tensor input, 
+        int destination
+        );
+void nccl_recv(
+        int handle, 
+        at::Tensor input, 
+        int sender
+        );
+std::vector<at::Tensor> left_right_halo_exchange(
+        int handle,
+        at::Tensor left_output_halo, 
+        at::Tensor right_output_halo,
+        int group_size
+        );
+void add_delay(int delay);
+}}}
+#endif

--- a/apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cuh
+++ b/apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cuh
@@ -37,6 +37,7 @@ void nccl_recv(
         int sender
         );
 void left_right_halo_exchange_inplace(
+        int handle,
 	at::Tensor left_output_halo,
 	at::Tensor right_output_halo,
 	at::Tensor left_input_halo,

--- a/apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cuh
+++ b/apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cuh
@@ -36,6 +36,12 @@ void nccl_recv(
         at::Tensor input, 
         int sender
         );
+void left_right_halo_exchange_inplace(
+	at::Tensor left_output_halo,
+	at::Tensor right_output_halo,
+	at::Tensor left_input_halo,
+	at::Tensor right_input_halo,
+	int group_size);
 std::vector<at::Tensor> left_right_halo_exchange(
         int handle,
         at::Tensor left_output_halo, 

--- a/apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cuh
+++ b/apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cuh
@@ -38,6 +38,8 @@ void nccl_recv(
         );
 void left_right_halo_exchange_inplace(
         int handle,
+	bool left_zero,
+	bool right_zero,
 	at::Tensor left_output_halo,
 	at::Tensor right_output_halo,
 	at::Tensor left_input_halo,
@@ -45,6 +47,8 @@ void left_right_halo_exchange_inplace(
 	int group_size);
 std::vector<at::Tensor> left_right_halo_exchange(
         int handle,
+	bool left_zero,
+	bool right_zero,
         at::Tensor left_output_halo, 
         at::Tensor right_output_halo,
         int group_size

--- a/apex/contrib/csrc/peer_memory/peer_memory.cpp
+++ b/apex/contrib/csrc/peer_memory/peer_memory.cpp
@@ -19,6 +19,7 @@
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("allocate_raw", &apex::contrib::peer_memory::allocate_raw, "allocate_raw");
     m.def("free_raw", &apex::contrib::peer_memory::free_raw, "free_raw");
+    m.def("zero", &apex::contrib::peer_memory::zero, "zero");
     m.def("get_raw_ipc_address", &apex::contrib::peer_memory::get_raw_ipc_address, "get_raw_ipc_address");
     m.def("get_raw_peers", &apex::contrib::peer_memory::get_raw_peers, "get_raw_peers");
     m.def("blob_view_half", &apex::contrib::peer_memory::blob_view_half, "blob_view_half");

--- a/apex/contrib/csrc/peer_memory/peer_memory.cpp
+++ b/apex/contrib/csrc/peer_memory/peer_memory.cpp
@@ -17,12 +17,12 @@
 #include "peer_memory_cuda.cuh"
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("allocate_raw", &apex::peer_memory::allocate_raw, "allocate_raw");
-    m.def("free_raw", &apex::peer_memory::free_raw, "free_raw");
-    m.def("get_raw_ipc_address", &apex::peer_memory::get_raw_ipc_address, "get_raw_ipc_address");
-    m.def("get_raw_peers", &apex::peer_memory::get_raw_peers, "get_raw_peers");
-    m.def("blob_view_half", &apex::peer_memory::blob_view_half, "blob_view_half");
-    m.def("blob_view_float", &apex::peer_memory::blob_view_float, "blob_view_float");
-    m.def("blob_view_int", &apex::peer_memory::blob_view_int, "blob_view_int");
-    m.def("push_pull_halos_1d", &apex::peer_memory::push_pull_halos_1d, "push_pull_halos_1d");
+    m.def("allocate_raw", &apex::contrib::peer_memory::allocate_raw, "allocate_raw");
+    m.def("free_raw", &apex::contrib::peer_memory::free_raw, "free_raw");
+    m.def("get_raw_ipc_address", &apex::contrib::peer_memory::get_raw_ipc_address, "get_raw_ipc_address");
+    m.def("get_raw_peers", &apex::contrib::peer_memory::get_raw_peers, "get_raw_peers");
+    m.def("blob_view_half", &apex::contrib::peer_memory::blob_view_half, "blob_view_half");
+    m.def("blob_view_float", &apex::contrib::peer_memory::blob_view_float, "blob_view_float");
+    m.def("blob_view_int", &apex::contrib::peer_memory::blob_view_int, "blob_view_int");
+    m.def("push_pull_halos_1d", &apex::contrib::peer_memory::push_pull_halos_1d, "push_pull_halos_1d");
 }

--- a/apex/contrib/csrc/peer_memory/peer_memory.cpp
+++ b/apex/contrib/csrc/peer_memory/peer_memory.cpp
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "peer_memory_cuda.cuh"
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("allocate_raw", &apex::peer_memory::allocate_raw, "allocate_raw");
+    m.def("free_raw", &apex::peer_memory::free_raw, "free_raw");
+    m.def("get_raw_ipc_address", &apex::peer_memory::get_raw_ipc_address, "get_raw_ipc_address");
+    m.def("get_raw_peers", &apex::peer_memory::get_raw_peers, "get_raw_peers");
+    m.def("blob_view_half", &apex::peer_memory::blob_view_half, "blob_view_half");
+    m.def("blob_view_float", &apex::peer_memory::blob_view_float, "blob_view_float");
+    m.def("blob_view_int", &apex::peer_memory::blob_view_int, "blob_view_int");
+    m.def("push_pull_halos_1d", &apex::peer_memory::push_pull_halos_1d, "push_pull_halos_1d");
+}

--- a/apex/contrib/csrc/peer_memory/peer_memory_cuda.cu
+++ b/apex/contrib/csrc/peer_memory/peer_memory_cuda.cu
@@ -388,7 +388,7 @@ void push_pull_halos_1d(
     const int numThreads = 128;
     dim3 block(numThreads,1,1);
     AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, top_out_halo.scalar_type(), "push_pull_halos_1d_kernel", [&]{
-	    if (diagnostics) printf("size(scalar_t) = %d\n",sizeof(scalar_t));
+	    if (diagnostics) printf("size(scalar_t) = %ld\n",sizeof(scalar_t));
             scalar_t* toh_p = top_out_halo.data_ptr<scalar_t>();
             scalar_t* tox_p = top_out_tx.data_ptr<scalar_t>();
             scalar_t* tix_p = top_inp_tx.data_ptr<scalar_t>();

--- a/apex/contrib/csrc/peer_memory/peer_memory_cuda.cu
+++ b/apex/contrib/csrc/peer_memory/peer_memory_cuda.cu
@@ -30,15 +30,23 @@ void deleter(void* ptr)
 */
 
 template<class T>
-at::Tensor blob_view(T* raw_ptr, std::vector<int64_t> shape, const at::TensorOptions& options)
+at::Tensor blob_view(T* raw_ptr, std::vector<int64_t> shape, const at::TensorOptions& options, bool channels_last)
 {
-    std::vector<int64_t> strides(shape.size());
     size_t size = 1;
-    int idx = strides.size();
-    for (auto it = shape.rbegin();  it != shape.rend();  ++it)
-    {
-	strides[--idx] = size;
-	size *= *it;
+    std::vector<int64_t> strides(shape.size());
+    if (channels_last) {
+        assert(shape.size() == 4);
+        strides[0] = shape[1]*shape[2]*shape[3];
+        strides[1] = 1;
+        strides[2] = shape[1]*shape[3];
+        strides[3] = shape[1];
+    } else {
+        int idx = strides.size();
+        for (auto it = shape.rbegin();  it != shape.rend();  ++it)
+        {
+	    strides[--idx] = size;
+	    size *= *it;
+        }
     }
     size *= sizeof(T);
     // TODO: Implement dynamic reuse of pooled peer memory.
@@ -139,11 +147,11 @@ __device__ void strided_copy_kernel(
     }
 }
 
+template<bool wait, bool clear> 
 __device__ void dual_signal_wait_clear(
 	volatile int* signal1_flag, volatile int* wait1_flag,
 	volatile int* signal2_flag, volatile int* wait2_flag,
-	const int v1, const int v2, const int v3, const int v4,
-	const bool clear
+	const int v1, const int v2, const int v3, const int v4
 	)
 {
     register int r1, r2, r3, r4, r5, r6, r7, r8;
@@ -152,17 +160,20 @@ __device__ void dual_signal_wait_clear(
     if (is_main_thread) {
 	asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(signal1_flag), "r"(v1), "r"(v2), "r"(v3), "r"(v4) : "memory");
 	asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(signal2_flag), "r"(v1), "r"(v2), "r"(v3), "r"(v4) : "memory");
-	do {
-	    asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(r1), "=r"(r2), "=r"(r3), "=r"(r4) : "l"(wait1_flag) : "memory");
-	    asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(r5), "=r"(r6), "=r"(r7), "=r"(r8) : "l"(wait2_flag) : "memory");
-	} while (r1 != v1 || r5 != v1 || r2 != v2 || r6 != v2 || r3 != v3 || r7 != v3 || r4 != v4 || r8 != v4);
+	if (wait) {
+	    do {
+	        asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(r1), "=r"(r2), "=r"(r3), "=r"(r4) : "l"(wait1_flag) : "memory");
+	        asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(r5), "=r"(r6), "=r"(r7), "=r"(r8) : "l"(wait2_flag) : "memory");
+	    } while (r1 != v1 || r5 != v1 || r2 != v2 || r6 != v2 || r3 != v3 || r7 != v3 || r4 != v4 || r8 != v4);
+	}
     }
     cg::this_grid().sync();
-    // optionally clear wait flag
-    if (clear && is_main_thread) {
-	r1 = 0;  r2 = 0;  r3 = 0;  r4 = 0;
-	asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(wait1_flag), "r"(r1), "r"(r2), "r"(r3), "r"(r4) : "memory");
-	asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(wait2_flag), "r"(r1), "r"(r2), "r"(r3), "r"(r4) : "memory");
+    if (clear) {
+        if (is_main_thread) {
+	    r1 = 0;  r2 = 0;  r3 = 0;  r4 = 0;
+	    asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(wait1_flag), "r"(r1), "r"(r2), "r"(r3), "r"(r4) : "memory");
+	    asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(wait2_flag), "r"(r1), "r"(r2), "r"(r3), "r"(r4) : "memory");
+        }
     }
 }
 
@@ -173,12 +184,14 @@ __launch_bounds__(128, 16)
 __global__ void push_pull_halos_1d_kernel(
         // top halo,
         const T* toh, int toh_stride_C, int toh_stride_H, int toh_stride_W,     // top output halo
-        T* tox, int tox_stride_C, int tox_stride_H, int tox_stride_W,           // top tx buffer
+        T* tox, int tox_stride_C, int tox_stride_H, int tox_stride_W,           // top output tx buffer
+        T* tix, int tix_stride_C, int tix_stride_H, int tix_stride_W,           // top input tx buffer
         T* tih, int tih_stride_C, int tih_stride_H, int tih_stride_W,           // top input halo
         // btm halo
-        const T* boh, int boh_stride_C, int boh_stride_H, int boh_stride_W,     // top output halo
-        T* box, int box_stride_C, int box_stride_H, int box_stride_W,           // top tx buffer
-        T* bih, int bih_stride_C, int bih_stride_H, int bih_stride_W,           // top input halo
+        const T* boh, int boh_stride_C, int boh_stride_H, int boh_stride_W,     // btm output halo
+        T* box, int box_stride_C, int box_stride_H, int box_stride_W,           // btm output tx buffer
+        T* bix, int bix_stride_C, int bix_stride_H, int bix_stride_W,           // btm input tx buffer
+        T* bih, int bih_stride_C, int bih_stride_H, int bih_stride_W,           // btm input halo
         // dimensions
         int NC, int NH, int NW,
         // signals
@@ -194,11 +207,11 @@ __global__ void push_pull_halos_1d_kernel(
     strided_copy_kernel<T,is_HWC>(box, box_stride_C, box_stride_H, box_stride_W, boh, boh_stride_C, boh_stride_H, boh_stride_W, NC, NH, NW);
     // signal to top and btm neigbhbors that output halos are ready to be read
     // the choice of values for v1-v4 is arbitrary and does not matter, as long as all ranks use the same values
-    dual_signal_wait_clear(signal1_flag, wait1_flag, signal2_flag, wait2_flag, -987751720, 840868300, -225529332, 281513358, true);
+    dual_signal_wait_clear<true,true>(signal1_flag, wait1_flag, signal2_flag, wait2_flag, -987751720, 840868300, -225529332, 281513358);
     // pull top halo from transfer buffer in peer memory to input
-    strided_copy_kernel<T,is_HWC>(tox, tox_stride_C, tox_stride_H, tox_stride_W, tih, tih_stride_C, tih_stride_H, tih_stride_W, NC, NH, NW);
+    strided_copy_kernel<T,is_HWC>(tih, tih_stride_C, tih_stride_H, tih_stride_W, tix, tix_stride_C, tix_stride_H, tix_stride_W, NC, NH, NW);
     // pull btm halo from transfer buffer in peer memory to input
-    strided_copy_kernel<T,is_HWC>(box, box_stride_C, box_stride_H, box_stride_W, bih, bih_stride_C, bih_stride_H, bih_stride_W, NC, NH, NW);
+    strided_copy_kernel<T,is_HWC>(bih, bih_stride_C, bih_stride_H, bih_stride_W, bix, bix_stride_C, bix_stride_H, bix_stride_W, NC, NH, NW);
 }
 
 }
@@ -246,29 +259,32 @@ std::vector<int64_t> get_raw_peers(at::Tensor ipc_addresses, int peer_rank, int6
     return results;
 }
 
-at::Tensor blob_view_half(int64_t raw, std::vector<int64_t> shape)
+at::Tensor blob_view_half(int64_t raw, std::vector<int64_t> shape, bool channels_last)
 {
-    return blob_view<at::Half>((at::Half*)raw, shape, torch::dtype(torch::kFloat16).device(torch::kCUDA));
+    return blob_view<at::Half>((at::Half*)raw, shape, torch::dtype(torch::kFloat16).device(torch::kCUDA), channels_last);
 }
 
-at::Tensor blob_view_float(int64_t raw, std::vector<int64_t> shape)
+at::Tensor blob_view_float(int64_t raw, std::vector<int64_t> shape, bool channels_last)
 {
-    return blob_view<float>((float*)raw, shape, torch::dtype(torch::kFloat16).device(torch::kCUDA));
+    return blob_view<float>((float*)raw, shape, torch::dtype(torch::kFloat32).device(torch::kCUDA), channels_last);
 }
 
-at::Tensor blob_view_int(int64_t raw, std::vector<int64_t> shape)
+at::Tensor blob_view_int(int64_t raw, std::vector<int64_t> shape, bool channels_last)
 {
-    return blob_view<int>((int*)raw, shape, torch::dtype(torch::kFloat16).device(torch::kCUDA));
+    return blob_view<int>((int*)raw, shape, torch::dtype(torch::kInt32).device(torch::kCUDA), channels_last);
 }
 
 void push_pull_halos_1d(
+	bool diagnostics,
         bool explicit_nhwc,
         int numSM,                      // number of SMs to use
         at::Tensor top_out_halo,        // top output halo in sender device memory
         at::Tensor top_out_tx,          // top output transfer buffer in sender peer pool memory
+	at::Tensor top_inp_tx,		// top input transfer buffer in top neighbor peer pool memory
         at::Tensor top_inp_halo,        // top input halo in receiver device memory
         at::Tensor btm_out_halo,        // btm output halo in sender device memory
         at::Tensor btm_out_tx,          // btm output transfer buffer in sender peer pool memory
+	at::Tensor btm_inp_tx,		// btm input transfer buffer in btm neighbor peer pool memory
         at::Tensor btm_inp_halo,        // btm input halo in receiver device memory
         at::Tensor top_signal,          // top input signal in receiver device memory
         at::Tensor btm_signal,          // btm input signal in receiver device memory
@@ -278,9 +294,11 @@ void push_pull_halos_1d(
     // basic checks of inputs
     TORCH_CHECK(top_out_halo.is_cuda());
     TORCH_CHECK(top_out_tx.is_cuda());
+    TORCH_CHECK(top_inp_tx.is_cuda());
     TORCH_CHECK(top_inp_halo.is_cuda());
     TORCH_CHECK(btm_out_halo.is_cuda());
     TORCH_CHECK(btm_out_tx.is_cuda());
+    TORCH_CHECK(btm_inp_tx.is_cuda());
     TORCH_CHECK(btm_inp_halo.is_cuda());
     TORCH_CHECK(top_signal.is_cuda());
     TORCH_CHECK(btm_signal.is_cuda());
@@ -291,46 +309,56 @@ void push_pull_halos_1d(
     tensor_shape(top_out_halo, explicit_nhwc, toh_N, toh_C, toh_H, toh_W);
     int tox_N, tox_C, tox_H, tox_W;
     tensor_shape(top_out_tx, explicit_nhwc, tox_N, tox_C, tox_H, tox_W);
+    int tix_N, tix_C, tix_H, tix_W;
+    tensor_shape(top_inp_tx, explicit_nhwc, tix_N, tix_C, tix_H, tix_W);
     int tih_N, tih_C, tih_H, tih_W;
     tensor_shape(top_inp_halo, explicit_nhwc, tih_N, tih_C, tih_H, tih_W);
     TORCH_CHECK(
-            (toh_N == tox_N && tox_N == tih_N) &&
-            (toh_C == tox_C && tox_C == tih_C) &&
-            (toh_H == tox_H && tox_H == tih_H) &&
-            (toh_W == tox_W && tox_W == tih_W));
+            (toh_N == tox_N && tox_N == tix_N && tix_N == tih_N) &&
+            (toh_C == tox_C && tox_C == tix_C && tix_C == tih_C) &&
+            (toh_H == tox_H && tox_H == tix_H && tix_H == tih_H) &&
+            (toh_W == tox_W && tox_W == tix_W && tix_W == tih_W));
     int boh_N, boh_C, boh_H, boh_W;
     tensor_shape(btm_out_halo, explicit_nhwc, boh_N, boh_C, boh_H, boh_W);
     int box_N, box_C, box_H, box_W;
     tensor_shape(btm_out_tx, explicit_nhwc, box_N, box_C, box_H, box_W);
+    int bix_N, bix_C, bix_H, bix_W;
+    tensor_shape(btm_inp_tx, explicit_nhwc, bix_N, bix_C, bix_H, bix_W);
     int bih_N, bih_C, bih_H, bih_W;
     tensor_shape(btm_inp_halo, explicit_nhwc, bih_N, bih_C, bih_H, bih_W);
     TORCH_CHECK(
-            (boh_N == box_N && box_N == bih_N) &&
-            (boh_C == box_C && box_C == bih_C) &&
-            (boh_H == box_H && box_H == bih_H) &&
-            (boh_W == box_W && box_W == bih_W));
+            (boh_N == box_N && box_N == bix_N && bix_N == bih_N) &&
+            (boh_C == box_C && box_C == bix_C && bix_C == bih_C) &&
+            (boh_H == box_H && box_H == bix_H && bix_H == bih_H) &&
+            (boh_W == box_W && box_W == bix_W && bix_W == bih_W));
     TORCH_CHECK(
 	    (toh_N == boh_N) &&
 	    (toh_C == boh_C) &&
 	    (toh_H == boh_H) &&
 	    (toh_W == boh_W));
     int NC=toh_C, NH=toh_H, NW=toh_W;
+    if (diagnostics) printf("NC=%d, NH=%d, NW=%d\n",NC,NH,NW);
 
     int toh_stride_N, toh_stride_C, toh_stride_H, toh_stride_W;
     tensor_strides(top_out_halo, explicit_nhwc, toh_stride_N, toh_stride_C, toh_stride_H, toh_stride_W);
     int tox_stride_N, tox_stride_C, tox_stride_H, tox_stride_W;
     tensor_strides(top_out_tx, explicit_nhwc, tox_stride_N, tox_stride_C, tox_stride_H, tox_stride_W);
+    int tix_stride_N, tix_stride_C, tix_stride_H, tix_stride_W;
+    tensor_strides(top_inp_tx, explicit_nhwc, tix_stride_N, tix_stride_C, tix_stride_H, tix_stride_W);
     int tih_stride_N, tih_stride_C, tih_stride_H, tih_stride_W;
     tensor_strides(top_inp_halo, explicit_nhwc, tih_stride_N, tih_stride_C, tih_stride_H, tih_stride_W);
     int boh_stride_N, boh_stride_C, boh_stride_H, boh_stride_W;
     tensor_strides(btm_out_halo, explicit_nhwc, boh_stride_N, boh_stride_C, boh_stride_H, boh_stride_W);
     int box_stride_N, box_stride_C, box_stride_H, box_stride_W;
     tensor_strides(btm_out_tx, explicit_nhwc, box_stride_N, box_stride_C, box_stride_H, box_stride_W);
+    int bix_stride_N, bix_stride_C, bix_stride_H, bix_stride_W;
+    tensor_strides(btm_inp_tx, explicit_nhwc, bix_stride_N, bix_stride_C, bix_stride_H, bix_stride_W);
     int bih_stride_N, bih_stride_C, bih_stride_H, bih_stride_W;
     tensor_strides(btm_inp_halo, explicit_nhwc, bih_stride_N, bih_stride_C, bih_stride_H, bih_stride_W);
 
     // determine if nhwc
     auto is_nhwc = (toh_stride_C == 1) ? true : false;
+    if (diagnostics) printf("is_nhwc = %s\n",is_nhwc?"true":"false");
 
     // figure out launch parameters
     int device;
@@ -342,35 +370,59 @@ void push_pull_halos_1d(
     const int numThreads = 128;
     dim3 block(numThreads,1,1);
     AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, top_out_halo.scalar_type(), "push_pull_halos_1d_kernel", [&]{
+	    if (diagnostics) printf("size(scalar_t) = %d\n",sizeof(scalar_t));
             scalar_t* toh_p = top_out_halo.data_ptr<scalar_t>();
             scalar_t* tox_p = top_out_tx.data_ptr<scalar_t>();
+            scalar_t* tix_p = top_inp_tx.data_ptr<scalar_t>();
             scalar_t* tih_p = top_inp_halo.data_ptr<scalar_t>();
             scalar_t* boh_p = btm_out_halo.data_ptr<scalar_t>();
             scalar_t* box_p = btm_out_tx.data_ptr<scalar_t>();
+            scalar_t* bix_p = btm_inp_tx.data_ptr<scalar_t>();
             scalar_t* bih_p = btm_inp_halo.data_ptr<scalar_t>();
-	    int* top_signal_p = top_signal.data_ptr<int>();
-	    int* btm_signal_p = btm_signal.data_ptr<int>() + 4;
+	    if (diagnostics) printf("waypoint1\n");
+	    int* top_signal_p = top_signal.data_ptr<int>() + 4;
+	    int* btm_signal_p = btm_signal.data_ptr<int>();
 	    int* top_wait_p = waits.data_ptr<int>();
 	    int* btm_wait_p = waits.data_ptr<int>() + 4;
+	    if (diagnostics) printf("waypoint2\n");
 
             // do int4 vector loads if channel count permits
             int elem_size_in_bytes = toh_C * sizeof(scalar_t);
             int elem_size_in_int4 = (elem_size_in_bytes / 16);
+	    if (diagnostics) printf("elem_size_in_bytes = %d, elem_size_in_int4 = %d\n",elem_size_in_bytes,elem_size_in_int4);
             if (is_nhwc && elem_size_in_int4*16 == elem_size_in_bytes) {
                 // can do int4 transfers
-	        int divisor = elem_size_in_bytes / elem_size_in_int4;
+	        int divisor = toh_C / elem_size_in_int4;
+		if (diagnostics) printf("CAN DO INT4 :: divisor = %d\n",divisor);
 		toh_stride_N /= divisor;   toh_stride_H /= divisor;    toh_stride_W /= divisor;
 		tox_stride_N /= divisor;   tox_stride_H /= divisor;    tox_stride_W /= divisor;
+		tix_stride_N /= divisor;   tix_stride_H /= divisor;    tix_stride_W /= divisor;
 		tih_stride_N /= divisor;   tih_stride_H /= divisor;    tih_stride_W /= divisor;
 		boh_stride_N /= divisor;   boh_stride_H /= divisor;    boh_stride_W /= divisor;
 		box_stride_N /= divisor;   box_stride_H /= divisor;    box_stride_W /= divisor;
+		bix_stride_N /= divisor;   bix_stride_H /= divisor;    bix_stride_W /= divisor;
 		bih_stride_N /= divisor;   bih_stride_H /= divisor;    bih_stride_W /= divisor;
+		NC /= divisor;
+		if (diagnostics) {
+                    printf("divisor=%d\n",divisor);
+                    printf("toh_stride :: N=%d, C=%d, H=%d, W=%d\n",toh_stride_N,toh_stride_C,toh_stride_H,toh_stride_W);
+                    printf("tox_stride :: N=%d, C=%d, H=%d, W=%d\n",tox_stride_N,tox_stride_C,tox_stride_H,tox_stride_W);
+                    printf("tix_stride :: N=%d, C=%d, H=%d, W=%d\n",tix_stride_N,tix_stride_C,tix_stride_H,tix_stride_W);
+                    printf("tih_stride :: N=%d, C=%d, H=%d, W=%d\n",tih_stride_N,tih_stride_C,tih_stride_H,tih_stride_W);
+                    printf("boh_stride :: N=%d, C=%d, H=%d, W=%d\n",boh_stride_N,boh_stride_C,boh_stride_H,boh_stride_W);
+                    printf("box_stride :: N=%d, C=%d, H=%d, W=%d\n",box_stride_N,box_stride_C,box_stride_H,box_stride_W);
+                    printf("bix_stride :: N=%d, C=%d, H=%d, W=%d\n",bix_stride_N,bix_stride_C,bix_stride_H,bix_stride_W);
+                    printf("bih_stride :: N=%d, C=%d, H=%d, W=%d\n",bih_stride_N,bih_stride_C,bih_stride_H,bih_stride_W);
+                    printf("NC=%d, NH=%d, NW=%d\n",NC,NH,NW);
+                }
 		void *kernelArgs[] = {
 		    (int4**)&toh_p, &toh_stride_C, &toh_stride_H, &toh_stride_W,
 		    (int4**)&tox_p, &tox_stride_C, &tox_stride_H, &tox_stride_W,
+		    (int4**)&tix_p, &tix_stride_C, &tix_stride_H, &tix_stride_W,
 		    (int4**)&tih_p, &tih_stride_C, &tih_stride_H, &tih_stride_W,
 		    (int4**)&boh_p, &boh_stride_C, &boh_stride_H, &boh_stride_W,
 		    (int4**)&box_p, &box_stride_C, &box_stride_H, &box_stride_W,
+		    (int4**)&bix_p, &bix_stride_C, &bix_stride_H, &bix_stride_W,
 		    (int4**)&bih_p, &bih_stride_C, &bih_stride_H, &bih_stride_W,
 		    &NC, &NH, &NW,
 		    &top_signal_p, &btm_signal_p, &top_wait_p, &btm_wait_p
@@ -381,12 +433,15 @@ void push_pull_halos_1d(
 	        cudaLaunchCooperativeKernel((void*)push_pull_halos_1d_kernel<int4,true>, grid, block, kernelArgs, 0, current_stream);
             } else {
                 // cannot do int4 transfers
+		if (diagnostics) printf("CAN NOT DO INT4\n");
 		void *kernelArgs[] = {
 		    &toh_p, &toh_stride_C, &toh_stride_H, &toh_stride_W,
 		    &tox_p, &tox_stride_C, &tox_stride_H, &tox_stride_W,
+		    &tix_p, &tix_stride_C, &tix_stride_H, &tix_stride_W,
 		    &tih_p, &tih_stride_C, &tih_stride_H, &tih_stride_W,
 		    &boh_p, &boh_stride_C, &boh_stride_H, &boh_stride_W,
 		    &box_p, &box_stride_C, &box_stride_H, &box_stride_W,
+		    &bix_p, &bix_stride_C, &bix_stride_H, &bix_stride_W,
 		    &bih_p, &bih_stride_C, &bih_stride_H, &bih_stride_W,
 		    &NC, &NH, &NW,
 		    &top_signal_p, &btm_signal_p, &top_wait_p, &btm_wait_p

--- a/apex/contrib/csrc/peer_memory/peer_memory_cuda.cu
+++ b/apex/contrib/csrc/peer_memory/peer_memory_cuda.cu
@@ -239,6 +239,7 @@ int64_t allocate_raw(int64_t size)
 {
     float* ptr = 0L;
     cudaMalloc(&ptr, size);
+    cudaMemset(ptr, 0, size);
     return (int64_t)ptr;
 }
 

--- a/apex/contrib/csrc/peer_memory/peer_memory_cuda.cu
+++ b/apex/contrib/csrc/peer_memory/peer_memory_cuda.cu
@@ -1,0 +1,409 @@
+#include <torch/extension.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <list>
+#include <cstdio>
+#include <cassert>
+#include <cuda_runtime_api.h>
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+
+#define CUDACHECK(cmd) do {                         \
+  cudaError_t err = cmd;                            \
+  if( err != cudaSuccess ) {                        \
+    char hostname[1024];                            \
+    gethostname(hostname, 1024);                    \
+    printf("%s: CUDA failure %s:%d '%s'\n",         \
+         hostname,                                  \
+        __FILE__,__LINE__,cudaGetErrorString(err)); \
+  }                                                 \
+} while(0)
+
+namespace {
+
+/* Basic deleter function for from_blob function.
+void deleter(void* ptr)
+{
+    printf("deleter(ptr=%p)\n",ptr);
+    cudaFree(ptr);
+}
+*/
+
+template<class T>
+at::Tensor blob_view(T* raw_ptr, std::vector<int64_t> shape, const at::TensorOptions& options)
+{
+    std::vector<int64_t> strides(shape.size());
+    size_t size = 1;
+    int idx = strides.size();
+    for (auto it = shape.rbegin();  it != shape.rend();  ++it)
+    {
+	strides[--idx] = size;
+	size *= *it;
+    }
+    size *= sizeof(T);
+    // TODO: Implement dynamic reuse of pooled peer memory.
+    // We provide no deleter function because all peer memory allocations are static in this implementation.
+    return torch::from_blob((void*)raw_ptr, shape, strides, 0L, options);
+}
+
+void tensor_shape(at::Tensor t, bool explicit_nhwc, int& N, int& C, int& H, int& W)
+{
+    if (t.dim() == 3) {
+	N = 1;
+        if (explicit_nhwc) {
+            C = t.size(2);
+            H = t.size(0);
+            W = t.size(1);
+        } else {
+	    C = t.size(0);
+    	    H = t.size(1);
+    	    W = t.size(2);
+        }
+    } else if (t.dim() == 4) {
+        if (explicit_nhwc) {
+            N = t.size(0);
+            C = t.size(3);
+            H = t.size(1);
+            W = t.size(2);
+        } else {
+            N = t.size(0);
+            C = t.size(1);
+            H = t.size(2);
+            W = t.size(3);
+        }
+    } else {
+        printf("%s;%d - t.dim() must be either 3 or 4 (was %d)\n",__FILE__,__LINE__,t.dim());
+        assert(t.dim() == 3 || t.dim() == 4);
+    }
+}
+
+void tensor_strides(at::Tensor t, bool explicit_nhwc, int& stride_N, int& stride_C, int& stride_H, int& stride_W)
+{
+    if (t.dim() == 3) {
+        if (explicit_nhwc) {
+            stride_C = t.stride(2);
+            stride_H = t.stride(0);
+            stride_W = t.stride(1);
+        } else {
+	    stride_C = t.stride(0);
+    	    stride_H = t.stride(1);
+    	    stride_W = t.stride(2);
+        }
+        stride_N = t.size(0)*t.size(1)*t.size(2);
+    } else if (t.dim() == 4) {
+        if (explicit_nhwc) {
+            stride_N = t.stride(0);
+            stride_C = t.stride(3);
+            stride_H = t.stride(1);
+            stride_W = t.stride(2);
+        } else {
+            stride_N = t.stride(0);
+            stride_C = t.stride(1);
+            stride_H = t.stride(2);
+            stride_W = t.stride(3);
+        }
+    } else {
+        printf("%s;%d - t.dim() must be either 3 or 4 (was %d)\n",__FILE__,__LINE__,t.dim());
+        assert(t.dim() == 3 || t.dim() == 4);
+    }
+}
+
+template<class T, bool is_HWC>
+__device__ void strided_copy_kernel(
+	T* dst, const int dst_stride_C, const int dst_stride_H, const int dst_stride_W, 
+	const T* src, const int src_stride_C, const int src_stride_H, const int src_stride_W, 
+	const int NC, const int NH, const int NW
+	)
+{
+    size_t tot_num_threads = gridDim.x * blockDim.x;
+    size_t thread_id = blockIdx.x * blockDim.x + threadIdx.x;
+    const size_t count = NC*NH*NW;
+    for (size_t i = thread_id;  i < count;  i += tot_num_threads)
+    {
+	size_t c,h,w;
+	if (is_HWC) {
+	    c = i % NC;
+	    w = i / NC;
+	    h = w / NW;
+	    w = w % NW;
+	}
+	else {
+	    w = i % NW;
+	    h = i / NW;
+	    c = h / NH;
+            h = h % NH;
+	}
+	size_t dst_off = c*dst_stride_C + h*dst_stride_H + w*dst_stride_W;
+	size_t src_off = c*src_stride_C + h*src_stride_H + w*src_stride_W;
+	dst[dst_off] = src[src_off];
+    }
+}
+
+__device__ void dual_signal_wait_clear(
+	volatile int* signal1_flag, volatile int* wait1_flag,
+	volatile int* signal2_flag, volatile int* wait2_flag,
+	const int v1, const int v2, const int v3, const int v4,
+	const bool clear
+	)
+{
+    register int r1, r2, r3, r4, r5, r6, r7, r8;
+    bool is_main_thread = (blockIdx.x == 0 && threadIdx.x == 0) ? true : false;
+    // signal and wait
+    if (is_main_thread) {
+	asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(signal1_flag), "r"(v1), "r"(v2), "r"(v3), "r"(v4) : "memory");
+	asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(signal2_flag), "r"(v1), "r"(v2), "r"(v3), "r"(v4) : "memory");
+	do {
+	    asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(r1), "=r"(r2), "=r"(r3), "=r"(r4) : "l"(wait1_flag) : "memory");
+	    asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(r5), "=r"(r6), "=r"(r7), "=r"(r8) : "l"(wait2_flag) : "memory");
+	} while (r1 != v1 || r5 != v1 || r2 != v2 || r6 != v2 || r3 != v3 || r7 != v3 || r4 != v4 || r8 != v4);
+    }
+    cg::this_grid().sync();
+    // optionally clear wait flag
+    if (clear && is_main_thread) {
+	r1 = 0;  r2 = 0;  r3 = 0;  r4 = 0;
+	asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(wait1_flag), "r"(r1), "r"(r2), "r"(r3), "r"(r4) : "memory");
+	asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(wait2_flag), "r"(r1), "r"(r2), "r"(r3), "r"(r4) : "memory");
+    }
+}
+
+template<class T, bool is_HWC>
+#if __CUDA_ARCH__ >= 700
+__launch_bounds__(128, 16)
+#endif
+__global__ void push_pull_halos_1d_kernel(
+        // top halo,
+        const T* toh, int toh_stride_C, int toh_stride_H, int toh_stride_W,     // top output halo
+        T* tox, int tox_stride_C, int tox_stride_H, int tox_stride_W,           // top tx buffer
+        T* tih, int tih_stride_C, int tih_stride_H, int tih_stride_W,           // top input halo
+        // btm halo
+        const T* boh, int boh_stride_C, int boh_stride_H, int boh_stride_W,     // top output halo
+        T* box, int box_stride_C, int box_stride_H, int box_stride_W,           // top tx buffer
+        T* bih, int bih_stride_C, int bih_stride_H, int bih_stride_W,           // top input halo
+        // dimensions
+        int NC, int NH, int NW,
+        // signals
+        int* signal1_flag,
+        int* signal2_flag,
+        int* wait1_flag,
+        int* wait2_flag
+        )
+{
+    // push top output halo to transfer buffer
+    strided_copy_kernel<T,is_HWC>(tox, tox_stride_C, tox_stride_H, tox_stride_W, toh, toh_stride_C, toh_stride_H, toh_stride_W, NC, NH, NW);
+    // push btm output halo to transfer buffer
+    strided_copy_kernel<T,is_HWC>(box, box_stride_C, box_stride_H, box_stride_W, boh, boh_stride_C, boh_stride_H, boh_stride_W, NC, NH, NW);
+    // signal to top and btm neigbhbors that output halos are ready to be read
+    // the choice of values for v1-v4 is arbitrary and does not matter, as long as all ranks use the same values
+    dual_signal_wait_clear(signal1_flag, wait1_flag, signal2_flag, wait2_flag, -987751720, 840868300, -225529332, 281513358, true);
+    // pull top halo from transfer buffer in peer memory to input
+    strided_copy_kernel<T,is_HWC>(tox, tox_stride_C, tox_stride_H, tox_stride_W, tih, tih_stride_C, tih_stride_H, tih_stride_W, NC, NH, NW);
+    // pull btm halo from transfer buffer in peer memory to input
+    strided_copy_kernel<T,is_HWC>(box, box_stride_C, box_stride_H, box_stride_W, bih, bih_stride_C, bih_stride_H, bih_stride_W, NC, NH, NW);
+}
+
+}
+
+namespace apex { namespace peer_memory {
+
+int64_t allocate_raw(int64_t size)
+{
+    float* ptr = 0L;
+    cudaMalloc(&ptr, size);
+    return (int64_t)ptr;
+}
+
+void free_raw(int64_t raw)
+{
+    cudaFree((void*)raw);
+}
+
+at::Tensor get_raw_ipc_address(int64_t raw)
+{
+    cudaIpcMemHandle_t mem_handle;
+    CUDACHECK( cudaIpcGetMemHandle(&mem_handle, (void*)raw) );
+    const int n = sizeof(cudaIpcMemHandle_t);
+    auto address_tensor = torch::empty({n}, torch::dtype(torch::kUInt8));
+    auto address_tensor_p = address_tensor.data_ptr<uint8_t>();
+    memcpy(address_tensor_p, (uint8_t*)&mem_handle, n);
+    return address_tensor;
+}
+
+std::vector<int64_t> get_raw_peers(at::Tensor ipc_addresses, int peer_rank, int64_t raw)
+{
+    int peer_group_size = ipc_addresses.size(0);
+    std::vector<int64_t> results(peer_group_size);
+    for (int i = 0;  i < peer_group_size;  ++i) {
+        if (i != peer_rank) {
+            cudaIpcMemHandle_t mem_handle;
+            memcpy(&mem_handle, ipc_addresses.index({i}).data_ptr<uint8_t>(), sizeof(cudaIpcMemHandle_t));
+            void* p = 0L;
+            CUDACHECK( cudaIpcOpenMemHandle((void**)&p, mem_handle, cudaIpcMemLazyEnablePeerAccess) );
+            results[i] = (int64_t)p;
+        } else {
+            results[i] = (int64_t)raw;
+        }
+    }
+    return results;
+}
+
+at::Tensor blob_view_half(int64_t raw, std::vector<int64_t> shape)
+{
+    return blob_view<at::Half>((at::Half*)raw, shape, torch::dtype(torch::kFloat16).device(torch::kCUDA));
+}
+
+at::Tensor blob_view_float(int64_t raw, std::vector<int64_t> shape)
+{
+    return blob_view<float>((float*)raw, shape, torch::dtype(torch::kFloat16).device(torch::kCUDA));
+}
+
+at::Tensor blob_view_int(int64_t raw, std::vector<int64_t> shape)
+{
+    return blob_view<int>((int*)raw, shape, torch::dtype(torch::kFloat16).device(torch::kCUDA));
+}
+
+void push_pull_halos_1d(
+        bool explicit_nhwc,
+        int numSM,                      // number of SMs to use
+        at::Tensor top_out_halo,        // top output halo in sender device memory
+        at::Tensor top_out_tx,          // top output transfer buffer in sender peer pool memory
+        at::Tensor top_inp_halo,        // top input halo in receiver device memory
+        at::Tensor btm_out_halo,        // btm output halo in sender device memory
+        at::Tensor btm_out_tx,          // btm output transfer buffer in sender peer pool memory
+        at::Tensor btm_inp_halo,        // btm input halo in receiver device memory
+        at::Tensor top_signal,          // top input signal in receiver device memory
+        at::Tensor btm_signal,          // btm input signal in receiver device memory
+        at::Tensor waits                // top and btm signals for this rank
+        )
+{
+    // basic checks of inputs
+    TORCH_CHECK(top_out_halo.is_cuda());
+    TORCH_CHECK(top_out_tx.is_cuda());
+    TORCH_CHECK(top_inp_halo.is_cuda());
+    TORCH_CHECK(btm_out_halo.is_cuda());
+    TORCH_CHECK(btm_out_tx.is_cuda());
+    TORCH_CHECK(btm_inp_halo.is_cuda());
+    TORCH_CHECK(top_signal.is_cuda());
+    TORCH_CHECK(btm_signal.is_cuda());
+    TORCH_CHECK(waits.is_cuda());
+
+    // shapes and strides
+    int toh_N, toh_C, toh_H, toh_W;
+    tensor_shape(top_out_halo, explicit_nhwc, toh_N, toh_C, toh_H, toh_W);
+    int tox_N, tox_C, tox_H, tox_W;
+    tensor_shape(top_out_tx, explicit_nhwc, tox_N, tox_C, tox_H, tox_W);
+    int tih_N, tih_C, tih_H, tih_W;
+    tensor_shape(top_inp_halo, explicit_nhwc, tih_N, tih_C, tih_H, tih_W);
+    TORCH_CHECK(
+            (toh_N == tox_N && tox_N == tih_N) &&
+            (toh_C == tox_C && tox_C == tih_C) &&
+            (toh_H == tox_H && tox_H == tih_H) &&
+            (toh_W == tox_W && tox_W == tih_W));
+    int boh_N, boh_C, boh_H, boh_W;
+    tensor_shape(btm_out_halo, explicit_nhwc, boh_N, boh_C, boh_H, boh_W);
+    int box_N, box_C, box_H, box_W;
+    tensor_shape(btm_out_tx, explicit_nhwc, box_N, box_C, box_H, box_W);
+    int bih_N, bih_C, bih_H, bih_W;
+    tensor_shape(btm_inp_halo, explicit_nhwc, bih_N, bih_C, bih_H, bih_W);
+    TORCH_CHECK(
+            (boh_N == box_N && box_N == bih_N) &&
+            (boh_C == box_C && box_C == bih_C) &&
+            (boh_H == box_H && box_H == bih_H) &&
+            (boh_W == box_W && box_W == bih_W));
+    TORCH_CHECK(
+	    (toh_N == boh_N) &&
+	    (toh_C == boh_C) &&
+	    (toh_H == boh_H) &&
+	    (toh_W == boh_W));
+    int NC=toh_C, NH=toh_H, NW=toh_W;
+
+    int toh_stride_N, toh_stride_C, toh_stride_H, toh_stride_W;
+    tensor_strides(top_out_halo, explicit_nhwc, toh_stride_N, toh_stride_C, toh_stride_H, toh_stride_W);
+    int tox_stride_N, tox_stride_C, tox_stride_H, tox_stride_W;
+    tensor_strides(top_out_tx, explicit_nhwc, tox_stride_N, tox_stride_C, tox_stride_H, tox_stride_W);
+    int tih_stride_N, tih_stride_C, tih_stride_H, tih_stride_W;
+    tensor_strides(top_inp_halo, explicit_nhwc, tih_stride_N, tih_stride_C, tih_stride_H, tih_stride_W);
+    int boh_stride_N, boh_stride_C, boh_stride_H, boh_stride_W;
+    tensor_strides(btm_out_halo, explicit_nhwc, boh_stride_N, boh_stride_C, boh_stride_H, boh_stride_W);
+    int box_stride_N, box_stride_C, box_stride_H, box_stride_W;
+    tensor_strides(btm_out_tx, explicit_nhwc, box_stride_N, box_stride_C, box_stride_H, box_stride_W);
+    int bih_stride_N, bih_stride_C, bih_stride_H, bih_stride_W;
+    tensor_strides(btm_inp_halo, explicit_nhwc, bih_stride_N, bih_stride_C, bih_stride_H, bih_stride_W);
+
+    // determine if nhwc
+    auto is_nhwc = (toh_stride_C == 1) ? true : false;
+
+    // figure out launch parameters
+    int device;
+    cudaGetDevice(&device);
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, device);
+    assert(numSM > 0 && numSM <= prop.multiProcessorCount);
+    auto current_stream = at::cuda::getCurrentCUDAStream();
+    const int numThreads = 128;
+    dim3 block(numThreads,1,1);
+    AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, top_out_halo.scalar_type(), "push_pull_halos_1d_kernel", [&]{
+            scalar_t* toh_p = top_out_halo.data_ptr<scalar_t>();
+            scalar_t* tox_p = top_out_tx.data_ptr<scalar_t>();
+            scalar_t* tih_p = top_inp_halo.data_ptr<scalar_t>();
+            scalar_t* boh_p = btm_out_halo.data_ptr<scalar_t>();
+            scalar_t* box_p = btm_out_tx.data_ptr<scalar_t>();
+            scalar_t* bih_p = btm_inp_halo.data_ptr<scalar_t>();
+	    int* top_signal_p = top_signal.data_ptr<int>();
+	    int* btm_signal_p = btm_signal.data_ptr<int>() + 4;
+	    int* top_wait_p = waits.data_ptr<int>();
+	    int* btm_wait_p = waits.data_ptr<int>() + 4;
+
+            // do int4 vector loads if channel count permits
+            int elem_size_in_bytes = toh_C * sizeof(scalar_t);
+            int elem_size_in_int4 = (elem_size_in_bytes / 16);
+            if (is_nhwc && elem_size_in_int4*16 == elem_size_in_bytes) {
+                // can do int4 transfers
+	        int divisor = elem_size_in_bytes / elem_size_in_int4;
+		toh_stride_N /= divisor;   toh_stride_H /= divisor;    toh_stride_W /= divisor;
+		tox_stride_N /= divisor;   tox_stride_H /= divisor;    tox_stride_W /= divisor;
+		tih_stride_N /= divisor;   tih_stride_H /= divisor;    tih_stride_W /= divisor;
+		boh_stride_N /= divisor;   boh_stride_H /= divisor;    boh_stride_W /= divisor;
+		box_stride_N /= divisor;   box_stride_H /= divisor;    box_stride_W /= divisor;
+		bih_stride_N /= divisor;   bih_stride_H /= divisor;    bih_stride_W /= divisor;
+		void *kernelArgs[] = {
+		    (int4**)&toh_p, &toh_stride_C, &toh_stride_H, &toh_stride_W,
+		    (int4**)&tox_p, &tox_stride_C, &tox_stride_H, &tox_stride_W,
+		    (int4**)&tih_p, &tih_stride_C, &tih_stride_H, &tih_stride_W,
+		    (int4**)&boh_p, &boh_stride_C, &boh_stride_H, &boh_stride_W,
+		    (int4**)&box_p, &box_stride_C, &box_stride_H, &box_stride_W,
+		    (int4**)&bih_p, &bih_stride_C, &bih_stride_H, &bih_stride_W,
+		    &NC, &NH, &NW,
+		    &top_signal_p, &btm_signal_p, &top_wait_p, &btm_wait_p
+		};
+            	int numBlocksPerSm;
+	        cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSm, push_pull_halos_1d_kernel<int4,true>, numThreads, 0);
+	        dim3 grid(numSM*numBlocksPerSm,1,1);
+	        cudaLaunchCooperativeKernel((void*)push_pull_halos_1d_kernel<int4,true>, grid, block, kernelArgs, 0, current_stream);
+            } else {
+                // cannot do int4 transfers
+		void *kernelArgs[] = {
+		    &toh_p, &toh_stride_C, &toh_stride_H, &toh_stride_W,
+		    &tox_p, &tox_stride_C, &tox_stride_H, &tox_stride_W,
+		    &tih_p, &tih_stride_C, &tih_stride_H, &tih_stride_W,
+		    &boh_p, &boh_stride_C, &boh_stride_H, &boh_stride_W,
+		    &box_p, &box_stride_C, &box_stride_H, &box_stride_W,
+		    &bih_p, &bih_stride_C, &bih_stride_H, &bih_stride_W,
+		    &NC, &NH, &NW,
+		    &top_signal_p, &btm_signal_p, &top_wait_p, &btm_wait_p
+		};
+                int numBlocksPerSm;
+                if (is_nhwc) {
+	            cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSm, push_pull_halos_1d_kernel<scalar_t,true>, numThreads, 0);
+	            dim3 grid(numSM*numBlocksPerSm,1,1);
+	            cudaLaunchCooperativeKernel((void*)push_pull_halos_1d_kernel<scalar_t,true>, grid, block, kernelArgs, 0, current_stream);
+                } else {
+	            cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSm, push_pull_halos_1d_kernel<scalar_t,false>, numThreads, 0);
+	            dim3 grid(numSM*numBlocksPerSm,1,1);
+	            cudaLaunchCooperativeKernel((void*)push_pull_halos_1d_kernel<scalar_t,false>, grid, block, kernelArgs, 0, current_stream);
+                }
+	    }
+        } );
+}
+
+} }
+

--- a/apex/contrib/csrc/peer_memory/peer_memory_cuda.cuh
+++ b/apex/contrib/csrc/peer_memory/peer_memory_cuda.cuh
@@ -19,7 +19,7 @@
 #ifndef _peer_memory_h_
 #define _peer_memory_h_ 
 
-namespace apex { namespace peer_memory {
+namespace apex { namespace contrib { namespace peer_memory {
     int64_t allocate_raw(int64_t size);
     void free_raw(int64_t raw);
     at::Tensor get_raw_ipc_address(int64_t raw);
@@ -43,5 +43,5 @@ namespace apex { namespace peer_memory {
         at::Tensor btm_signal,          // btm input signal in receiver device memory
         at::Tensor waits                // top and btm signals for this rank
         );
-} }
+} } }
 #endif

--- a/apex/contrib/csrc/peer_memory/peer_memory_cuda.cuh
+++ b/apex/contrib/csrc/peer_memory/peer_memory_cuda.cuh
@@ -24,17 +24,20 @@ namespace apex { namespace peer_memory {
     void free_raw(int64_t raw);
     at::Tensor get_raw_ipc_address(int64_t raw);
     std::vector<int64_t> get_raw_peers(at::Tensor ipc_addresses, int peer_rank, int64_t raw);
-    at::Tensor blob_view_half(int64_t raw, std::vector<int64_t> shape);
-    at::Tensor blob_view_float(int64_t raw, std::vector<int64_t> shape);
-    at::Tensor blob_view_int(int64_t raw, std::vector<int64_t> shape);
+    at::Tensor blob_view_half(int64_t raw, std::vector<int64_t> shape, bool channels_last);
+    at::Tensor blob_view_float(int64_t raw, std::vector<int64_t> shape, bool channels_last);
+    at::Tensor blob_view_int(int64_t raw, std::vector<int64_t> shape, bool channels_last);
     void push_pull_halos_1d(
+        bool diagnostics,
         bool explicit_nhwc,
         int numSM,                      // number of SMs to use
         at::Tensor top_out_halo,        // top output halo in sender device memory
         at::Tensor top_out_tx,          // top output transfer buffer in sender peer pool memory
+	at::Tensor top_inp_tx,		// top input transfer buffer in top neighbor peer pool memory
         at::Tensor top_inp_halo,        // top input halo in receiver device memory
         at::Tensor btm_out_halo,        // btm output halo in sender device memory
         at::Tensor btm_out_tx,          // btm output transfer buffer in sender peer pool memory
+	at::Tensor btm_inp_tx,		// btm input transfer buffer in btm neighbor peer pool memory
         at::Tensor btm_inp_halo,        // btm input halo in receiver device memory
         at::Tensor top_signal,          // top input signal in receiver device memory
         at::Tensor btm_signal,          // btm input signal in receiver device memory

--- a/apex/contrib/csrc/peer_memory/peer_memory_cuda.cuh
+++ b/apex/contrib/csrc/peer_memory/peer_memory_cuda.cuh
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <torch/extension.h>
+#ifndef _peer_memory_h_
+#define _peer_memory_h_ 
+
+namespace apex { namespace peer_memory {
+    int64_t allocate_raw(int64_t size);
+    void free_raw(int64_t raw);
+    at::Tensor get_raw_ipc_address(int64_t raw);
+    std::vector<int64_t> get_raw_peers(at::Tensor ipc_addresses, int peer_rank, int64_t raw);
+    at::Tensor blob_view_half(int64_t raw, std::vector<int64_t> shape);
+    at::Tensor blob_view_float(int64_t raw, std::vector<int64_t> shape);
+    at::Tensor blob_view_int(int64_t raw, std::vector<int64_t> shape);
+    void push_pull_halos_1d(
+        bool explicit_nhwc,
+        int numSM,                      // number of SMs to use
+        at::Tensor top_out_halo,        // top output halo in sender device memory
+        at::Tensor top_out_tx,          // top output transfer buffer in sender peer pool memory
+        at::Tensor top_inp_halo,        // top input halo in receiver device memory
+        at::Tensor btm_out_halo,        // btm output halo in sender device memory
+        at::Tensor btm_out_tx,          // btm output transfer buffer in sender peer pool memory
+        at::Tensor btm_inp_halo,        // btm input halo in receiver device memory
+        at::Tensor top_signal,          // top input signal in receiver device memory
+        at::Tensor btm_signal,          // btm input signal in receiver device memory
+        at::Tensor waits                // top and btm signals for this rank
+        );
+} }
+#endif

--- a/apex/contrib/csrc/peer_memory/peer_memory_cuda.cuh
+++ b/apex/contrib/csrc/peer_memory/peer_memory_cuda.cuh
@@ -22,6 +22,7 @@
 namespace apex { namespace contrib { namespace peer_memory {
     int64_t allocate_raw(int64_t size);
     void free_raw(int64_t raw);
+    void zero(int64_t raw, int64_t size);
     at::Tensor get_raw_ipc_address(int64_t raw);
     std::vector<int64_t> get_raw_peers(at::Tensor ipc_addresses, int peer_rank, int64_t raw);
     at::Tensor blob_view_half(int64_t raw, std::vector<int64_t> shape, bool channels_last);

--- a/apex/contrib/peer_memory/__init__.py
+++ b/apex/contrib/peer_memory/__init__.py
@@ -1,0 +1,1 @@
+from .peer_memory import PeerMemoryPool

--- a/apex/contrib/peer_memory/__init__.py
+++ b/apex/contrib/peer_memory/__init__.py
@@ -1,1 +1,2 @@
 from .peer_memory import PeerMemoryPool
+from .peer_halo_exchanger_1d import PeerHaloExchanger1d

--- a/apex/contrib/peer_memory/peer_halo_exchange_module_tests.py
+++ b/apex/contrib/peer_memory/peer_halo_exchange_module_tests.py
@@ -1,6 +1,6 @@
 import torch
 from apex.contrib.peer_memory import PeerMemoryPool, PeerHaloExchanger1d
-import peer_memory as pm
+import peer_memory_cuda as pm
 
 # How to run:
 # torchrun --nproc_per_node <num-GPU> <this-python-prog>

--- a/apex/contrib/peer_memory/peer_halo_exchange_module_tests.py
+++ b/apex/contrib/peer_memory/peer_halo_exchange_module_tests.py
@@ -134,7 +134,7 @@ def main():
     halo_ex = PeerHaloExchanger1d(rank, world_size, pool, half_halo)
 
     H_split_tests(1,64,336,200, half_halo,rank,world_size,halo_ex)
-    W_split_tests(1,64,200,336, half_halo,world_size,halo_ex)
+    W_split_tests(1,64,200,336, half_halo,rank,world_size,halo_ex)
 
 
 if __name__ == "__main__":

--- a/apex/contrib/peer_memory/peer_halo_exchange_module_tests.py
+++ b/apex/contrib/peer_memory/peer_halo_exchange_module_tests.py
@@ -1,0 +1,196 @@
+import torch
+from apex.contrib.peer_memory import PeerMemoryPool
+import peer_memory as pm
+
+
+class HaloExchangerPeerMemory:
+    def __init__(self, rank, peer_group_size, peer_pool):
+        self.peer_group_size = peer_group_size
+        self.peer_rank = rank % peer_group_size
+        self.peer_pool = peer_pool
+        self.signals = peer_pool.allocate_peer_tensors([2,4], torch.int32, False, False)
+        self.signals[self.peer_rank].zero_()
+
+    def __call__(self, y, half_halo, H_split=True, explicit_nhwc=False, numSM=1):
+        channels_last = y.is_contiguous(memory_format=torch.channels_last)
+        if H_split:
+            if explicit_nhwc:
+                _, Hs, _, _ = list(y.shape)
+                H = Hs - 2*half_halo
+                top_out_halo = y[:,half_halo:2*half_halo,:,:]
+                top_tx = self.peer_pool.allocate_peer_tensors(list(top_out_halo.shape), top_out_halo.dtype, False, True)
+                top_inp_halo = y[:,:half_halo,:,:]
+                btm_out_halo = y[:,H:H+half_halo,:,:]
+                btm_tx = self.peer_pool.allocate_peer_tensors(list(btm_out_halo.shape), btm_out_halo.dtype, False, True)
+                btm_inp_halo = y[:,H+half_halo:H+2*half_halo,:,:]
+            else:
+                _, _, Hs, _ = list(y.shape)
+                H = Hs - 2*half_halo
+                top_out_halo = y[:,:,half_halo:2*half_halo,:]
+                top_tx = self.peer_pool.allocate_peer_tensors(list(top_out_halo.shape), top_out_halo.dtype, channels_last, True)
+                top_inp_halo = y[:,:,:half_halo,:]
+                btm_out_halo = y[:,:,H:H+half_halo,:]
+                btm_tx = self.peer_pool.allocate_peer_tensors(list(btm_out_halo.shape), btm_out_halo.dtype, channels_last, True)
+                btm_inp_halo = y[:,:,H+half_halo:H+2*half_halo,:]
+        else:
+            if explicit_nhwc:
+                _, _, Ws, _ = list(y.shape)
+                W = Ws - 2*half_halo
+                top_out_halo = y[:,:,half_halo:2*half_halo,:]
+                top_tx = self.peer_pool.allocate_peer_tensors(list(top_out_halo.shape), top_out_halo.dtype, False, True)
+                top_inp_halo = y[:,:,:half_halo,:]
+                btm_out_halo = y[:,:,W:W+half_halo,:]
+                btm_tx = self.peer_pool.allocate_peer_tensors(list(btm_out_halo.shape), btm_out_halo.dtype, False, True)
+                btm_inp_halo = y[:,:,W+half_halo:W+2*half_halo,:]
+            else:
+                _, _, _, Ws = list(y.shape)
+                W = Ws - 2*half_halo
+                top_out_halo = y[:,:,:,half_halo:2*half_halo]
+                top_tx = self.peer_pool.allocate_peer_tensors(list(top_out_halo.shape), top_out_halo.dtype, channels_last, True)
+                top_inp_halo = y[:,:,:,:half_halo]
+                btm_out_halo = y[:,:,:,W:W+half_halo]
+                btm_tx = self.peer_pool.allocate_peer_tensors(list(btm_out_halo.shape), btm_out_halo.dtype, channels_last, True)
+                btm_inp_halo = y[:,:,:,W+half_halo:W+2*half_halo]
+        top_neighbor = (self.peer_rank + self.peer_group_size - 1) % self.peer_group_size
+        btm_neighbor = (self.peer_rank + 1) % self.peer_group_size
+        pm.push_pull_halos_1d(
+                False, #True if self.peer_rank == 0 else False,
+                explicit_nhwc, numSM,
+                top_out_halo, top_tx[self.peer_rank], btm_tx[top_neighbor], top_inp_halo, 
+                btm_out_halo, btm_tx[self.peer_rank], top_tx[btm_neighbor], btm_inp_halo,
+                self.signals[top_neighbor], self.signals[btm_neighbor], self.signals[self.peer_rank]
+                )
+
+
+def nccl_halo_ex(peer_rank, peer_group_size, y, half_halo, explicit_nhwc, H_split):
+    if explicit_nhwc:
+        if H_split:
+            _, Hp, _, _ = list(y.shape)
+            H = Hp - 2*half_halo
+            top_out_halo = y[:,half_halo:2*half_halo,:,:]
+            top_inp_halo = y[:,:half_halo,:,:]
+            btm_out_halo = y[:,H:H+half_halo,:,:]
+            btm_inp_halo = y[:,H+half_halo:H+2*half_halo,:,:]
+        else:
+            _, _, Wp, _ = list(y.shape)
+            W = Wp - 2*half_halo
+            top_out_halo = y[:,:,half_halo:2*half_halo,:]
+            top_inp_halo = y[:,:,:half_halo,:]
+            btm_out_halo = y[:,:,W:W+half_halo,:]
+            btm_inp_halo = y[:,:,W+half_halo:W+2*half_halo,:]
+    else:
+        if H_split:
+            _, _, Hp, _ = list(y.shape)
+            H = Hp - 2*half_halo
+            top_out_halo = y[:,:,half_halo:2*half_halo,:]
+            top_inp_halo = y[:,:,:half_halo,:]
+            btm_out_halo = y[:,:,H:H+half_halo,:]
+            btm_inp_halo = y[:,:,H+half_halo:H+2*half_halo,:]
+        else:
+            _, _, _, Wp = list(y.shape)
+            W = Wp - 2*half_halo
+            top_out_halo = y[:,:,:,half_halo:2*half_halo]
+            top_inp_halo = y[:,:,:,:half_halo]
+            btm_out_halo = y[:,:,:,W:W+half_halo]
+            btm_inp_halo = y[:,:,:,W+half_halo:W+2*half_halo]
+
+    top_out_halo = top_out_halo.clone(memory_format=torch.preserve_format)
+    btm_out_halo = btm_out_halo.clone(memory_format=torch.preserve_format)
+
+    top_inp_halos = [torch.empty_like(top_out_halo) for _ in range(peer_group_size)]
+    torch.distributed.all_gather(top_inp_halos, top_out_halo)
+    btm_inp_halos = [torch.empty_like(btm_out_halo) for _ in range(peer_group_size)]
+    torch.distributed.all_gather(btm_inp_halos, btm_out_halo)
+    top_rank = (peer_rank + peer_group_size - 1) % peer_group_size
+    btm_rank = (peer_rank + 1) % peer_group_size
+    top_inp_halo.copy_(btm_inp_halos[top_rank])
+    btm_inp_halo.copy_(top_inp_halos[btm_rank])
+
+
+def single_test(peer_rank, peer_group_size, halo_ex, C, H, W, half_halo, dtype, memory_format, H_split, numSM=1):
+    if memory_format == 1:
+        # 1 -> explicit nhwc
+        explicit_nhwc = True
+        if H_split:
+            y = torch.randn([1,H+2*half_halo,W,C], dtype=dtype, device='cuda')
+            ym = y[:,half_halo:H+half_halo,:,:]
+        else:
+            y = torch.randn([1,H,W+2*half_halo,C], dtype=dtype, device='cuda')
+            ym = y[:,:,half_halo:W+half_halo,:]
+    else:
+        # 2 -> native nhwc
+        # 3 -> nchw
+        explicit_nhwc = False
+        if H_split:
+            y = torch.randn([1,C,H+2*half_halo,W], dtype=dtype, device='cuda')
+            if memory_format == 2:
+                y = y.to(memory_format=torch.channels_last)
+            ym = y[:,:,half_halo:H+half_halo,:]
+        else:
+            y = torch.randn([1,C,H,W+2*half_halo], dtype=dtype, device='cuda')
+            if memory_format == 2:
+                y = y.to(memory_format=torch.channels_last)
+            ym = y[:,:,:,half_halo:W+half_halo]
+    y2 = y.clone()
+    halo_ex(y, half_halo, H_split, explicit_nhwc, numSM)
+    nccl_halo_ex(peer_rank, peer_group_size, y2, half_halo, explicit_nhwc, H_split)
+    is_equal = torch.all(torch.eq(y,y2))
+    if peer_rank == 0:
+        if memory_format == 1:
+            memory_format_str = "explicit_nhwc"
+        elif memory_format == 2:
+            memory_format_str = "native nhwc"
+        elif memory_format == 3:
+            memory_format_str = "nchw"
+        else:
+            memory_format_str = "???"
+        if is_equal:
+            print("SUCCESS : N,C,H,W = 1,%d,%d,%d, half_halo=%d, %s, %s, %s" % (C,H,W,half_halo,str(dtype),memory_format_str,"H-split" if H_split else "W-split"))
+        else:
+            print("FAILURE : N,C,H,W = 1,%d,%d,%d, half_halo=%d, %s, %s, %s" % (C,H,W,half_halo,str(dtype),memory_format_str,"H-split" if H_split else "W-split"))
+
+    # peer memory flag sync relies on there being at least one barrier per step
+    torch.distributed.barrier()
+
+
+def H_split_tests(N, C, H, W, half_halo, rank, world_size, halo_ex):
+    Hr = 8*world_size
+    Hp = ((H + Hr - 1) // Hr) * 8
+
+    for i in range(4):
+        div = int(pow(2,i))
+        single_test(rank, world_size, halo_ex, C*div, Hp//div, W//div, half_halo, torch.float16, 1, True)
+        single_test(rank, world_size, halo_ex, C*div, Hp//div, W//div, half_halo, torch.float16, 2, True)
+        single_test(rank, world_size, halo_ex, C*div, Hp//div, W//div, half_halo, torch.float16, 3, True)
+
+
+def W_split_tests(N, C, H, W, half_halo, rank, world_size, halo_ex):
+    Wr = 8*world_size
+    Wp = ((W + Wr - 1) // Wr) * 8
+
+    for i in range(4):
+        div = int(pow(2,i))
+        single_test(rank, world_size, halo_ex, C*div, H//div, Wp//div, half_halo, torch.float16, 1, False)
+        single_test(rank, world_size, halo_ex, C*div, H//div, Wp//div, half_halo, torch.float16, 2, False)
+        single_test(rank, world_size, halo_ex, C*div, H//div, Wp//div, half_halo, torch.float16, 3, False)
+
+
+def main():
+    # for this trivial example peer_rank == rank and peer_group_size == world_size
+
+    torch.distributed.init_process_group("nccl")
+    rank = torch.distributed.get_rank()
+    world_size = torch.distributed.get_world_size()
+    torch.cuda.set_device(rank)
+    pool = PeerMemoryPool(rank, world_size, world_size, 64*1024, 2*1024*1024)
+
+    halo_ex = HaloExchangerPeerMemory(rank, world_size, pool)
+
+    half_halo = 1
+
+    H_split_tests(1,64,336,200, half_halo,rank,world_size,halo_ex)
+    W_split_tests(1,64,200,336, half_halo,rank,world_size,halo_ex)
+
+
+if __name__ == "__main__":
+    main()

--- a/apex/contrib/peer_memory/peer_halo_exchanger_1d.py
+++ b/apex/contrib/peer_memory/peer_halo_exchanger_1d.py
@@ -1,6 +1,6 @@
 import torch
 from apex.contrib.peer_memory import PeerMemoryPool
-import peer_memory as pm
+import peer_memory_cuda as pm
 
 class PeerHaloExchanger1d:
     def __init__(self, rank, peer_group_size, peer_pool, half_halo):

--- a/apex/contrib/peer_memory/peer_halo_exchanger_1d.py
+++ b/apex/contrib/peer_memory/peer_halo_exchanger_1d.py
@@ -1,0 +1,61 @@
+import torch
+from apex.contrib.peer_memory import PeerMemoryPool
+import peer_memory as pm
+
+class PeerHaloExchanger1d:
+    def __init__(self, rank, peer_group_size, peer_pool, half_halo):
+        self.peer_group_size = peer_group_size
+        self.peer_rank = rank % peer_group_size
+        self.peer_pool = peer_pool
+        self.signals = peer_pool.allocate_peer_tensors([2,4], torch.int32, False, False)
+        self.signals[self.peer_rank].zero_()
+        self.half_halo = half_halo
+
+    def __call__(self, y, H_split=True, explicit_nhwc=False, numSM=1, diagnostics=False):
+        channels_last = y.is_contiguous(memory_format=torch.channels_last) and not explicit_nhwc
+        if H_split:
+            if explicit_nhwc:
+                _, Hs, _, _ = list(y.shape)
+                H = Hs - 2*self.half_halo
+                top_out_halo = y[:,self.half_halo:2*self.half_halo,:,:]
+                top_tx = self.peer_pool.allocate_peer_tensors(list(top_out_halo.shape), top_out_halo.dtype, False, True)
+                top_inp_halo = y[:,:self.half_halo,:,:]
+                btm_out_halo = y[:,H:H+self.half_halo,:,:]
+                btm_tx = self.peer_pool.allocate_peer_tensors(list(btm_out_halo.shape), btm_out_halo.dtype, False, True)
+                btm_inp_halo = y[:,H+self.half_halo:H+2*self.half_halo,:,:]
+            else:
+                _, _, Hs, _ = list(y.shape)
+                H = Hs - 2*self.half_halo
+                top_out_halo = y[:,:,self.half_halo:2*self.half_halo,:]
+                top_tx = self.peer_pool.allocate_peer_tensors(list(top_out_halo.shape), top_out_halo.dtype, channels_last, True)
+                top_inp_halo = y[:,:,:self.half_halo,:]
+                btm_out_halo = y[:,:,H:H+self.half_halo,:]
+                btm_tx = self.peer_pool.allocate_peer_tensors(list(btm_out_halo.shape), btm_out_halo.dtype, channels_last, True)
+                btm_inp_halo = y[:,:,H+self.half_halo:H+2*self.half_halo,:]
+        else:
+            if explicit_nhwc:
+                _, _, Ws, _ = list(y.shape)
+                W = Ws - 2*self.half_halo
+                top_out_halo = y[:,:,self.half_halo:2*self.half_halo,:]
+                top_tx = self.peer_pool.allocate_peer_tensors(list(top_out_halo.shape), top_out_halo.dtype, False, True)
+                top_inp_halo = y[:,:,:self.half_halo,:]
+                btm_out_halo = y[:,:,W:W+self.half_halo,:]
+                btm_tx = self.peer_pool.allocate_peer_tensors(list(btm_out_halo.shape), btm_out_halo.dtype, False, True)
+                btm_inp_halo = y[:,:,W+self.half_halo:W+2*self.half_halo,:]
+            else:
+                _, _, _, Ws = list(y.shape)
+                W = Ws - 2*self.half_halo
+                top_out_halo = y[:,:,:,self.half_halo:2*self.half_halo]
+                top_tx = self.peer_pool.allocate_peer_tensors(list(top_out_halo.shape), top_out_halo.dtype, channels_last, True)
+                top_inp_halo = y[:,:,:,:self.half_halo]
+                btm_out_halo = y[:,:,:,W:W+self.half_halo]
+                btm_tx = self.peer_pool.allocate_peer_tensors(list(btm_out_halo.shape), btm_out_halo.dtype, channels_last, True)
+                btm_inp_halo = y[:,:,:,W+self.half_halo:W+2*self.half_halo]
+        top_neighbor = (self.peer_rank + self.peer_group_size - 1) % self.peer_group_size
+        btm_neighbor = (self.peer_rank + 1) % self.peer_group_size
+        pm.push_pull_halos_1d(
+                diagnostics, explicit_nhwc, numSM,
+                top_out_halo, top_tx[self.peer_rank], btm_tx[top_neighbor], top_inp_halo, 
+                btm_out_halo, btm_tx[self.peer_rank], top_tx[btm_neighbor], btm_inp_halo,
+                self.signals[top_neighbor], self.signals[btm_neighbor], self.signals[self.peer_rank]
+                )

--- a/apex/contrib/peer_memory/peer_memory.py
+++ b/apex/contrib/peer_memory/peer_memory.py
@@ -1,0 +1,50 @@
+import torch
+import numpy as np
+import peer_memory
+
+class PeerMemoryPool(object):
+
+    def __init__(self, rank, world_size, peer_group_size, size):
+        self.peer_group = rank // peer_group_size
+        self.peer_rank = rank % peer_group_size
+        self.peer_group_size = peer_group_size
+        self.alignment = 256
+        self.size = size
+        # allocate giant pool of device memory
+        self.raw = allocate_raw(size)
+        # exchange peer pointers with nccl
+        raw_ipc = get_raw_ipc_address(self.raw).cuda()
+        peer_raw_ipcs = [torch.empty_like(raw_ipc) for _ in range(world_size)]
+        torch.distributed.all_gather(peer_raw_ipcs, raw_ipc)
+        peer_raw_ipcs = torch.stack(peer_raw_ipcs).cpu()
+        self.peer_raw = get_raw_peers(peer_raw_ipcs, self.peer_rank, self.raw)
+        self.current = 0
+
+    def __del__(self):
+        free_raw(self.raw)
+
+    def reset(self):
+        self.current = 0
+
+    def allocate_peer_tensors(self, shape, dtype):
+        nels = np.prod(shape)
+        if dtype == torch.float16:
+            elem_size = 2
+            start = ((self.current + self.alignment - 1) // self.alignment) * self.alignment
+            self.current = start + nels * elem_size
+            assert(self.current < self.size), "Peer memory pool exhausted"
+            return [blob_view_half(pr + start, shape) for pr in self.peer_raw]
+        elif dtype == torch.float32:
+            elem_size = 4
+            start = ((self.current + self.alignment - 1) // self.alignment) * self.alignment
+            self.current = start + nels * elem_size
+            assert(self.current < self.size), "Peer memory pool exhausted"
+            return [blob_view_float(pr + start, shape) for pr in self.peer_raw]
+        elif dtype == torch.int32:
+            elem_size = 4
+            start = ((self.current + self.alignment - 1) // self.alignment) * self.alignment
+            self.current = start + nels * elem_size
+            assert(self.current < self.size), "Peer memory pool exhausted"
+            return [blob_view_int(pr + start, shape) for pr in self.peer_raw]
+        else:
+            assert(False), "Unknown dtype : %s" % (str(dtype))

--- a/apex/contrib/peer_memory/peer_memory.py
+++ b/apex/contrib/peer_memory/peer_memory.py
@@ -1,6 +1,6 @@
 import torch
 import numpy as np
-import peer_memory as pm
+import peer_memory_cuda as pm
 
 class PeerMemoryPool(object):
 

--- a/apex/contrib/peer_memory/peer_memory.py
+++ b/apex/contrib/peer_memory/peer_memory.py
@@ -1,50 +1,70 @@
 import torch
 import numpy as np
-import peer_memory
+import peer_memory as pm
 
 class PeerMemoryPool(object):
 
-    def __init__(self, rank, world_size, peer_group_size, size):
+    def __init__(self, rank, world_size, peer_group_size, static_size, dynamic_size):
         self.peer_group = rank // peer_group_size
         self.peer_rank = rank % peer_group_size
         self.peer_group_size = peer_group_size
         self.alignment = 256
-        self.size = size
+        self.static_size = ((static_size + self.alignment - 1) // self.alignment) * self.alignment
+        self.dynamic_size = ((dynamic_size + self.alignment - 1) // self.alignment) * self.alignment
         # allocate giant pool of device memory
-        self.raw = allocate_raw(size)
+        self.raw = pm.allocate_raw(self.static_size+self.dynamic_size)
         # exchange peer pointers with nccl
-        raw_ipc = get_raw_ipc_address(self.raw).cuda()
+        raw_ipc = pm.get_raw_ipc_address(self.raw).cuda()
         peer_raw_ipcs = [torch.empty_like(raw_ipc) for _ in range(world_size)]
         torch.distributed.all_gather(peer_raw_ipcs, raw_ipc)
         peer_raw_ipcs = torch.stack(peer_raw_ipcs).cpu()
-        self.peer_raw = get_raw_peers(peer_raw_ipcs, self.peer_rank, self.raw)
-        self.current = 0
+        self.peer_raw = pm.get_raw_peers(peer_raw_ipcs, self.peer_rank, self.raw)
+        self.static_offset = 0
+        self.dynamic_offset = 0
 
     def __del__(self):
-        free_raw(self.raw)
+        pm.free_raw(self.raw)
 
     def reset(self):
-        self.current = 0
+        self.dynamic_offset = 0
 
-    def allocate_peer_tensors(self, shape, dtype):
+    def allocate_peer_tensors(self, shape, dtype, channels_last, dynamic):
         nels = np.prod(shape)
         if dtype == torch.float16:
             elem_size = 2
-            start = ((self.current + self.alignment - 1) // self.alignment) * self.alignment
-            self.current = start + nels * elem_size
-            assert(self.current < self.size), "Peer memory pool exhausted"
-            return [blob_view_half(pr + start, shape) for pr in self.peer_raw]
-        elif dtype == torch.float32:
+            if dynamic:
+                start = ((self.dynamic_offset + self.alignment - 1) // self.alignment) * self.alignment
+                self.dynamic_offset =  start + nels * elem_size
+                assert(self.dynamic_offset < self.dynamic_size), "Dynamic peer memory pool exhausted"
+                return [pm.blob_view_half(pr + self.static_size + start, shape, channels_last) for pr in self.peer_raw]
+            else:
+                start = ((self.static_offset + self.alignment - 1) // self.alignment) * self.alignment
+                self.static_offset = start + nels * elem_size
+                assert(self.static_offset < self.static_size), "Static peer memory pool exhausted"
+                return [pm.blob_view_half(pr + start, shape, channels_last) for pr in self.peer_raw]
+        if dtype == torch.float32:
             elem_size = 4
-            start = ((self.current + self.alignment - 1) // self.alignment) * self.alignment
-            self.current = start + nels * elem_size
-            assert(self.current < self.size), "Peer memory pool exhausted"
-            return [blob_view_float(pr + start, shape) for pr in self.peer_raw]
-        elif dtype == torch.int32:
+            if dynamic:
+                start = ((self.dynamic_offset + self.alignment - 1) // self.alignment) * self.alignment
+                self.dynamic_offset =  start + nels * elem_size
+                assert(self.dynamic_offset < self.dynamic_size), "Dynamic peer memory pool exhausted"
+                return [pm.blob_view_float(pr + self.static_size + start, shape, channels_last) for pr in self.peer_raw]
+            else:
+                start = ((self.static_offset + self.alignment - 1) // self.alignment) * self.alignment
+                self.static_offset = start + nels * elem_size
+                assert(self.static_offset < self.static_size), "Static peer memory pool exhausted"
+                return [pm.blob_view_float(pr + start, shape, channels_last) for pr in self.peer_raw]
+        if dtype == torch.int32:
             elem_size = 4
-            start = ((self.current + self.alignment - 1) // self.alignment) * self.alignment
-            self.current = start + nels * elem_size
-            assert(self.current < self.size), "Peer memory pool exhausted"
-            return [blob_view_int(pr + start, shape) for pr in self.peer_raw]
+            if dynamic:
+                start = ((self.dynamic_offset + self.alignment - 1) // self.alignment) * self.alignment
+                self.dynamic_offset =  start + nels * elem_size
+                assert(self.dynamic_offset < self.dynamic_size), "Dynamic peer memory pool exhausted"
+                return [pm.blob_view_int(pr + self.static_size + start, shape, channels_last) for pr in self.peer_raw]
+            else:
+                start = ((self.static_offset + self.alignment - 1) // self.alignment) * self.alignment
+                self.static_offset = start + nels * elem_size
+                assert(self.static_offset < self.static_size), "Static peer memory pool exhausted"
+                return [pm.blob_view_int(pr + start, shape, channels_last) for pr in self.peer_raw]
         else:
-            assert(False), "Unknown dtype : %s" % (str(dtype))
+            assert(False), "dtype %s not supported" % (str(dtype))

--- a/setup.py
+++ b/setup.py
@@ -627,6 +627,20 @@ if "--fast_bottleneck" in sys.argv:
         )
     )
 
+if "--peer_memory" in sys.argv:
+    sys.argv.remove("--peer_memory")
+    raise_if_cuda_home_none("--peer_memory")
+    ext_modules.append(
+        CUDAExtension(
+            name="peer_memory",
+            sources=[
+                "apex/contrib/csrc/peer_memory/peer_memory_cuda.cu",
+                "apex/contrib/csrc/peer_memory/peer_memory.cpp",
+            ],
+            extra_compile_args={"cxx": ["-O3"] + version_dependent_macros + generator_flag},
+        )
+    )
+
 
 setup(
     name="apex",

--- a/setup.py
+++ b/setup.py
@@ -646,7 +646,7 @@ if "--nccl_p2p" in sys.argv:
     raise_if_cuda_home_none("--nccl_p2p")
     ext_modules.append(
         CUDAExtension(
-            name="nccl_p2p",
+            name="nccl_p2p_cuda",
             sources=[
                 "apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cu",
                 "apex/contrib/csrc/nccl_p2p/nccl_p2p.cpp",

--- a/setup.py
+++ b/setup.py
@@ -632,7 +632,7 @@ if "--peer_memory" in sys.argv:
     raise_if_cuda_home_none("--peer_memory")
     ext_modules.append(
         CUDAExtension(
-            name="peer_memory",
+            name="peer_memory_cuda",
             sources=[
                 "apex/contrib/csrc/peer_memory/peer_memory_cuda.cu",
                 "apex/contrib/csrc/peer_memory/peer_memory.cpp",

--- a/setup.py
+++ b/setup.py
@@ -641,6 +641,20 @@ if "--peer_memory" in sys.argv:
         )
     )
 
+if "--nccl_p2p" in sys.argv:
+    sys.argv.remove("--nccl_p2p")
+    raise_if_cuda_home_none("--nccl_p2p")
+    ext_modules.append(
+        CUDAExtension(
+            name="nccl_p2p",
+            sources=[
+                "apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cu",
+                "apex/contrib/csrc/nccl_p2p/nccl_p2p.cpp",
+            ],
+            extra_compile_args={"cxx": ["-O3"] + version_dependent_macros + generator_flag},
+        )
+    )
+
 
 setup(
     name="apex",


### PR DESCRIPTION
This PR implements a peer memory pool that ranks can allocate tensors from.
Tensors allocated from the peer memory pool can be accessed from all ranks within a single node.
This PR also implements a push-pull 1d halo exchange kernel that relies on busy waiting on flags in peer memory to synchronize sender and receiver. This way of exchanging halos has very low latency.
