### PR TITLE
[WIP] [transformer] add loss comparison to test_pipeline_parallel_fwd_bwd

### DIFF
--- a/apex/transformer/testing/commons.py
+++ b/apex/transformer/testing/commons.py
@@ -38,13 +38,6 @@ class MyLayer(nn.Module):
         self.post_process = post_process
         self.layer = nn.Linear(hidden_size, hidden_size)
 
-        with torch.no_grad():
-            rank = torch.cuda.current_device()
-            weights = torch.ones((hidden_size, hidden_size)) + rank
-            biases = torch.ones((hidden_size))
-            self.layer.weight.copy_(weights)
-            self.layer.bias.copy_(biases)
-
     def forward(self, x):
         return self.layer(x)
 

--- a/apex/transformer/testing/commons.py
+++ b/apex/transformer/testing/commons.py
@@ -38,6 +38,13 @@ class MyLayer(nn.Module):
         self.post_process = post_process
         self.layer = nn.Linear(hidden_size, hidden_size)
 
+        with torch.no_grad():
+            rank = torch.cuda.current_device()
+            weights = torch.ones((hidden_size, hidden_size)) + rank
+            biases = torch.ones((hidden_size))
+            self.layer.weight.copy_(weights)
+            self.layer.bias.copy_(biases)
+
     def forward(self, x):
         return self.layer(x)
 

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -43,9 +43,9 @@ def get_target_loss(hidden_size: int, microbatch_size: int, parallel_model_world
     layers_per_rank = world_size // parallel_model_world_size
     data = torch.arange(start = 0, end = layers_per_rank, dtype = torch.int) + 1
     
-    w = (torch.arange(world_size, dtype = torch.int) + 1)
+    w = (torch.arange(world_size, dtype = torch.int) + 1) / weight_coeff
     b = torch.ones(world_size, dtype = torch.int)
-    w = hidden_size * w / weight_coeff
+    w = hidden_size * w
 
     for pd in range(0, world_size, layers_per_rank):
         eid = pd+layers_per_rank
@@ -83,6 +83,8 @@ class PipelineParallelForwardBackwardTest(DistributedTestBase):
 
             if pipeline_model_parallel_world_size is None:
                 pipeline_model_parallel_world_size =  self.world_size // (tensor_model_parallel_world_size * data_parallel_size)
+            else:
+                data_parallel_size = self.world_size // (tensor_model_parallel_world_size * pipeline_model_parallel_world_size)
 
             parallel_state.initialize_model_parallel(
                 tensor_model_parallel_size_=tensor_model_parallel_world_size,


### PR DESCRIPTION
Added a loss comparison to `test_pipeline_parallel_fwd_bwd.py`.
In order to effectively predict the target loss value, `apex/transformer/testing/commons.py` was also modified to prevent randomization of weights. 

EDIT: 
On second commit I applied some of the suggested changes:
- Reverted the changes in `commons.py`. Instead, the test calls `torch.nn.Module.apply`.
- Minor change in the assertion line.
- Added `get_target_loss` that calculates the loss assuming that `forward_backward_no_pipelining` is correct...

I kept `rank = torch.distributed.get_rank()` because ~~`parallel_state.get_rank_info()` returns something weird...~~ it is easier to debug.

EDIT 2:
- Target loss calculation function is now correct for any size of `pipeline_model_parallel_world_size`.
- Test changed for running on `float32` by default. 