### PR TITLE
Async pipeline parallel

### DIFF
--- a/apex/transformer/pipeline_parallel/p2p_communication.py
+++ b/apex/transformer/pipeline_parallel/p2p_communication.py
@@ -85,12 +85,6 @@ def _run_p2pops(
             tensor_recv_prev_req = None if tensor_recv_prev is None else reqs.pop(0)
             tensor_send_next_req = None if tensor_send_next is None else reqs.pop(0)
             tensor_recv_next_req = None if tensor_recv_next is None else reqs.pop(0)
-            #for req in reqs:
-            #    req.wait()
-            #if tensor_send_prev_req is not None:
-            #    tensor_send_prev_req.wait()
-            #if tensor_send_next_req is not None:
-            #    tensor_send_next_req.wait()
             return (tensor_send_prev_req, tensor_recv_prev_req, tensor_send_next_req, tensor_recv_next_req)
         else:
             for req in reqs:

--- a/apex/transformer/pipeline_parallel/p2p_communication.py
+++ b/apex/transformer/pipeline_parallel/p2p_communication.py
@@ -39,7 +39,7 @@ class FutureTensor(object):
             # To protect against race condition when using batch_isend_irecv().
             torch.cuda.synchronize()
             if isinstance(res, torch.Tensor):
-                self.tensor = tensor
+                self.tensor = res
             self.waitfunc = None
         return self.tensor
 
@@ -235,9 +235,14 @@ def _communicate(
             tensor_recv_next_waitfunc = gather_recv_next_wait
     if async_comm:
         if tensor_recv_prev is not None:
-            tensor_recv_prev = FutureTensor(tensor_recv_prev, tensor_recv_prev_waitfunc)
+            future_tensor_recv_prev = FutureTensor(tensor_recv_prev, tensor_recv_prev_waitfunc)
+        else:
+            future_tensor_recv_prev = None
         if tensor_recv_next is not None:
-            tensor_recv_next = FutureTensor(tensor_recv_next, tensor_recv_next_waitfunc)
+            future_tensor_recv_next = FutureTensor(tensor_recv_next, tensor_recv_next_waitfunc)
+        else:
+            future_tensor_recv_next = None
+        return future_tensor_recv_prev, future_tensor_recv_next
         
     return tensor_recv_prev, tensor_recv_next
 

--- a/apex/transformer/pipeline_parallel/p2p_communication.py
+++ b/apex/transformer/pipeline_parallel/p2p_communication.py
@@ -27,7 +27,7 @@ from apex.transformer.pipeline_parallel._timers import _Timers
 
 
 
-class FutureTensor():
+class FutureTensor:
     def __init__(self, tensor: torch.Tensor, waitfunc):
         self.tensor = tensor
         self.waitfunc = waitfunc

--- a/apex/transformer/pipeline_parallel/schedules/common.py
+++ b/apex/transformer/pipeline_parallel/schedules/common.py
@@ -20,7 +20,7 @@ from apex.transformer.log_util import get_transformer_logger
 _logger = get_transformer_logger(__name__)
 
 
-Batch = Union[torch.Tensor, List[torch.Tensor], Tuple[torch.Tensor, ...]]
+Batch = Union[torch.Tensor, FutureTensor, List[Union[torch.Tensor, FutureTensor]], Tuple[Union[torch.Tensor, FutureTensor], ...]]
 LossFunc = Callable[[torch.Tensor], torch.Tensor]
 FwdStepFunc = Callable[
     [Optional[Batch], torch.nn.Module], Tuple[torch.Tensor, LossFunc]

--- a/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_without_interleaving.py
+++ b/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_without_interleaving.py
@@ -65,13 +65,14 @@ def recv_forward(
     tensor_shapes: List[Union[None, List[int]]],
     *,
     dtype: Optional[torch.dtype] = None,
+    async_comm: bool = False,
 ) -> List[Union[None, torch.Tensor]]:
     input_tensors = []
     for tensor_shape in tensor_shapes:
         if tensor_shape is None:
             input_tensors.append(None)
         else:
-            input_tensors.append(p2p_communication.recv_forward(tensor_shape=tensor_shape, dtype=dtype))
+            input_tensors.append(p2p_communication.recv_forward(tensor_shape=tensor_shape, dtype=dtype, async_comm=async_comm))
     return input_tensors
 
 
@@ -79,13 +80,14 @@ def recv_backward(
     tensor_shapes: List[Union[None, List[int]]],
     *,
     dtype: Optional[torch.dtype] = None,
+    async_comm: bool = False,
 ) -> List[Union[None, torch.Tensor]]:
     output_tensor_grads = []
     for tensor_shape in tensor_shapes:
         if tensor_shape is None:
             output_tensor_grads.append(None)
         else:
-            output_tensor_grads.append(p2p_communication.recv_backward(tensor_shape=tensor_shape, dtype=dtype))
+            output_tensor_grads.append(p2p_communication.recv_backward(tensor_shape=tensor_shape, dtype=dtype, async_comm=async_comm))
     return output_tensor_grads
 
 
@@ -94,13 +96,14 @@ def send_forward(
     tensor_shapes: List[Union[None, List[int]]],
     *,
     dtype: Optional[torch.dtype] = None,
+    async_comm: bool = False,
 ) -> None:
     if not isinstance(output_tensors, list):
         output_tensors = [output_tensors]
     for (output_tensor, tensor_shape) in zip(output_tensors, tensor_shapes):
         if tensor_shape is None:
             continue
-        p2p_communication.send_forward(output_tensor, tensor_shape=tensor_shape, dtype=dtype)
+        p2p_communication.send_forward(output_tensor, tensor_shape=tensor_shape, dtype=dtype, async_comm=async_comm)
 
 
 def send_backward(
@@ -108,13 +111,14 @@ def send_backward(
     tensor_shapes: List[Union[None, List[int]]],
     *,
     dtype: Optional[torch.dtype] = None,
+    async_comm: bool = False,
 ) -> None:
     if not isinstance(input_tensor_grads, list):
         input_tensor_grads = [input_tensor_grads]
     for (input_tensor_grad, tensor_shape) in zip(input_tensor_grads, tensor_shapes):
         if tensor_shape is None:
             continue
-        p2p_communication.send_backward(input_tensor_grad, tensor_shape=tensor_shape, dtype=dtype)
+        p2p_communication.send_backward(input_tensor_grad, tensor_shape=tensor_shape, dtype=dtype, async_comm=async_comm)
 
 
 def send_forward_recv_backward(
@@ -122,6 +126,7 @@ def send_forward_recv_backward(
     tensor_shapes: List[Union[None, List[int]]],
     *,
     dtype: Optional[torch.dtype] = None,
+    async_comm: bool = False,
 ) -> List[Union[None, torch.Tensor]]:
     if not isinstance(output_tensors, list):
         output_tensors = [output_tensors]
@@ -130,7 +135,7 @@ def send_forward_recv_backward(
         if tensor_shape is None:
             output_tensor_grads.append(None)
             continue
-        output_tensor_grad = p2p_communication.send_forward_recv_backward(output_tensor, tensor_shape=tensor_shape, dtype=dtype)
+        output_tensor_grad = p2p_communication.send_forward_recv_backward(output_tensor, tensor_shape=tensor_shape, dtype=dtype, async_comm=async_comm)
         output_tensor_grads.append(output_tensor_grad)
     return output_tensor_grads
 
@@ -140,6 +145,7 @@ def send_backward_recv_forward(
     tensor_shapes: List[Union[None, List[int]]],
     *,
     dtype: Optional[torch.dtype] = None,
+    async_comm: bool = False,
 ) -> List[Union[None, torch.Tensor]]:
     if not isinstance(input_tensor_grads, list):
         input_tensor_grads = [input_tensor_grads]
@@ -148,7 +154,7 @@ def send_backward_recv_forward(
         if tensor_shape is None:
             input_tensors.append(None)
             continue
-        input_tensor = p2p_communication.send_backward_recv_forward(input_tensor_grad, tensor_shape=tensor_shape, dtype=dtype)
+        input_tensor = p2p_communication.send_backward_recv_forward(input_tensor_grad, tensor_shape=tensor_shape, dtype=dtype, async_comm=async_comm)
         input_tensors.append(input_tensor)
     return input_tensors
 
@@ -165,7 +171,8 @@ def forward_backward_pipelining_without_interleaving(
     grad_scaler: Optional[torch.cuda.amp.GradScaler] = None,
     disable_autocast: bool = False,
     deallocate_pipeline_outputs: bool = False,
-    **kwawrgs,
+    async_comm: bool = False,
+    **kwargs,
 ) -> List[Union[torch.Tensor, Sequence[torch.Tensor]]]:
     """Run non-interleaved 1F1B schedule, with communication between pipeline stages.
 
@@ -243,7 +250,7 @@ def forward_backward_pipelining_without_interleaving(
     for i in range(num_warmup_microbatches):
         _logger.debug(f"warmup iter: {i} / {num_warmup_microbatches}")
         _logger.debug("receive fwd")
-        input_tensor = recv_forward(tensor_shapes=recv_tensor_shapes, dtype=dtype)
+        input_tensor = recv_forward(tensor_shapes=recv_tensor_shapes, dtype=dtype, async_comm=async_comm)
         cur_microbatch: Optional[torch.Tensor] = get_kth_microbatch(batch, i)
         output_tensor = forward_step(
             forward_step_func,
@@ -255,7 +262,7 @@ def forward_backward_pipelining_without_interleaving(
             disable_autocast,
         )
         _logger.debug("send fwd")
-        send_forward(output_tensor, tensor_shapes=send_tensor_shapes, dtype=dtype)
+        send_forward(output_tensor, tensor_shapes=send_tensor_shapes, dtype=dtype, async_comm=async_comm)
 
         if not forward_only:
             input_tensors.append(input_tensor)
@@ -267,7 +274,7 @@ def forward_backward_pipelining_without_interleaving(
     # receive this tensor here.
     if num_microbatches_remaining > 0:
         _logger.debug("recv_forward before steady state start")
-        input_tensor: List[Union[None, torch.Tensor]] = recv_forward(tensor_shapes=recv_tensor_shapes, dtype=dtype)
+        input_tensor: List[Union[None, torch.Tensor]] = recv_forward(tensor_shapes=recv_tensor_shapes, dtype=dtype, async_comm=async_comm)
 
     ###################################################################################################################
     # Run 1F1B in steady state.
@@ -289,15 +296,15 @@ def forward_backward_pipelining_without_interleaving(
         )
         if forward_only:
             _logger.debug("send fwd")
-            send_forward(output_tensor, tensor_shapes=send_tensor_shapes, dtype=dtype)
+            send_forward(output_tensor, tensor_shapes=send_tensor_shapes, dtype=dtype, async_comm=async_comm)
 
             if not last_iteration:
                 _logger.debug("receive fwd (last iteration)")
-                input_tensor = recv_forward(tensor_shapes=recv_tensor_shapes, dtype=dtype)
+                input_tensor = recv_forward(tensor_shapes=recv_tensor_shapes, dtype=dtype, async_comm=async_comm)
 
         else:
             _logger.debug("send fwd & receive bwd")
-            output_tensor_grad = send_forward_recv_backward(output_tensor, tensor_shapes=send_tensor_shapes, dtype=dtype)
+            output_tensor_grad = send_forward_recv_backward(output_tensor, tensor_shapes=send_tensor_shapes, dtype=dtype, async_comm=async_comm)
 
             # Add input_tensor and output_tensor to end of list.
             input_tensors.append(input_tensor)
@@ -320,10 +327,10 @@ def forward_backward_pipelining_without_interleaving(
             if last_iteration:
                 input_tensor = None
                 _logger.debug("send bwd")
-                send_backward(input_tensor_grad, tensor_shapes=recv_tensor_shapes, dtype=dtype)
+                send_backward(input_tensor_grad, tensor_shapes=recv_tensor_shapes, dtype=dtype, async_comm=async_comm)
             else:
                 _logger.debug("send bwd and receive fwd")
-                input_tensor = send_backward_recv_forward(input_tensor_grad, tensor_shapes=recv_tensor_shapes, dtype=dtype)
+                input_tensor = send_backward_recv_forward(input_tensor_grad, tensor_shapes=recv_tensor_shapes, dtype=dtype, async_comm=async_comm)
     ###################################################################################################################
     # Run cooldown backward passes.
     ###################################################################################################################
@@ -335,7 +342,7 @@ def forward_backward_pipelining_without_interleaving(
             output_tensor = output_tensors.pop(0)
 
             _logger.debug("receive bwd")
-            output_tensor_grad = recv_backward(tensor_shapes=send_tensor_shapes, dtype=dtype)
+            output_tensor_grad = recv_backward(tensor_shapes=send_tensor_shapes, dtype=dtype, async_comm=async_comm)
 
             input_tensor_grad = backward_step(
                 input_tensor,
@@ -347,6 +354,6 @@ def forward_backward_pipelining_without_interleaving(
             )
 
             _logger.debug("send bwd")
-            send_backward(input_tensor_grad, tensor_shapes=recv_tensor_shapes, dtype=dtype)
+            send_backward(input_tensor_grad, tensor_shapes=recv_tensor_shapes, dtype=dtype, async_comm=async_comm)
 
     return losses_reduced

--- a/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_without_interleaving.py
+++ b/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_without_interleaving.py
@@ -6,6 +6,7 @@ import torch
 from apex.transformer import parallel_state
 from apex.transformer.enums import ModelType
 from apex.transformer.pipeline_parallel import p2p_communication
+from apex.transformer.pipeline_parallel.p2p_communication import FutureTensor
 from apex.transformer.pipeline_parallel.utils import get_kth_microbatch
 from apex.transformer.pipeline_parallel.utils import listify_model
 from apex.transformer.pipeline_parallel.utils import get_num_microbatches
@@ -66,7 +67,7 @@ def recv_forward(
     *,
     dtype: Optional[torch.dtype] = None,
     async_comm: bool = False,
-) -> List[Union[None, torch.Tensor]]:
+) -> List[Union[None, torch.Tensor, FutureTensor]]:
     input_tensors = []
     for tensor_shape in tensor_shapes:
         if tensor_shape is None:
@@ -81,7 +82,7 @@ def recv_backward(
     *,
     dtype: Optional[torch.dtype] = None,
     async_comm: bool = False,
-) -> List[Union[None, torch.Tensor]]:
+) -> List[Union[None, torch.Tensor, FutureTensor]]:
     output_tensor_grads = []
     for tensor_shape in tensor_shapes:
         if tensor_shape is None:
@@ -127,7 +128,7 @@ def send_forward_recv_backward(
     *,
     dtype: Optional[torch.dtype] = None,
     async_comm: bool = False,
-) -> List[Union[None, torch.Tensor]]:
+) -> List[Union[None, torch.Tensor, FutureTensor]]:
     if not isinstance(output_tensors, list):
         output_tensors = [output_tensors]
     output_tensor_grads = []
@@ -146,7 +147,7 @@ def send_backward_recv_forward(
     *,
     dtype: Optional[torch.dtype] = None,
     async_comm: bool = False,
-) -> List[Union[None, torch.Tensor]]:
+) -> List[Union[None, torch.Tensor, FutureTensor]]:
     if not isinstance(input_tensor_grads, list):
         input_tensor_grads = [input_tensor_grads]
     input_tensors = []
@@ -274,7 +275,7 @@ def forward_backward_pipelining_without_interleaving(
     # receive this tensor here.
     if num_microbatches_remaining > 0:
         _logger.debug("recv_forward before steady state start")
-        input_tensor: List[Union[None, torch.Tensor]] = recv_forward(tensor_shapes=recv_tensor_shapes, dtype=dtype, async_comm=async_comm)
+        input_tensor: List[Union[None, torch.Tensor, FutureTensor]] = recv_forward(tensor_shapes=recv_tensor_shapes, dtype=dtype, async_comm=async_comm)
 
     ###################################################################################################################
     # Run 1F1B in steady state.

--- a/tests/L0/run_transformer/run_bert_minimal_test.py
+++ b/tests/L0/run_transformer/run_bert_minimal_test.py
@@ -116,7 +116,7 @@ def fwd_step_func(batch, model):
         lm_loss = torch.sum(lm_loss_.view(-1) * loss_mask.reshape(-1)) / loss_mask.sum()
         averaged_loss = average_losses_across_data_parallel_group([lm_loss])
         if data_idx >= 1536:
-            assert lm_loss < 4.8
+            assert averaged_loss < 4.8
             if not ONCE:
                 print("LOSS OK")
                 ONCE = True
@@ -139,7 +139,7 @@ def train(
         batch = generate_fancy_data_labels(sequence_len, batch_size)
         optim.zero_grad()
         forward_backward_func(
-            fwd_step_func, batch, model, forward_only=False, tensor_shape=tensor_shape
+            fwd_step_func, batch, model, forward_only=False, tensor_shape=tensor_shape, #async_comm=True,
         )
         optim.step()
 
@@ -157,51 +157,57 @@ if __name__ == "__main__":
     initialize_distributed()
     world_size = torch.distributed.get_world_size()
     failure = None
+    init = True
     try:
-        args = global_vars.get_args()
-        args.padded_vocab_size = 128  # needed in standalone gpt
-        batch_size = args.global_batch_size
-        micro_batch_size = args.micro_batch_size
-        setup_microbatch_calculator(
-            args.rank,
-            args.rampup_batch_size,
-            args.global_batch_size,
-            args.micro_batch_size,
-            args.data_parallel_size,
-        )
-        virtual_pipeline_model_parallel_size = 2
-        pipeline_model_parallel_size = world_size
-        parallel_state.initialize_model_parallel(
-            args.tensor_model_parallel_size,
-            args.pipeline_model_parallel_size,
-            virtual_pipeline_model_parallel_size,
-        )
-        pipeline_model_parallel_size = (
-            parallel_state.get_pipeline_model_parallel_world_size()
-        )
-        tensor_parallel.random.model_parallel_cuda_manual_seed(0)
-        model = build_model(
-            bert_model_provider,
-            wrap_with_ddp=True,
-            virtual_pipeline_model_parallel_size=virtual_pipeline_model_parallel_size,
-            cpu_offload=args.cpu_offload,
-        )
-        assert isinstance(model, list)
-        assert len(model) == (
-            1
-            if virtual_pipeline_model_parallel_size is None
-            else virtual_pipeline_model_parallel_size
-        )
-        _param_groups = _get_params_for_weight_decay_optimization(model)
-        optim = torch.optim.Adam(_param_groups)
-        print(effective_length)
-        print(fancy_data.size(0))
-        train(
-            model,
-            optim,
-            virtual_pipeline_model_parallel_size,
-            args.pipeline_model_parallel_size,
-        )
+        for virtual_pipeline_model_parallel_size in (None, 2):
+            data_idx = 0
+            if init:
+                init = False
+                args = global_vars.get_args()
+                args.padded_vocab_size = 128  # needed in standalone gpt
+                batch_size = args.global_batch_size
+                micro_batch_size = args.micro_batch_size
+                setup_microbatch_calculator(
+                    args.rank,
+                    args.rampup_batch_size,
+                    args.global_batch_size,
+                    args.micro_batch_size,
+                    args.data_parallel_size,
+                )
+            else:
+               parallel_state.destroy_model_parallel()
+            parallel_state.initialize_model_parallel(
+                args.tensor_model_parallel_size,
+                args.pipeline_model_parallel_size,
+                virtual_pipeline_model_parallel_size,
+            )
+            pipeline_model_parallel_size = (
+                parallel_state.get_pipeline_model_parallel_world_size()
+            )
+
+            tensor_parallel.random.model_parallel_cuda_manual_seed(0)
+            model = build_model(
+                bert_model_provider,
+                wrap_with_ddp=True,
+                virtual_pipeline_model_parallel_size=virtual_pipeline_model_parallel_size,
+                cpu_offload=args.cpu_offload,
+            )
+            assert isinstance(model, list)
+            assert len(model) == (
+                1
+                if virtual_pipeline_model_parallel_size is None
+                else virtual_pipeline_model_parallel_size
+            )
+            _param_groups = _get_params_for_weight_decay_optimization(model)
+            optim = torch.optim.Adam(_param_groups)
+            print(effective_length)
+            print(fancy_data.size(0))
+            train(
+                model,
+                optim,
+                virtual_pipeline_model_parallel_size,
+                args.pipeline_model_parallel_size,
+            )
     except Exception as e:
         failure = str(e)
     finally:

--- a/tests/L0/run_transformer/run_gpt_minimal_test.py
+++ b/tests/L0/run_transformer/run_gpt_minimal_test.py
@@ -92,7 +92,6 @@ def loss_func(loss_mask, output_tensor):
 
     # Reduce loss for logging.
     averaged_loss = average_losses_across_data_parallel_group([loss])
-    print(averaged_loss)
     return loss, {"lm loss": averaged_loss[0]}
 
 

--- a/tests/L0/run_transformer/run_gpt_minimal_test.py
+++ b/tests/L0/run_transformer/run_gpt_minimal_test.py
@@ -138,7 +138,7 @@ def train(model, optim, pipeline_model_parallel_size, async_comm):
 
 if __name__ == "__main__":
     init = True
-    for async_comm in (True, False):
+    for async_comm in (False, True):
         global fancy_data
         global effective_length
 
@@ -166,6 +166,8 @@ if __name__ == "__main__":
             )
             world_size = torch.distributed.get_world_size()
 
+        print(args.tensor_model_parallel_size, "MODEL PARALLEL SIZE")
+
         parallel_state.initialize_model_parallel(
             tensor_model_parallel_size_=args.tensor_model_parallel_size,
             pipeline_model_parallel_size_=args.pipeline_model_parallel_size,
@@ -187,7 +189,7 @@ if __name__ == "__main__":
         runtime = train(model, optim, args.pipeline_model_parallel_size, async_comm)
 
         parallel_state.destroy_model_parallel()
-        torch.distributed.barrier()
-        if torch.distributed.get_rank() == 0:
-            print(TEST_SUCCESS_MESSAGE)
-            print("Average Iteration Time:", runtime)
+    torch.distributed.barrier()
+    if torch.distributed.get_rank() == 0:
+        print(TEST_SUCCESS_MESSAGE)
+        print("Average Iteration Time:", runtime)

--- a/tests/L0/run_transformer/run_gpt_minimal_test.py
+++ b/tests/L0/run_transformer/run_gpt_minimal_test.py
@@ -92,7 +92,7 @@ def loss_func(loss_mask, output_tensor):
 
     # Reduce loss for logging.
     averaged_loss = average_losses_across_data_parallel_group([loss])
-
+    print(averaged_loss)
     return loss, {"lm loss": averaged_loss[0]}
 
 
@@ -104,7 +104,7 @@ def fwd_step_func(batch, model):
     return output_tensor, partial(loss_func, loss_mask)
 
 
-def train(model, optim, pipeline_model_parallel_size):
+def train(model, optim, pipeline_model_parallel_size, async_comm):
     sequence_len = global_vars.get_args().seq_length
     micro_batch_size = global_vars.get_args().micro_batch_size
     hidden_size = global_vars.get_args().hidden_size
@@ -125,7 +125,7 @@ def train(model, optim, pipeline_model_parallel_size):
             print("finished making batch...")
         optim.zero_grad()
         fwd_bwd_func(
-            fwd_step_func, batch, model, forward_only=False, tensor_shape=tensor_shape
+            fwd_step_func, batch, model, forward_only=False, tensor_shape=tensor_shape, async_comm=async_comm
         )
         if torch.distributed.get_rank() == 0:
             print("finished forward step")
@@ -137,53 +137,57 @@ def train(model, optim, pipeline_model_parallel_size):
 
 
 if __name__ == "__main__":
-    global fancy_data
-    global effective_length
+    init = True
+    for async_comm in (True, False):
+        global fancy_data
+        global effective_length
 
-    global_vars.set_global_variables()
+        if init:
+            init = False
+            global_vars.set_global_variables()
+            args = global_vars.get_args()
+            fancy_data = download_fancy_data()
+            effective_length = fancy_data.size(0) // args.seq_length
+            effective_length = fancy_data.size(0) - args.seq_length
 
-    fancy_data = download_fancy_data()
-    args = global_vars.get_args()
-    effective_length = fancy_data.size(0) // args.seq_length
-    effective_length = fancy_data.size(0) - args.seq_length
+            initialize_distributed()
+            world_size = torch.distributed.get_world_size()
 
-    initialize_distributed()
-    world_size = torch.distributed.get_world_size()
+            failure = None
+            args.padded_vocab_size = 128
+            batch_size = args.global_batch_size
+            micro_batch_size = args.micro_batch_size
+            setup_microbatch_calculator(
+                args.rank,
+                args.rampup_batch_size,
+                args.global_batch_size,
+                args.micro_batch_size,
+                args.data_parallel_size,  # args.data_parallel_size,
+            )
+            world_size = torch.distributed.get_world_size()
 
-    failure = None
-    args.padded_vocab_size = 128
-    batch_size = args.global_batch_size
-    micro_batch_size = args.micro_batch_size
-    setup_microbatch_calculator(
-        args.rank,
-        args.rampup_batch_size,
-        args.global_batch_size,
-        args.micro_batch_size,
-        args.data_parallel_size,  # args.data_parallel_size,
-    )
-    world_size = torch.distributed.get_world_size()
-    parallel_state.initialize_model_parallel(
-        tensor_model_parallel_size_=args.tensor_model_parallel_size,
-        pipeline_model_parallel_size_=args.pipeline_model_parallel_size,
-    )
+        parallel_state.initialize_model_parallel(
+            tensor_model_parallel_size_=args.tensor_model_parallel_size,
+            pipeline_model_parallel_size_=args.pipeline_model_parallel_size,
+        )
 
-    pipeline_model_parallel_size = (
-        parallel_state.get_pipeline_model_parallel_world_size()
-    )
-    model_parallel_cuda_manual_seed(0)
-    model = build_model(
-        gpt_model_provider,
-        wrap_with_ddp=True,
-        virtual_pipeline_model_parallel_size=None,
-        cpu_offload=args.cpu_offload,
-    )
-    assert isinstance(model, list), model
-    _param_groups = _get_params_for_weight_decay_optimization(model)
-    optim = torch.optim.Adam(_param_groups)
-    runtime = train(model, optim, args.pipeline_model_parallel_size)
+        pipeline_model_parallel_size = (
+            parallel_state.get_pipeline_model_parallel_world_size()
+        )
+        model_parallel_cuda_manual_seed(0)
+        model = build_model(
+            gpt_model_provider,
+            wrap_with_ddp=True,
+            virtual_pipeline_model_parallel_size=None,
+            cpu_offload=args.cpu_offload,
+        )
+        assert isinstance(model, list), model
+        _param_groups = _get_params_for_weight_decay_optimization(model)
+        optim = torch.optim.Adam(_param_groups)
+        runtime = train(model, optim, args.pipeline_model_parallel_size, async_comm)
 
-    parallel_state.destroy_model_parallel()
-    torch.distributed.barrier()
-    if torch.distributed.get_rank() == 0:
-        print(TEST_SUCCESS_MESSAGE)
-        print("Average Iteration Time:", runtime)
+        parallel_state.destroy_model_parallel()
+        torch.distributed.barrier()
+        if torch.distributed.get_rank() == 0:
+            print(TEST_SUCCESS_MESSAGE)
+            print("Average Iteration Time:", runtime)

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -70,6 +70,7 @@ class PipelineParallelForwardBackwardTest(DistributedTestBase):
         fwd_bwd_func: FwdStepFunc,
         pipeline_model_parallel_world_size: Optional[int],
         virtual_pipeline_model_parallel_size: Optional[int],
+        async_comm: bool = False,
     ) -> None:
         for dtype, deallocate_pipeline_outputs in itertools.product(
             [torch.float32] + _get_autocast_dtypes(), (True, False),
@@ -136,6 +137,7 @@ class PipelineParallelForwardBackwardTest(DistributedTestBase):
                     PipelineParallelForwardBackwardTest.HIDDEN_SIZE,
                 ),
                 dtype=dtype,
+                async_comm=async_comm,
                 grad_scaler=grad_scaler,
                 deallocate_pipeline_output=deallocate_pipeline_outputs,
             )
@@ -167,6 +169,11 @@ class PipelineParallelForwardBackwardTest(DistributedTestBase):
     def test_pipelining(self):
         self._forward_backward_test_impl(
             False, forward_backward_pipelining_without_interleaving, None, None
+        )
+
+    def test_pipelining_async(self):
+        self._forward_backward_test_impl(
+            False, forward_backward_pipelining_without_interleaving, None, None, True
         )
 
     def test_pipelining_inference(self):

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -166,7 +166,7 @@ class PipelineParallelForwardBackwardTest(DistributedTestBase):
     def test_no_pipelining_inference(self):
         self._forward_backward_test_impl(True, forward_backward_no_pipelining, 1, None)
 
-    def test_pipelining(self):
+    def test_pipelining_default(self):
         self._forward_backward_test_impl(
             False, forward_backward_pipelining_without_interleaving, None, None
         )

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -173,12 +173,17 @@ class PipelineParallelForwardBackwardTest(DistributedTestBase):
 
     def test_pipelining_async(self):
         self._forward_backward_test_impl(
-            False, forward_backward_pipelining_without_interleaving, None, None, True
+            False, forward_backward_pipelining_without_interleaving, None, None, async_comm=True
         )
 
     def test_pipelining_inference(self):
         self._forward_backward_test_impl(
             True, forward_backward_pipelining_without_interleaving, None, None
+        )
+
+    def test_pipelining_inference_async(self):
+        self._forward_backward_test_impl(
+            True, forward_backward_pipelining_without_interleaving, None, None, async_comm=True
         )
 
     def test_pipelining_with_interleaving(self):


### PR DESCRIPTION
(non-interleaved, needs more tests and performance verification)

Current questions:
Does `wait()` need to be respected for `isend` calls? Is there a danger of the underlying memory being repurposed without it?

Why is `torch.cuda.synchronize()` called after `wait()`? Is `wait()` alone not safe enough or is there some issue where CUDA kernel launches aren't serialized?
Follow-up: *Seems important that `torch.cuda.synchronize()` is called _before_ the gather* see also: https://github.com/NVIDIA/Megatron-LM/commit/27fc468964064eeb33b703c9a0b2af938d80dd14

Does the batched `isend`/`irecv` produces reqs that correspond 1:1 with the `P2POp`s?