### PR TITLE
Give Some Extensions Version Guard in Build&Runtime

### DIFF
--- a/apex/__init__.py
+++ b/apex/__init__.py
@@ -45,7 +45,7 @@ def check_cudnn_version_and_warn(global_option: str, required_cudnn_version: int
     cudnn_version = torch.backends.cudnn.version() if cudnn_available else None
     if not (cudnn_available and (cudnn_version >= required_cudnn_version)):
         warnings.warn(
-            f"Skip `{global_option}` as it requires cuDNN {required_cudnn_version} or later, "
+            f"`{global_option}` depends on cuDNN {required_cudnn_version} or later, "
             f"but {'cuDNN is not available' if not cudnn_available else cudnn_version}"
         )
         return False

--- a/apex/__init__.py
+++ b/apex/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 # May help avoid undefined symbol errors https://pytorch.org/cppdocs/notes/faq.html#undefined-symbol-errors-from-pytorch-aten
 import torch
@@ -37,3 +38,15 @@ handler = logging.StreamHandler()
 handler.setFormatter(RankInfoFormatter("%(asctime)s - PID:%(process)d - rank:%(rank_info)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s", "%y-%m-%d %H:%M:%S"))
 _library_root_logger.addHandler(handler)
 _library_root_logger.propagate = False
+
+
+def check_cudnn_version_and_warn(global_option: str, required_cudnn_version: int) -> bool:
+    cudnn_available = torch.backends.cudnn.is_available()
+    cudnn_version = torch.backends.cudnn.version() if cudnn_available else None
+    if not (cudnn_available and (cudnn_version >= required_cudnn_version)):
+        warnings.warn(
+            f"Skip `{global_option}` as it requires cuDNN {required_cudnn_version} or later, "
+            f"but {'cuDNN is not available' if not cudnn_available else cudnn_version}"
+        )
+        return False
+    return True

--- a/apex/contrib/bottleneck/bottleneck.py
+++ b/apex/contrib/bottleneck/bottleneck.py
@@ -1,9 +1,16 @@
 import functools as func
+
 import torch
 import torch.distributed as dist
 from torch import nn
+
+from apex import check_cudnn_version_and_warn
 import fast_bottleneck
 import nccl_p2p_cuda as inc
+
+
+assert check_cudnn_version_and_warn(__name__, 8400)
+
 
 def kaiming_uniform_(tensor, a=0, mode='fan_in', nonlinearity='leaky_relu'):
     weight_tensor_nchw = tensor

--- a/apex/contrib/conv_bias_relu/conv_bias_relu.py
+++ b/apex/contrib/conv_bias_relu/conv_bias_relu.py
@@ -1,7 +1,12 @@
-import torch
 import pdb
+
+import torch
 from torch.autograd import gradcheck
+
+from apex import check_cudnn_version_and_warn
 import fused_conv_bias_relu
+
+check_cudnn_version_and_warn(__name__, 8400)
 
 
 class ConvBiasReLU_(torch.autograd.Function):

--- a/apex/contrib/test/conv_bias_relu/test_conv_bias_relu.py
+++ b/apex/contrib/test/conv_bias_relu/test_conv_bias_relu.py
@@ -1,12 +1,21 @@
+import copy
+import math
+import random
+import unittest
+
 import torch
 import torch.nn.functional as F
-import unittest
-import copy
-import random
-import math
-from apex.contrib.conv_bias_relu import ConvBiasReLU, ConvBias, ConvBiasMaskReLU
+
+HAS_CONV_BIAS_RELU = None
+try:
+    from apex.contrib.conv_bias_relu import ConvBiasReLU, ConvBias, ConvBiasMaskReLU
+except ImportError as e:
+    HAS_CONV_BIAS_RELU = False
+else:
+    HAS_CONV_BIAS_RELU = True
 
 
+@unittest.skipIf(not HAS_CONV_BIAS_RELU, "`apex.contrib.conv_bias_relu` is not found.")
 class FusedDenseTest(unittest.TestCase):
     def setUp(self, seed=0):
         torch.manual_seed(seed)

--- a/apex/contrib/test/fmha/test_fmha.py
+++ b/apex/contrib/test/fmha/test_fmha.py
@@ -25,13 +25,21 @@
 #
 ###############################################################################
 
+import math
 import sys
+import unittest
+
 import torch
 import numpy as np
-import unittest
-import math
 
 import fmhalib as mha
+
+
+def _get_device_properties(device = torch.device("cuda")):
+    # type: (str or torch.device) -> Tuple[int, int]
+    properties = torch.cuda.get_device_properties(device)
+    return properties.major, properties.minor
+
 
 def py_mha(qkv, amask, b, s, h, d):
     qkv = qkv.view(b, s, h, 3, d)
@@ -48,6 +56,7 @@ def py_mha(qkv, amask, b, s, h, d):
 
     return ctx
 
+@unittest.skipIf(not _get_device_properties() == (8, 0), "FMHA only supports sm80")
 class TestFMHA(unittest.TestCase):
 
     def run_test(self, s: int, b: int, zero_tensors: bool):

--- a/apex/contrib/test/focal_loss/test_focal_loss.py
+++ b/apex/contrib/test/focal_loss/test_focal_loss.py
@@ -12,6 +12,7 @@ except ImportError:
 from apex.contrib.focal_loss import focal_loss
 
 
+@unittest.skipIf(not reference_available, "Reference implementation `torchvision.ops.focal_loss.sigmoid_focal_loss` is not available.")
 class FocalLossTest(unittest.TestCase):
 
     N_SAMPLES = 12

--- a/setup.py
+++ b/setup.py
@@ -644,9 +644,7 @@ if "--transducer" in sys.argv:
         )
     )
 
