### PR TITLE
Add LANS Optimizer

### DIFF
--- a/apex/optimizers/__init__.py
+++ b/apex/optimizers/__init__.py
@@ -4,3 +4,4 @@ from .fused_novograd import FusedNovoGrad
 from .fused_lamb import FusedLAMB
 from .fused_adagrad import FusedAdagrad
 from .fused_mixed_precision_lamb import FusedMixedPrecisionLamb
+from .fused_lans import FusedLANS

--- a/apex/optimizers/fused_lans.py
+++ b/apex/optimizers/fused_lans.py
@@ -120,7 +120,7 @@ class FusedLANS(torch.optim.Optimizer):
 
                 # Buffer for scaled grad
                 scaled_grad = torch.zeros_like(p.data)
-                if p.dtype == torch.float16 or torch.bfloat16:
+                if p.dtype == torch.float16 or p.dtype == torch.bfloat16:
                     g_16.append(p.grad.data)
                     q_16.append(scaled_grad)
                     p_16.append(p.data)

--- a/apex/optimizers/fused_lans.py
+++ b/apex/optimizers/fused_lans.py
@@ -1,0 +1,172 @@
+import torch
+from apex.multi_tensor_apply import multi_tensor_applier
+
+class FusedLANS(torch.optim.Optimizer):
+
+    """Implements LANS algorithm.
+
+    Currently GPU-only.  Requires Apex to be installed via
+    ``pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./``.
+
+    This version of fused LANS implements 2 fusions.
+
+      * Fusion of the LANS update's elementwise operations
+      * A multi-tensor apply launch that batches the elementwise updates applied to all the model's parameters into one or a few kernel launches.
+
+    :class:`apex.optimizers.FusedLANS`'s usage is identical to any ordinary Pytorch optimizer::
+
+        opt = apex.optimizers.FusedLANS(model.parameters(), lr = ....)
+        ...
+        opt.step()
+
+    :class:`apex.optimizers.FusedLANS` may be used with or without Amp.  If you wish to use :class:`FusedLANS` with Amp,
+    you may choose any ``opt_level``::
+
+        opt = apex.optimizers.FusedLANS(model.parameters(), lr = ....)
+        model, opt = amp.initialize(model, opt, opt_level="O0" or "O1 or "O2")
+        ...
+        opt.step()
+
+    In general, ``opt_level="O1"`` is recommended.
+
+    Arguments:
+        params (iterable): iterable of parameters to optimize or dicts defining
+            parameter groups.
+        lr (float, optional): learning rate. (default: 1e-3)
+        betas (Tuple[float, float], optional): coefficients used for computing
+            running averages of gradient and its norm. (default: (0.9, 0.999))
+        eps (float, optional): term added to the denominator to improve
+            numerical stability. (default: 1e-8)
+        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+        adam_w_mode (boolean, optional): Apply L2 regularization or weight decay
+            True for decoupled weight decay(also known as AdamW) (default: True)
+        grad_averaging (bool, optional): whether apply (1-beta2) to grad when
+            calculating running averages of gradient. (default: True)
+        set_grad_none (bool, optional): whether set grad to None when zero_grad()
+            method is called. (default: True)
+        normalize_grad (bool, optional): whether to normalize per-tensor grad
+            (default: False)
+        stochastic_rounding (bool, optional): whether to perform stochastic rounding for bfloat16 update
+            (default: False)
+
+    .. _Accelerated Large Batch Optimization of BERT Pretraining in 54 minutes:
+        https://arxiv.org/abs/2006.13484
+    """
+
+    def __init__(self, params, lr=1e-3, bias_correction=True,
+                 betas=(0.9, 0.999), eps=1e-6, weight_decay=0.01,
+                 adam_w_mode=True, grad_averaging=True, set_grad_none=True,
+                 normalize_grad=False, stochastic_rounding=False):
+        defaults = dict(lr=lr, bias_correction=bias_correction,
+                        betas=betas, eps=eps, weight_decay=weight_decay,
+                        grad_averaging=grad_averaging,
+                        normalize_grad=normalize_grad,
+                        stochastic_rounding=stochastic_rounding)
+        super(FusedLANS, self).__init__(params, defaults)
+        if multi_tensor_applier.available:
+            import amp_C
+            # Skip buffer
+            self._dummy_overflow_buf = torch.tensor([0], dtype=torch.int,
+                                                    device=self.param_groups[0]["params"][0].device)
+            self.multi_tensor_lans = amp_C.multi_tensor_lans
+        else:
+            raise RuntimeError('apex.optimizers.FusedLANS requires cuda extensions')
+
+        self.adam_w_mode = 1 if adam_w_mode else 0
+        self.set_grad_none = set_grad_none
+
+    def zero_grad(self):
+        if self.set_grad_none:
+            for group in self.param_groups:
+                for p in group['params']:
+                    p.grad = None
+        else:
+            super(FusedLANS, self).zero_grad()
+
+    def step(self, closure=None):
+        """Performs a single optimization step.
+
+        Arguments:
+            closure (callable, optional): A closure that reevaluates the model
+                and returns the loss.
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            bias_correction = 1 if group['bias_correction'] else 0
+            beta1, beta2 = group['betas']
+            grad_averaging = 1 if group['grad_averaging'] else 0
+
+            # create lists for multi-tensor apply
+            g_16, q_16, p_16, m_16, v_16 = [], [], [], [], []
+            g_32, q_32, p_32, m_32, v_32 = [], [], [], [], []
+
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+                if p.grad.data.is_sparse:
+                    raise RuntimeError('FusedLANS does not support sparse gradients, please consider SparseAdam instead')
+
+                state = self.state[p]
+                # State initialization
+                if len(state) == 0:
+                    state['step'] = 0
+                    # Exponential moving average of gradient values
+                    state['exp_avg'] = torch.zeros_like(p.data)
+                    # Exponential moving average of gradient values
+                    state['exp_avg_sq'] = torch.zeros_like(p.data)
+
+                # Buffer for scaled grad
+                scaled_grad = torch.zeros_like(p.data)
+                if p.dtype == torch.float16 or torch.bfloat16:
+                    g_16.append(p.grad.data)
+                    q_16.append(scaled_grad)
+                    p_16.append(p.data)
+                    m_16.append(state['exp_avg'])
+                    v_16.append(state['exp_avg_sq'])
+                elif p.dtype == torch.float32:
+                    assert not group['stochastic_rounding'], 'stochastic rounding has to be disabled when float32 optimizer is used'
+                    g_32.append(p.grad.data)
+                    q_32.append(scaled_grad)
+                    p_32.append(p.data)
+                    m_32.append(state['exp_avg'])
+                    v_32.append(state['exp_avg_sq'])
+                else:
+                    raise RuntimeError('FusedLANS only support fp16, bfloat16, and fp32.')
+
+            if(len(g_16) > 0):
+                state['step'] += 1
+                multi_tensor_applier(self.multi_tensor_lans,
+                                     self._dummy_overflow_buf,
+                                     [g_16, q_16, p_16, m_16, v_16],
+                                     group['lr'],
+                                     beta1,
+                                     beta2,
+                                     group['eps'],
+                                     state['step'],
+                                     bias_correction,
+                                     group['weight_decay'],
+                                     grad_averaging,
+                                     self.adam_w_mode,
+                                     group['normalize_grad'],
+                                     group['stochastic_rounding'])
+            if(len(g_32) > 0):
+                state['step'] += 1
+                multi_tensor_applier(self.multi_tensor_lans,
+                                     self._dummy_overflow_buf,
+                                     [g_32, q_32, p_32, m_32, v_32],
+                                     group['lr'],
+                                     beta1,
+                                     beta2,
+                                     group['eps'],
+                                     state['step'],
+                                     bias_correction,
+                                     group['weight_decay'],
+                                     grad_averaging,
+                                     self.adam_w_mode,
+                                     group['normalize_grad'],
+                                     False)
+
+        return loss

--- a/csrc/amp_C_frontend.cpp
+++ b/csrc/amp_C_frontend.cpp
@@ -144,6 +144,22 @@ void multi_tensor_lamb_mp_cuda(
   at::Tensor found_inf,
   at::Tensor inv_scale);
 
+void multi_tensor_lans_cuda(
+  int chunk_size,
+  at::Tensor noop_flag,
+  std::vector<std::vector<at::Tensor>> tensor_lists,
+  const float lr,
+  const float beta1,
+  const float beta2,
+  const float epsilon,
+  const int step,
+  const int bias_correction,
+  const float weight_decay,
+  const int grad_averaging,
+  const int mode,
+  const bool normalize_grad,
+  const bool stochastic_rounding);
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("multi_tensor_scale", &multi_tensor_scale_cuda,
         "Fused overflow check + scale for a list of contiguous tensors");
@@ -171,4 +187,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "Computes and apply update for LAMB optimizer");
   m.def("multi_tensor_lamb_mp", &multi_tensor_lamb_mp_cuda,
         "Computes and apply update for LAMB optimizer");
+  m.def("multi_tensor_lans", &multi_tensor_lans_cuda,
+        "Computes and apply update for LANS optimizer");
 }

--- a/csrc/multi_tensor_l2norm_kernel.cu
+++ b/csrc/multi_tensor_l2norm_kernel.cu
@@ -323,7 +323,7 @@ std::tuple<at::Tensor, at::Tensor> multi_tensor_l2norm_cuda(
     ret_per_tensor = at::empty({0}, float_options);
   }
 
-  DISPATCH_FLOAT_AND_HALF(tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_cuda",
+  DISPATCH_FLOAT_HALF_AND_BFLOAT(tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_cuda",
     multi_tensor_apply<1>(
       BLOCK_SIZE,
       chunk_size,
@@ -392,7 +392,7 @@ void multi_tensor_norm_out_cuda(
   output_per_tensor = at::zeros({ntensors*max_chunks_per_tensor}, float_options);
 
   if (norm_type == 0) {
-    DISPATCH_FLOAT_AND_HALF(
+    DISPATCH_FLOAT_HALF_AND_BFLOAT(
       tensor_lists[0][0].scalar_type(), 0, "multi_tensor_maxnorm_cuda",
       multi_tensor_apply<1>(
         BLOCK_SIZE,
@@ -406,7 +406,7 @@ void multi_tensor_norm_out_cuda(
         max_chunks_per_tensor);)
   }
   else {
-    DISPATCH_FLOAT_AND_HALF(
+    DISPATCH_FLOAT_HALF_AND_BFLOAT(
       tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_cuda",
       multi_tensor_apply<1>(
         BLOCK_SIZE,

--- a/csrc/multi_tensor_lans.cu
+++ b/csrc/multi_tensor_lans.cu
@@ -1,0 +1,442 @@
+#include <ATen/ATen.h>
+#include <ATen/AccumulateType.h>
+#ifdef OLD_GENERATOR_PATH
+#include <ATen/CUDAGeneratorImpl.h>
+#else
+#include <ATen/cuda/CUDAGeneratorImpl.h>
+#endif
+#include <ATen/cuda/CUDAGraphsUtils.cuh>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/Exceptions.h>
+// Another possibility:
+// #include <torch/all.h>
+
+#include <curand_kernel.h>
+#include <assert.h>
+
+#include "type_shim.h"
+#include "multi_tensor_apply.cuh"
+#include "stochastic_round.cuh"
+
+#define BLOCK_SIZE 512
+#define ILP 4
+
+typedef enum{
+  MOMENT_MODE_0   =0, // L2 regularization mode
+  MOMENT_MODE_1   =1  // Decoupled weight decay mode
+} adamMode_t;
+
+std::tuple<at::Tensor, at::Tensor> multi_tensor_l2norm_cuda(
+  int chunk_size,
+  at::Tensor noop_flag,
+  std::vector<std::vector<at::Tensor>> tensor_lists,
+  at::optional<bool> per_tensor_python);
+
+using MATH_T = float;
+using MATH_T4 = float4;
+
+template<typename T>
+struct LANSStage1Functor
+{
+   __device__ __forceinline__ void operator()(
+    int chunk_size,
+    volatile int* noop_gmem,
+    TensorListMetadata<5>& tl,
+    const float beta1,
+    const float beta2,
+    const float beta3,
+    const float beta1_correction,
+    const float beta2_correction,
+    const float epsilon,
+    adamMode_t mode,
+    const float decay,
+    float* per_tensor_grad_norm,
+    bool normalize_grad)
+  {
+    // I'd like this kernel to propagate infs/nans.
+    // if(*noop_gmem == 1)
+    //   return;
+
+    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    int tensor_num = tl.start_tensor_this_launch + tensor_loc;
+    int chunk_idx = tl.block_to_chunk[blockIdx.x];
+    int n = tl.sizes[tensor_loc];
+
+    float grad_norm = per_tensor_grad_norm[tensor_num];
+
+    T* g = (T*)tl.addresses[0][tensor_loc];
+    g += chunk_idx*chunk_size;
+
+    T* q = (T*)tl.addresses[1][tensor_loc];
+    q += chunk_idx*chunk_size;
+
+    T* p = (T*)tl.addresses[2][tensor_loc];
+    p += chunk_idx*chunk_size;
+
+    T* m = (T*)tl.addresses[3][tensor_loc];
+    m += chunk_idx*chunk_size;
+
+    T* v = (T*)tl.addresses[4][tensor_loc];
+    v += chunk_idx*chunk_size;
+
+    n -= chunk_idx*chunk_size;
+
+    // see note in multi_tensor_scale_kernel.cu
+    for(int i_start = 0;
+            i_start < n && i_start < chunk_size;
+            i_start += blockDim.x*ILP)
+    {
+      MATH_T r_g[ILP];
+      MATH_T r_q[ILP];
+      MATH_T r_p[ILP];
+      MATH_T r_m[ILP];
+      MATH_T r_v[ILP];
+#pragma unroll
+      for(int ii = 0; ii < ILP; ii++)
+      {
+        int i = i_start + threadIdx.x + ii*blockDim.x;
+        if(i < n && i < chunk_size)
+        {
+          r_g[ii] = g[i];
+          r_q[ii] = q[i];
+          // special ?optimization? for lans stage 1
+          if (decay == 0) {
+            r_p[ii] = MATH_T(0);
+          }
+          else {
+            r_p[ii] = p[i];
+          }
+          r_m[ii] = m[i];
+          r_v[ii] = v[i];
+        } else {
+          r_g[ii] = MATH_T(0);
+          r_q[ii] = MATH_T(0);
+          r_p[ii] = MATH_T(0);
+          r_m[ii] = MATH_T(0);
+          r_v[ii] = MATH_T(0);
+        }
+      }
+#pragma unroll
+      for(int ii = 0; ii < ILP; ii++)
+      {
+        MATH_T scaled_grad = r_g[ii];
+        if (normalize_grad && grad_norm != 0.0f) {
+           scaled_grad /= (grad_norm + epsilon);
+        }
+        if (mode == MOMENT_MODE_0) {
+          // L2 on scaled grad
+          scaled_grad = scaled_grad + decay*r_p[ii];
+          r_m[ii] = r_m[ii] * beta1 + beta3 * scaled_grad;
+          r_v[ii] = r_v[ii] * beta2 + (1-beta2) * scaled_grad * scaled_grad;
+          MATH_T next_m_unbiased = r_m[ii] / beta1_correction;
+          MATH_T next_v_unbiased = r_v[ii] / beta2_correction;
+          MATH_T denom = sqrtf(next_v_unbiased) + epsilon;
+          r_p[ii] = next_m_unbiased / denom;
+          r_q[ii] = scaled_grad / denom;
+        }
+        else {
+          r_m[ii] = r_m[ii] * beta1 + beta3 * scaled_grad;
+          r_v[ii] = r_v[ii] * beta2 + (1-beta2) * scaled_grad * scaled_grad;
+          MATH_T next_m_unbiased = r_m[ii] / beta1_correction;
+          MATH_T next_v_unbiased = r_v[ii] / beta2_correction;
+          MATH_T denom = sqrtf(next_v_unbiased) + epsilon;
+          MATH_T scaled_p = decay * r_p[ii];
+          r_p[ii] = (next_m_unbiased/denom) + scaled_p;
+          r_q[ii] = (scaled_grad/denom) + scaled_p;
+        }
+      }
+#pragma unroll
+      for(int ii = 0; ii < ILP; ii++)
+      {
+        int i = i_start + threadIdx.x + ii*blockDim.x;
+        if(i < n && i < chunk_size)
+        {
+          g[i] = r_p[ii];
+          q[i] = r_q[ii];
+          m[i] = r_m[ii];
+          v[i] = r_v[ii];
+        }
+      }
+    }
+  }
+};
+
+// Step 2 reads in 'update' value and per-tensor param_norm and update_norm.
+// It computes new parameter value.
+template<typename T>
+struct LANSStage2Functor
+{
+   __device__ __forceinline__ void operator()(
+    int chunk_size,
+    volatile int* noop_gmem,
+    TensorListMetadata<3>& tl,
+    const float beta1,
+    const float beta3,
+    const float* per_tensor_param_norm,
+    const float* per_tensor_update_m_norm,
+    const float* per_tensor_update_g_norm,
+    const float learning_rate)
+  {
+    // I'd like this kernel to propagate infs/nans.
+    // if(*noop_gmem == 1)
+    //   return;
+
+    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    int tensor_num = tl.start_tensor_this_launch + tensor_loc;
+    int chunk_idx = tl.block_to_chunk[blockIdx.x];
+    int n = tl.sizes[tensor_loc];
+
+    float param_norm = per_tensor_param_norm[tensor_num];
+    float update_m_norm = per_tensor_update_m_norm[tensor_num];
+    float update_g_norm = per_tensor_update_g_norm[tensor_num];
+    MATH_T ratio_m = (update_m_norm != 0.0f && param_norm != 0.0f) ? learning_rate * (param_norm / update_m_norm) : learning_rate;
+    MATH_T ratio_g = (update_g_norm != 0.0f && param_norm != 0.0f) ? learning_rate * (param_norm / update_g_norm) : learning_rate;
+    ratio_m *= beta1;
+    ratio_g *= beta3;
+
+    T* update_m = (T*)tl.addresses[0][tensor_loc];
+    update_m += chunk_idx*chunk_size;
+
+    T* update_g = (T*)tl.addresses[1][tensor_loc];
+    update_g += chunk_idx*chunk_size;
+
+    T* p = (T*)tl.addresses[2][tensor_loc];
+    p += chunk_idx*chunk_size;
+
+    n -= chunk_idx*chunk_size;
+
+    for(int i_start = 0;
+            i_start < n && i_start < chunk_size;
+            i_start += blockDim.x*ILP)
+    {
+      MATH_T r_p[ILP];
+      MATH_T r_update_m[ILP];
+      MATH_T r_update_g[ILP];
+#pragma unroll
+      for(int ii = 0; ii < ILP; ii++)
+      {
+       	int i = i_start + threadIdx.x + ii*blockDim.x;
+        if(i < n && i < chunk_size)
+        {
+          r_p[ii] = p[i];
+          r_update_m[ii] = update_m[i];
+          r_update_g[ii] = update_g[i];
+        }
+      }
+#pragma unroll
+      for(int ii = 0; ii < ILP; ii++)
+      {
+       	r_p[ii] = r_p[ii] - (ratio_m * r_update_m[ii]) - (ratio_g * r_update_g[ii]);
+      }
+#pragma unroll
+      for(int ii = 0; ii < ILP; ii++)
+      {
+        int i = i_start + threadIdx.x + ii*blockDim.x;
+        if(i < n && i < chunk_size)
+        {
+          p[i] = r_p[ii];
+        }
+      }
+    }
+  }
+
+  __device__ __forceinline__ void operator()(
+    int chunk_size,
+    volatile int* noop_gmem,
+    TensorListMetadata<3>& tl,
+    const float beta1,
+    const float beta3,
+    const float* per_tensor_param_norm,
+    const float* per_tensor_update_m_norm,
+    const float* per_tensor_update_g_norm,
+    const float learning_rate,
+    at::PhiloxCudaState philox_args)
+  {
+    // I'd like this kernel to propagate infs/nans.
+    // if(*noop_gmem == 1)
+    //   return;
+
+    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    int tensor_num = tl.start_tensor_this_launch + tensor_loc;
+    int chunk_idx = tl.block_to_chunk[blockIdx.x];
+    int n = tl.sizes[tensor_loc];
+
+    float param_norm = per_tensor_param_norm[tensor_num];
+    float update_m_norm = per_tensor_update_m_norm[tensor_num];
+    float update_g_norm = per_tensor_update_g_norm[tensor_num];
+    MATH_T ratio_m = (update_m_norm != 0.0f && param_norm != 0.0f) ? learning_rate * (param_norm / update_m_norm) : learning_rate;
+    MATH_T ratio_g = (update_g_norm != 0.0f && param_norm != 0.0f) ? learning_rate * (param_norm / update_g_norm) : learning_rate;
+    ratio_m *= beta1;
+    ratio_g *= beta3;
+
+    T* update_m = (T*)tl.addresses[0][tensor_loc];
+    update_m += chunk_idx*chunk_size;
+
+    T* update_g = (T*)tl.addresses[1][tensor_loc];
+    update_g += chunk_idx*chunk_size;
+
+    T* p = (T*)tl.addresses[2][tensor_loc];
+    p += chunk_idx*chunk_size;
+
+    n -= chunk_idx*chunk_size;
+
+    curandStatePhilox4_32_10_t state;
+    auto seeds = at::cuda::philox::unpack(philox_args);
+    uint32_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    curand_init(
+        std::get<0>(seeds),
+        idx,
+        std::get<1>(seeds),
+        &state);
+
+    for(int i_start = 0;
+            i_start < n && i_start < chunk_size;
+            i_start += blockDim.x*ILP)
+    {
+      MATH_T r_p[ILP];
+      MATH_T r_update_m[ILP];
+      MATH_T r_update_g[ILP];
+      MATH_T4 rand = curand_uniform4(&state);
+#pragma unroll
+      for(int ii = 0; ii < ILP; ii++)
+      {
+        int i = i_start + threadIdx.x + ii*blockDim.x;
+        if(i < n && i < chunk_size)
+        {
+          r_p[ii] = p[i];
+          r_update_m[ii] = update_m[i];
+          r_update_g[ii] = update_g[i];
+        }
+      }
+#pragma unroll
+      for(int ii = 0; ii < ILP; ii++)
+      {
+        r_p[ii] = r_p[ii] - (ratio_m * r_update_m[ii]) - (ratio_g * r_update_g[ii]);
+      }
+#pragma unroll
+      for(int ii = 0; ii < ILP; ii++)
+      {
+        int i = i_start + threadIdx.x + ii*blockDim.x;
+        if(i < n && i < chunk_size)
+        {
+          p[i] = __stochastic_round<T>(r_p[ii], (&rand.x)[ii]);
+        }
+      }
+    }
+  }
+};
+
+
+void multi_tensor_lans_cuda(
+  int chunk_size,
+  at::Tensor noop_flag,
+  std::vector<std::vector<at::Tensor>> tensor_lists,
+  const float lr,
+  const float beta1,
+  const float beta2,
+  const float epsilon,
+  const int step,
+  const int bias_correction,
+  const float weight_decay,
+  const int grad_averaging,
+  const int mode,
+  const bool normalize_grad,
+  const bool stochastic_rounding)
+{
+  using namespace at;
+  // Master weight and 32bit momentum(potentially changing) is not handled by this
+  // So we assume every tensor are all in the same type
+
+  // Handle bias correction mode
+  float bias_correction1 = 1.0f, bias_correction2 = 1.0f;
+  if (bias_correction == 1) {
+    bias_correction1 = 1 - std::pow(beta1, step);
+    bias_correction2 = 1 - std::pow(beta2, step);
+  }
+
+  // Handle grad averaging mode
+  float beta3 = 1.0f;
+  if (grad_averaging == 1) beta3 = 1 - beta1;
+
+  std::vector<std::vector<at::Tensor>> grad_list(tensor_lists.begin(), tensor_lists.begin()+1);
+  std::vector<std::vector<at::Tensor>> param_list(tensor_lists.begin()+2, tensor_lists.begin()+3);
+
+  // Compute per-layer grad norm
+  auto grad_norm_tuple = multi_tensor_l2norm_cuda(chunk_size, noop_flag, grad_list, true);
+
+  // Compute per tensor param norm
+  auto param_norm_tuple = multi_tensor_l2norm_cuda(chunk_size, noop_flag, param_list, true);
+
+  // We now in-place modify grad to store update before compute its norm
+  // Generally this is not a issue since people modify grad in step() method all the time
+  // We can also grab list of empty tensor to avoid this, but I'd like to save space/cpu code
+  DISPATCH_FLOAT_HALF_AND_BFLOAT(tensor_lists[0][0].scalar_type(), 0, "lans_stage_1",
+      multi_tensor_apply<5>(
+        BLOCK_SIZE,
+        chunk_size,
+        noop_flag,
+        tensor_lists,
+        LANSStage1Functor<scalar_t_0>(),
+        beta1,
+        beta2,
+        beta3, // 1-beta1 or 1 depends on averaging mode
+        bias_correction1,
+        bias_correction2,
+        epsilon,
+        (adamMode_t) mode,
+        weight_decay,
+        std::get<1>(grad_norm_tuple).DATA_PTR<float>(),
+        normalize_grad); )
+
+  // Compute update norms
+  auto update_m_norm_tuple = multi_tensor_l2norm_cuda(chunk_size, noop_flag, grad_list, true);
+
+  std::vector<std::vector<at::Tensor>> q_list(tensor_lists.begin()+1, tensor_lists.begin()+2);
+  auto update_g_norm_tuple = multi_tensor_l2norm_cuda(chunk_size, noop_flag, q_list, true);
+
+  std::vector<std::vector<at::Tensor>> grad_q_param_list(tensor_lists.begin(), tensor_lists.begin()+3);
+
+  if(stochastic_rounding)
+  {
+    auto gen = at::cuda::detail::getDefaultCUDAGenerator();
+    at::PhiloxCudaState rng_engine_inputs;
+    uint64_t counter_offset = (chunk_size - 1) / BLOCK_SIZE + 1;
+    {
+      // See Note [Acquire lock when using random generators]
+      std::lock_guard<std::mutex> lock(gen.mutex());
+      rng_engine_inputs = at::check_generator<at::CUDAGeneratorImpl>(gen)->philox_cuda_state(counter_offset);
+    }
+
+    DISPATCH_FLOAT_HALF_AND_BFLOAT(tensor_lists[0][0].scalar_type(), 0, "lans_stage_2",
+        multi_tensor_apply<3>(
+          BLOCK_SIZE,
+          chunk_size,
+          noop_flag,
+          grad_q_param_list,
+          LANSStage2Functor<scalar_t_0>(),
+          beta1,
+          beta3,
+          std::get<1>(param_norm_tuple).DATA_PTR<float>(),
+          std::get<1>(update_m_norm_tuple).DATA_PTR<float>(),
+          std::get<1>(update_g_norm_tuple).DATA_PTR<float>(),
+          lr,
+          rng_engine_inputs); )
+  } else {
+    DISPATCH_FLOAT_HALF_AND_BFLOAT(tensor_lists[0][0].scalar_type(), 0, "lans_stage_2",
+        multi_tensor_apply<3>(
+          BLOCK_SIZE,
+          chunk_size,
+          noop_flag,
+          grad_q_param_list,
+          LANSStage2Functor<scalar_t_0>(),
+          beta1,
+          beta3,
+          std::get<1>(param_norm_tuple).DATA_PTR<float>(),
+          std::get<1>(update_m_norm_tuple).DATA_PTR<float>(),
+          std::get<1>(update_g_norm_tuple).DATA_PTR<float>(),
+          lr); )
+  }
+
+  AT_CUDA_CHECK(cudaGetLastError());
+
+}

--- a/csrc/stochastic_round.cuh
+++ b/csrc/stochastic_round.cuh
@@ -1,0 +1,34 @@
+#include <ATen/ATen.h>
+#include <ATen/AccumulateType.h>
+#include <ATen/cuda/CUDAContext.h>
+
+
+template<typename T>
+__device__ __forceinline__ T __stochastic_round(const float value,
+						const float rand)
+{
+#if defined(USE_ROCM)
+  if (value != value) {
+#elif defined(_MSC_VER)
+  if (isnan(value)) {
+#else
+  if (std::isnan(value)) {
+#endif
+    return static_cast<T>(UINT16_C(0x7FC0));
+  } else {
+    union {
+      int32_t I32;
+      float F32;
+    };
+
+    F32 = value;
+    int32_t shifted_i32 = I32 >> 16;
+    int32_t ru_bias = (shifted_i32 | 1) + INT32_C(0x7FFF);
+    int32_t rd_bias = (shifted_i32 & 0) + INT32_C(0x7FFF);
+    float ru = __int_as_float((I32 + ru_bias) & ~(((uint32_t)1 << 16) - 1));
+    float rd = __int_as_float((I32 + rd_bias) & ~(((uint32_t)1 << 16) - 1));
+    float p = (value - rd) / ((ru - rd) + 1e-8);
+    float mask = rand <= p;
+    return static_cast<T>(mask * ru + (1.0f - mask) * rd);
+  }
+}

--- a/docs/source/optimizers.rst
+++ b/docs/source/optimizers.rst
@@ -16,6 +16,9 @@ apex.optimizers
 .. autoclass:: FusedLAMB
     :members:
 
+.. autoclass:: FusedLANS
+    :members:
+
 .. autoclass:: FusedNovoGrad
     :members:
 

--- a/tests/L0/run_optimizers/test_lans.py
+++ b/tests/L0/run_optimizers/test_lans.py
@@ -1,0 +1,177 @@
+import torch
+from torch.optim import Optimizer
+import apex
+import unittest
+
+from test_fused_optimizer import TestFusedOptimizer
+from itertools import product
+
+
+class LANS(Optimizer):
+    """
+    Implements LANS algorithm.
+
+    Args:
+        params (iterable): iterable of parameters to optimize or dicts defining
+            parameter groups.
+        lr (float, optional): learning rate. (default: 1e-3)
+        betas (Tuple[float, float], optional): coefficients used for computing
+            running averages of gradient and its norm. (default: (0.9, 0.999))
+        eps (float, optional): term added to the denominator to improve
+            numerical stability. (default: 1e-8)
+        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+    """
+
+    def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-6, weight_decay=0.01):
+        if not 0.0 <= lr:
+            raise ValueError("Invalid learning rate: {}".format(lr))
+        if not 0.0 <= eps:
+            raise ValueError("Invalid epsilon value: {}".format(eps))
+        if not 0.0 <= betas[0] < 1.0:
+            raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))
+        if not 0.0 <= betas[1] < 1.0:
+            raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))
+        defaults = dict(lr=lr,
+                        betas=betas,
+                        eps=eps,
+                        weight_decay=weight_decay)
+        super(LANS, self).__init__(params, defaults)
+
+    def step(self, closure=None):
+        """Performs a single optimization step.
+
+        Arguments:
+            closure (callable, optional): A closure that reevaluates the model
+            and returns the loss.
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+                p.grad.data /= p.grad.data.norm().add(group['eps'])
+
+                grad = p.grad.data
+                if grad.is_sparse:
+                    raise RuntimeError('LANS does not support sparse gradients, consider SparseAdam instad.')
+
+                state = self.state[p]
+
+                # State initialization
+                if len(state) == 0:
+                    state['step'] = 0
+                    # Exponential moving average of gradient values
+                    state['m'] = torch.zeros_like(p.data)
+                    # Exponential moving average of squared gradient values
+                    state['v'] = torch.zeros_like(p.data)
+
+                m_t, v_t = state['m'], state['v']
+                beta1, beta2 = group['betas']
+
+                state['step'] += 1
+
+                # m_t = beta1 * m + (1 - beta1) * g_t
+                m_t.mul_(beta1).add_(grad, alpha=1 - beta1)
+                # v_t = beta2 * v + (1 - beta2) * (g_t * g_t)
+                v_t.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
+
+                # Debiasing
+                m_t_hat = m_t / (1.0 - beta1 ** state['step'])
+                v_t_hat = v_t / (1.0 - beta2 ** state['step'])
+
+                update_m = m_t_hat / v_t_hat.sqrt().add(group['eps'])
+                update_c = grad / v_t_hat.sqrt().add(group['eps'])
+
+                if group['weight_decay'] != 0:
+                    update_m.add_(p.data, alpha=group['weight_decay'])
+                    update_c.add_(p.data, alpha=group['weight_decay'])
+
+                trust_m_ratio = 1.0
+                trust_c_ratio = 1.0
+                w_norm = p.data.pow(2).sum().sqrt()
+                m_norm = update_m.pow(2).sum().sqrt()
+                c_norm = update_c.pow(2).sum().sqrt()
+                if w_norm > 0 and m_norm > 0:
+                    trust_m_ratio = w_norm / m_norm
+                if w_norm > 0 and c_norm > 0:
+                    trust_c_ratio = w_norm / c_norm
+
+                step_size = group['lr']
+
+                p.data.add_(update_m, alpha=-step_size * beta1 * trust_m_ratio)
+                p.data.add_(update_c, alpha=-step_size * (1 - beta1) * trust_c_ratio)
+
+        return loss
+
+
+class TestFusedLANS(TestFusedOptimizer):
+
+    def __init__(self, *args, **kwargs):
+        super(TestFusedLANS, self).__init__(*args, **kwargs)
+
+        # The options for LANS and FusedLANS are very specific if they
+        # are expected to behave the same.
+        self.options = {'lr': 1e-3, 'betas': (0.95, 0), 'eps': 1e-8,
+                        'weight_decay': 0}
+
+        self.tst_options = {'lr': 1e-3, 'betas': (0.95, 0), 'eps': 1e-8,
+                            'weight_decay': 0}
+
+        self.ref_optim = LANS
+        self.fused_optim = apex.optimizers.FusedLANS
+
+    def test_float(self):
+        self.gen_single_type_test(param_type=torch.float)
+
+    def test_half(self):
+        self.gen_single_type_test(param_type=torch.float16)
+
+    @unittest.skipIf(torch.cuda.device_count() < 2, "more than 1 GPU required")
+    def test_multi_device(self):
+        devices = ("cuda:1", "cuda:0")
+        for current_dev, tensor_dev in product(devices, devices):
+            with torch.cuda.device(current_dev):
+                torch.cuda.synchronize()
+                self.gen_single_type_test(param_type=torch.float, device=tensor_dev)
+
+    def test_multi_params(self):
+        sizes = [[4096, 1024], [4096], [4096, 2048], [32320, 1024], [1]]
+
+        tensors = []
+        for size in sizes:
+            tensors.append(torch.rand(size, dtype=torch.float, device="cuda"))
+        ref_param, tst_param, ref_optim, tst_optim = self.gen_param_optim(
+            tensors, self.options, self.tst_options
+        )
+
+        for _ in range(self.iters):
+            self.gen_grad(ref_param, tst_param)
+            ref_optim.step()
+            tst_optim.step()
+            max_abs_diff, max_rel_diff = self.get_max_diff(ref_param, tst_param)
+            self.assertLessEqual(max_abs_diff, self.max_abs_diff)
+            self.assertLessEqual(max_rel_diff, self.max_rel_diff)
+
+    @unittest.skipIf(~torch.cuda.is_bf16_supported() == False, "bfloat16 is not supported")
+    def test_stochastic_rounding(self):
+        sizes = [[4096, 1024], [4096], [4096, 2048], [32320, 1024], [1]]
+
+        tensors = []
+        for size in sizes:
+            tensors.append(torch.rand(size, dtype=torch.bfloat16, device="cuda"))
+        tst_options = {'lr': 1e-3, 'betas': (0.95, 0), 'eps': 1e-8,
+                       'weight_decay': 0, 'stochastic_rounding': True}
+        ref_param, tst_param, ref_optim, tst_optim = self.gen_param_optim(
+            tensors, self.options, tst_options
+        )
+
+        for _ in range(self.iters):
+            self.gen_grad(ref_param, tst_param)
+            tst_optim.step()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
As per the discussion offline, I am opening this PR for upstreaming [LANS optimizer](https://arxiv.org/abs/2006.13484) into Apex master. LANS improves over LAMB on large-batch training for Transformer based models. The implementation is built based on Apex LAMB code. We clocked 54 mins training of BERT-large model on 1536 V100 GPUs dated back in 2020. In addition to LANS, this PR also adds support for stochastic rounding for optimization step with bfloat16. A [recent study ](https://arxiv.org/abs/2010.06192) shows that we can use bfloat16 optimizer state if apply stochastic rounding to the optimization step. In our experiment, it still does not match with the accuracy with the float32 training, but it does improve over the vanilla training with bfloat16 optimizer state.
