### PR TITLE
Add get_world_info()

### DIFF
--- a/apex/transformer/parallel_state.py
+++ b/apex/transformer/parallel_state.py
@@ -268,7 +268,7 @@ def get_rank_info() -> Tuple[int, int, int]:
             get_pipeline_model_parallel_rank(),
             get_virtual_pipeline_model_parallel_rank(),
         )
-    return (0, 0, 0, 0)
+    return (-1, -1, -1, -1)
 
 
 def model_parallel_is_initialized():

--- a/apex/transformer/parallel_state.py
+++ b/apex/transformer/parallel_state.py
@@ -247,6 +247,18 @@ def initialize_model_parallel(
             _POSITION_EMBEDDING_GLOBAL_RANKS = position_embedding_ranks
 
 
+def get_world_info() -> Tuple[int, int, int]:
+    """Returns a tuple of (data, tensor, pipeline, virtual pipeline)-parallel-world_size for logger."""
+    if model_parallel_is_initialized():
+        return (
+            get_data_parallel_world_size(),
+            get_tensor_model_parallel_world_size(),
+            get_pipeline_model_parallel_world_size(),
+            get_virtual_pipeline_model_parallel_world_size(),
+        )
+    return (0, 0, 0, 0)
+
+
 def get_rank_info() -> Tuple[int, int, int]:
     """Returns a tuple of (data, tensor, pipeline, virtual pipeline)-parallel-rank for logger."""
     if model_parallel_is_initialized():


### PR DESCRIPTION
A method `get_world_info()` will be very useful for variety of purposes especially for testing and debugging.
Additionally, returning all zeros in `get_rank_info()` when parallel is not initialized can be misleading. 
I think it would be even better to have `assert model_parallel_is_initialized()` in future. 