-# note (mkozuki): Now `--fast_bottleneck` option depends on `--peer_memory` and `--nccl_p2p`.
-# Therefore, if you want to build this, it's mandated to put the two options before this.
-# e.g. `pip install --global-option="--peer_memory" --global-option="--nccl_p2p" --global-option="--fast_bottleneck"`.
+# note (mkozuki): Now `--fast_bottleneck` option (i.e. apex/contrib/bottleneck) depends on `--peer_memory` and `--nccl_p2p`.
 if "--fast_bottleneck" in sys.argv:
     sys.argv.remove("--fast_bottleneck")
     raise_if_cuda_home_none("--fast_bottleneck")

--- a/setup.py
+++ b/setup.py
@@ -662,32 +662,30 @@ if "--fast_bottleneck" in sys.argv:
 if "--peer_memory" in sys.argv:
     sys.argv.remove("--peer_memory")
     raise_if_cuda_home_none("--peer_memory")
-    if check_cudnn_version_and_warn("--peer_memory", 8400):
-        ext_modules.append(
-            CUDAExtension(
-                name="peer_memory_cuda",
-                sources=[
-                    "apex/contrib/csrc/peer_memory/peer_memory_cuda.cu",
-                    "apex/contrib/csrc/peer_memory/peer_memory.cpp",
-                ],
-                extra_compile_args={"cxx": ["-O3"] + version_dependent_macros + generator_flag},
-            )
+    ext_modules.append(
+        CUDAExtension(
+            name="peer_memory_cuda",
+            sources=[
+                "apex/contrib/csrc/peer_memory/peer_memory_cuda.cu",
+                "apex/contrib/csrc/peer_memory/peer_memory.cpp",
+            ],
+            extra_compile_args={"cxx": ["-O3"] + version_dependent_macros + generator_flag},
         )
+    )
 
 if "--nccl_p2p" in sys.argv:
     sys.argv.remove("--nccl_p2p")
     raise_if_cuda_home_none("--nccl_p2p")
-    if check_cudnn_version_and_warn("--nccl_p2p", 8400):
-        ext_modules.append(
-            CUDAExtension(
-                name="nccl_p2p_cuda",
-                sources=[
-                    "apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cu",
-                    "apex/contrib/csrc/nccl_p2p/nccl_p2p.cpp",
-                ],
-                extra_compile_args={"cxx": ["-O3"] + version_dependent_macros + generator_flag},
-            )
+    ext_modules.append(
+        CUDAExtension(
+            name="nccl_p2p_cuda",
+            sources=[
+                "apex/contrib/csrc/nccl_p2p/nccl_p2p_cuda.cu",
+                "apex/contrib/csrc/nccl_p2p/nccl_p2p.cpp",
+            ],
+            extra_compile_args={"cxx": ["-O3"] + version_dependent_macros + generator_flag},
         )
+    )
 
 
 if "--fused_conv_bias_relu" in sys.argv:


### PR DESCRIPTION
- Check cuDNN version if `--fast_bottleneck` is specified as it requires cuDNN>=8400.
- Add a comment about the dependency mentioned in https://github.com/NVIDIA/apex/pull/1340#discussion_r841257679.
- Runtime version guard for `apex.contrib.bottleneck` and `apex.contrib.conv_bias_relu`.

If cuDNN doesn't meet the condition, then the following warning will be displayed.
```
#26 112.7     /tmp/pip-req-build-vxkqatsx/setup.py:65: UserWarning: Skip `--fast_bottleneck` as it requires cuDNN 8400 or later, but 8303
#26 112.7       warnings.warn(
#26 112.7     /tmp/pip-req-build-vxkqatsx/setup.py:65: UserWarning: Skip `--fused_conv_bias_relu` as it requires cuDNN 8400 or later, but 8303
#26 112.7       warnings.warn(
```