### PR TITLE
[transformer] Allow for different backend for Pipeline Parallel ProcessGroups

### DIFF
--- a/apex/transformer/parallel_state.py
+++ b/apex/transformer/parallel_state.py
@@ -122,7 +122,7 @@ def initialize_model_parallel(
         check_torch_ucc_availability()
         warnings.warn("`ucc` backend support is experimental", ExperimentalWarning)
     if default_backend == "ucc":
-        warnings.warn("The UCC's functionalit as `default_backend` is not well verified", ExperimentalWarning)
+        warnings.warn("The UCC's functionality as `default_backend` is not well verified", ExperimentalWarning)
 
     world_size: int = torch.distributed.get_world_size()
     tensor_model_parallel_size: int = min(tensor_model_parallel_size_, world_size)

--- a/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_without_interleaving.py
+++ b/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_without_interleaving.py
@@ -101,7 +101,7 @@ def send_forward(
 ) -> None:
     if not isinstance(output_tensors, list):
         output_tensors = [output_tensors]
-    for (output_tensor, tensor_shape) in zip(output_tensors, tensor_shapes):
+    for output_tensor, tensor_shape in zip(output_tensors, tensor_shapes):
         if tensor_shape is None:
             continue
         p2p_communication.send_forward(output_tensor, tensor_shape=tensor_shape, dtype=dtype, async_comm=async_comm)
@@ -116,7 +116,7 @@ def send_backward(
 ) -> None:
     if not isinstance(input_tensor_grads, list):
         input_tensor_grads = [input_tensor_grads]
-    for (input_tensor_grad, tensor_shape) in zip(input_tensor_grads, tensor_shapes):
+    for input_tensor_grad, tensor_shape in zip(input_tensor_grads, tensor_shapes):
         if tensor_shape is None:
             continue
         p2p_communication.send_backward(input_tensor_grad, tensor_shape=tensor_shape, dtype=dtype, async_comm=async_comm)
@@ -132,7 +132,7 @@ def send_forward_recv_backward(
     if not isinstance(output_tensors, list):
         output_tensors = [output_tensors]
     output_tensor_grads = []
-    for (output_tensor, tensor_shape) in zip(output_tensors, tensor_shapes):
+    for output_tensor, tensor_shape in zip(output_tensors, tensor_shapes):
         if tensor_shape is None:
             output_tensor_grads.append(None)
             continue
@@ -151,7 +151,7 @@ def send_backward_recv_forward(
     if not isinstance(input_tensor_grads, list):
         input_tensor_grads = [input_tensor_grads]
     input_tensors = []
-    for (input_tensor_grad, tensor_shape) in zip(input_tensor_grads, tensor_shapes):
+    for input_tensor_grad, tensor_shape in zip(input_tensor_grads, tensor_shapes):
         if tensor_shape is None:
             input_tensors.append(None)
             continue

--- a/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_without_interleaving.py
+++ b/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_without_interleaving.py
@@ -101,7 +101,7 @@ def send_forward(
 ) -> None:
     if not isinstance(output_tensors, list):
         output_tensors = [output_tensors]
-    for output_tensor, tensor_shape in zip(output_tensors, tensor_shapes):
+    for (output_tensor, tensor_shape) in zip(output_tensors, tensor_shapes):
         if tensor_shape is None:
             continue
         p2p_communication.send_forward(output_tensor, tensor_shape=tensor_shape, dtype=dtype, async_comm=async_comm)
@@ -116,7 +116,7 @@ def send_backward(
 ) -> None:
     if not isinstance(input_tensor_grads, list):
         input_tensor_grads = [input_tensor_grads]
-    for input_tensor_grad, tensor_shape in zip(input_tensor_grads, tensor_shapes):
+    for (input_tensor_grad, tensor_shape) in zip(input_tensor_grads, tensor_shapes):
         if tensor_shape is None:
             continue
         p2p_communication.send_backward(input_tensor_grad, tensor_shape=tensor_shape, dtype=dtype, async_comm=async_comm)
@@ -132,7 +132,7 @@ def send_forward_recv_backward(
     if not isinstance(output_tensors, list):
         output_tensors = [output_tensors]
     output_tensor_grads = []
-    for output_tensor, tensor_shape in zip(output_tensors, tensor_shapes):
+    for (output_tensor, tensor_shape) in zip(output_tensors, tensor_shapes):
         if tensor_shape is None:
             output_tensor_grads.append(None)
             continue
@@ -151,7 +151,7 @@ def send_backward_recv_forward(
     if not isinstance(input_tensor_grads, list):
         input_tensor_grads = [input_tensor_grads]
     input_tensors = []
-    for input_tensor_grad, tensor_shape in zip(input_tensor_grads, tensor_shapes):
+    for (input_tensor_grad, tensor_shape) in zip(input_tensor_grads, tensor_shapes):
         if tensor_shape is None:
             input_tensors.append(None)
             continue

--- a/apex/transformer/testing/commons.py
+++ b/apex/transformer/testing/commons.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
 import os
 import random
 from typing import Optional, Union, List
@@ -145,7 +146,8 @@ def initialize_distributed(backend="nccl"):
     master_port = os.getenv("MASTER_PORT", "6000")
     init_method += master_ip + ":" + master_port
     torch.distributed.init_process_group(
-        backend=backend, world_size=world_size, rank=rank, init_method=init_method
+        backend=backend, world_size=world_size, rank=rank, init_method=init_method,
+        timeout=datetime.timedelta(seconds=60),
     )
 
 

--- a/apex/transformer/testing/commons.py
+++ b/apex/transformer/testing/commons.py
@@ -117,6 +117,10 @@ def initialize_distributed(backend="nccl"):
     # parser.add_argument('--local_rank', type=int, default=None,
     #                    help='local rank passed from distributed launcher')
     # args = parser.parse_args()
+    if backend not in ("nccl", "ucc"):
+        raise RuntimeError(f"Currently only nccl & ucc are supported but {backend}")
+    if backend == "ucc":
+        import torch_ucc  # NOQA
     args = global_vars.get_args()
     local_rank = args.local_rank
 

--- a/apex/transformer/testing/distributed_test_base.py
+++ b/apex/transformer/testing/distributed_test_base.py
@@ -91,7 +91,8 @@ class NcclDistributedTestBase(DistributedTestBase):
 )
 @unittest.skipUnless(
     HAS_TORCH_UCC_COMPAT_NVIDIA_DRIVER,
-    f"`torch_ucc` requires NVIDIA driver >= {_TORCH_UCC_COMPAT_NVIDIA_DRIVER_VERSION} but {_driver_version} found",
+    f"`torch_ucc` requires NVIDIA driver >= {_TORCH_UCC_COMPAT_NVIDIA_DRIVER_VERSION} but {_driver_version} found. "
+    "See https://github.com/openucx/ucc/issues/496",
 )
 class UccDistributedTestBase(DistributedTestBase):
 

--- a/apex/transformer/testing/distributed_test_base.py
+++ b/apex/transformer/testing/distributed_test_base.py
@@ -77,7 +77,10 @@ class NcclDistributedTestBase(DistributedTestBase):
     DISTRIBUTED_BACKEND = "nccl"
 
 
-@unittest.skipUnless(HAS_TORCH_UCC, "Requires torch_ucc")
+@unittest.skipUnless(
+    HAS_TORCH_UCC,
+    "Requires [`torch_ucc`](https://github.com/facebookresearch/torch_ucc)",
+)
 class UccDistributedTestBase(DistributedTestBase):
 
     DISTRIBUTED_BACKEND = "ucc"
@@ -86,7 +89,7 @@ class UccDistributedTestBase(DistributedTestBase):
         self.master_addr = "localhost"
         os.environ["MASTER_ADDR"] = "localhost"
         self._has_master_port = "MASTER_PORT" in os.environ
-        if self._has_master_port in os.environ:
+        if self._has_master_port:
             self.master_port = os.environ["MASTER_PORT"]
         else:
             try:

--- a/apex/transformer/testing/distributed_test_base.py
+++ b/apex/transformer/testing/distributed_test_base.py
@@ -101,7 +101,8 @@ class UccDistributedTestBase(DistributedTestBase):
 
         self._has_ucx_tls = "UCX_TLS" in os.environ
         if not self._has_ucx_tls:
-            os.environ["UCX_TLS"] = "sm,tcp"
+            os.environ["UCX_TLS"] = "tcp,cuda_copy"
+        print('os.environ[\"UCX_TLS\"] = {}'.format(os.environ["UCX_TLS"]))
 
     def tearDown(self) -> None:
         super().tearDown()

--- a/tests/L0/run_transformer/run_bert_minimal_test.py
+++ b/tests/L0/run_transformer/run_bert_minimal_test.py
@@ -1,5 +1,12 @@
 import random
 import torch
+try:
+    import torch_ucc
+except ImportError:
+    HAS_TORCH_UCC = False
+else:
+    HAS_TORCH_UCC = True
+    print("Use UCC as backend of Pipeline Parallel ProcessGroups")
 
 from apex.transformer import tensor_parallel
 from apex.transformer import parallel_state
@@ -184,6 +191,8 @@ if __name__ == "__main__":
                 args.tensor_model_parallel_size,
                 args.pipeline_model_parallel_size,
                 virtual_pipeline_model_parallel_size,
+                default_backend="nccl",
+                p2p_backend="ucc" if HAS_TORCH_UCC else "nccl",
             )
             pipeline_model_parallel_size = (
                 parallel_state.get_pipeline_model_parallel_world_size()

--- a/tests/L0/run_transformer/run_bert_minimal_test.py
+++ b/tests/L0/run_transformer/run_bert_minimal_test.py
@@ -3,6 +3,7 @@ import torch
 
 from apex.transformer import tensor_parallel
 from apex.transformer import parallel_state
+from apex.transformer.log_util import set_logging_level
 from apex.transformer.tensor_parallel import vocab_parallel_cross_entropy
 from apex.transformer.pipeline_parallel.utils import setup_microbatch_calculator
 from apex.transformer.pipeline_parallel.utils import (
@@ -27,6 +28,7 @@ class DebugWarning(Warning):
     pass
 
 
+set_logging_level("WARNING")
 mode = None
 MANUAL_SEED = 42
 inds = None
@@ -154,7 +156,7 @@ if __name__ == "__main__":
     effective_length = fancy_data.size(0) // global_vars.get_args().seq_length
     effective_length = fancy_data.size(0) - global_vars.get_args().seq_length
 
-    initialize_distributed()
+    initialize_distributed("nccl")
     world_size = torch.distributed.get_world_size()
     failure = None
     init = True

--- a/tests/L0/run_transformer/run_gpt_minimal_test.py
+++ b/tests/L0/run_transformer/run_gpt_minimal_test.py
@@ -172,7 +172,8 @@ if __name__ == "__main__":
         parallel_state.initialize_model_parallel(
             tensor_model_parallel_size_=args.tensor_model_parallel_size,
             pipeline_model_parallel_size_=args.pipeline_model_parallel_size,
-            use_ucc_for_pipeline_parallel=True,
+            default_backend="nccl",
+            p2p_backend="ucc",
         )
 
         pipeline_model_parallel_size = (

--- a/tests/L0/run_transformer/run_gpt_minimal_test.py
+++ b/tests/L0/run_transformer/run_gpt_minimal_test.py
@@ -3,6 +3,13 @@ from typing import List
 import time
 
 import torch
+try:
+    import torch_ucc
+except ImportError:
+    HAS_TORCH_UCC = False
+else:
+    HAS_TORCH_UCC = True
+    print("Use UCC as backend of Pipeline Parallel ProcessGroups")
 
 from apex.transformer import parallel_state
 from apex.transformer.tensor_parallel import model_parallel_cuda_manual_seed
@@ -173,7 +180,7 @@ if __name__ == "__main__":
             tensor_model_parallel_size_=args.tensor_model_parallel_size,
             pipeline_model_parallel_size_=args.pipeline_model_parallel_size,
             default_backend="nccl",
-            p2p_backend="ucc",
+            p2p_backend="ucc" if HAS_TORCH_UCC else "nccl",
         )
 
         pipeline_model_parallel_size = (

--- a/tests/L0/run_transformer/run_gpt_minimal_test.py
+++ b/tests/L0/run_transformer/run_gpt_minimal_test.py
@@ -196,7 +196,7 @@ if __name__ == "__main__":
         assert isinstance(model, list), model
         _param_groups = _get_params_for_weight_decay_optimization(model)
         optim = torch.optim.Adam(_param_groups)
-        runtime = train(model, optim, args.pipeline_model_parallel_size)
+        runtime = train(model, optim, args.pipeline_model_parallel_size, async_comm)
 
         parallel_state.destroy_model_parallel()
     torch.distributed.barrier()

--- a/tests/L0/run_transformer/run_gpt_minimal_test.py
+++ b/tests/L0/run_transformer/run_gpt_minimal_test.py
@@ -172,6 +172,7 @@ if __name__ == "__main__":
         parallel_state.initialize_model_parallel(
             tensor_model_parallel_size_=args.tensor_model_parallel_size,
             pipeline_model_parallel_size_=args.pipeline_model_parallel_size,
+            use_ucc_for_pipeline_parallel=True,
         )
 
         pipeline_model_parallel_size = (

--- a/tests/L0/run_transformer/test_cross_entropy.py
+++ b/tests/L0/run_transformer/test_cross_entropy.py
@@ -12,6 +12,7 @@ from apex.transformer import tensor_parallel
 from apex.transformer.tensor_parallel import cross_entropy
 from apex.transformer.testing.commons import set_random_seed, IdentityLayer
 from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
+from apex.transformer.testing.distributed_test_base import UccDistributedTestBase
 
 logging.getLogger("apex").setLevel(logging.WARNING)
 
@@ -54,7 +55,7 @@ def tensor_sharded_cross_entropy(
     return loss, identity.weight.grad
 
 
-class VocabParallelCrossEntropy(NcclDistributedTestBase):
+class VocabParallelCrossEntropyTestBase:
     def test_cross_entropy(self):
         batch_size, sequence_length, vocab_size_per_partition = 13, 17, 11
         logits_scale = 1000.0
@@ -83,6 +84,10 @@ class VocabParallelCrossEntropy(NcclDistributedTestBase):
                 torch.testing.assert_close(grad_torch, grad_tensor_parallel)
 
                 parallel_state.destroy_model_parallel()
+
+
+class NcclVocabParallelCrossEntropyTest(VocabParallelCrossEntropyTestBase, NcclDistributedTestBase): pass
+class UccVocabParallelCrossEntropyTest(VocabParallelCrossEntropyTestBase, UccDistributedTestBase): pass
 
 
 if __name__ == "__main__":

--- a/tests/L0/run_transformer/test_cross_entropy.py
+++ b/tests/L0/run_transformer/test_cross_entropy.py
@@ -11,7 +11,7 @@ from apex.transformer import parallel_state
 from apex.transformer import tensor_parallel
 from apex.transformer.tensor_parallel import cross_entropy
 from apex.transformer.testing.commons import set_random_seed, IdentityLayer
-from apex.transformer.testing.distributed_test_base import DistributedTestBase
+from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
 
 logging.getLogger("apex").setLevel(logging.WARNING)
 
@@ -54,7 +54,7 @@ def tensor_sharded_cross_entropy(
     return loss, identity.weight.grad
 
 
-class VocabParallelCrossEntropy(DistributedTestBase):
+class VocabParallelCrossEntropy(NcclDistributedTestBase):
     def test_cross_entropy(self):
         batch_size, sequence_length, vocab_size_per_partition = 13, 17, 11
         logits_scale = 1000.0

--- a/tests/L0/run_transformer/test_data.py
+++ b/tests/L0/run_transformer/test_data.py
@@ -7,12 +7,12 @@ logging.getLogger("torch").setLevel(logging.WARNING)
 
 from apex.transformer import parallel_state
 from apex.transformer.tensor_parallel import data as data_utils
-from apex.transformer.testing.distributed_test_base import DistributedTestBase
+from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
 
 logging.getLogger("torch").setLevel(logging.WARNING)
 
 
-class BroadcastDataTest(DistributedTestBase):
+class BroadcastDataTest(NcclDistributedTestBase):
     def test_broadcast_data(self):
         tensor_model_parallel_world_size: int = self.world_size // (
             1 + self.world_size > 1

--- a/tests/L0/run_transformer/test_data.py
+++ b/tests/L0/run_transformer/test_data.py
@@ -8,11 +8,12 @@ logging.getLogger("torch").setLevel(logging.WARNING)
 from apex.transformer import parallel_state
 from apex.transformer.tensor_parallel import data as data_utils
 from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
+from apex.transformer.testing.distributed_test_base import UccDistributedTestBase
 
 logging.getLogger("torch").setLevel(logging.WARNING)
 
 
-class BroadcastDataTest(NcclDistributedTestBase):
+class BroadcastDataTestBase:
     def test_broadcast_data(self):
         tensor_model_parallel_world_size: int = self.world_size // (
             1 + self.world_size > 1
@@ -53,6 +54,10 @@ class BroadcastDataTest(NcclDistributedTestBase):
             torch.testing.assert_close(broadcasted_data[key], data_t[key].cuda())
 
         parallel_state.destroy_model_parallel()
+
+
+class NcclBroadcastDataTest(BroadcastDataTestBase, NcclDistributedTestBase): pass
+class UccBroadcastDataTest(BroadcastDataTestBase, UccDistributedTestBase): pass
 
 
 if __name__ == "__main__":

--- a/tests/L0/run_transformer/test_layers.py
+++ b/tests/L0/run_transformer/test_layers.py
@@ -10,6 +10,7 @@ from apex.transformer import parallel_state
 from apex.transformer.tensor_parallel import layers
 from apex.transformer.testing.commons import set_random_seed
 from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
+from apex.transformer.testing.distributed_test_base import UccDistributedTestBase
 
 logging.getLogger("apex").setLevel(logging.WARNING)
 
@@ -20,7 +21,7 @@ logging.getLogger("apex").setLevel(logging.WARNING)
 torch.backends.cuda.matmul.allow_tf32 = False
 
 
-class TensorParallelLayerTest(NcclDistributedTestBase):
+class TensorParallelLayerTestBase:
 
     BATCH_SIZE: int = 17
     SEQUENCE_LENGTH: int = 23
@@ -40,29 +41,29 @@ class TensorParallelLayerTest(NcclDistributedTestBase):
                 parallel_state.initialize_model_parallel(
                     tensor_model_parallel_size_=tensor_model_parallel_world_size,
                 )
-                set_random_seed(TensorParallelLayerTest.SEED + 1)
+                set_random_seed(self.SEED + 1)
                 input_tensor = torch.randint(
                     0,
-                    TensorParallelLayerTest.VOCAB_SIZE,
+                    self.VOCAB_SIZE,
                     (
-                        TensorParallelLayerTest.BATCH_SIZE,
-                        TensorParallelLayerTest.SEQUENCE_LENGTH,
+                        self.BATCH_SIZE,
+                        self.SEQUENCE_LENGTH,
                     ),
                     device="cuda",
                 )
                 loss_weight = torch.randn(
                     (
-                        TensorParallelLayerTest.BATCH_SIZE,
-                        TensorParallelLayerTest.SEQUENCE_LENGTH,
-                        TensorParallelLayerTest.HIDDEN_SIZE,
+                        self.BATCH_SIZE,
+                        self.SEQUENCE_LENGTH,
+                        self.HIDDEN_SIZE,
                     ),
                     device="cuda",
                 )
 
-                set_random_seed(TensorParallelLayerTest.SEED)
+                set_random_seed(self.SEED)
                 embedding_torch = nn.Embedding(
-                    TensorParallelLayerTest.VOCAB_SIZE,
-                    TensorParallelLayerTest.HIDDEN_SIZE,
+                    self.VOCAB_SIZE,
+                    self.HIDDEN_SIZE,
                 ).cuda()
                 output_torch = embedding_torch(input_tensor)
                 loss_torch = torch.mul(output_torch, loss_weight).sum()
@@ -71,10 +72,10 @@ class TensorParallelLayerTest(NcclDistributedTestBase):
                 # N.B. (mkozuki): With affine weight initialization on GPU,
                 # it's super difficult to keep the consistency with nn.Embedding.
                 # Thus, turning on `use_cpu_initialization`.
-                set_random_seed(TensorParallelLayerTest.SEED)
+                set_random_seed(self.SEED)
                 embedding_vocab_parallel = layers.VocabParallelEmbedding(
-                    TensorParallelLayerTest.VOCAB_SIZE,
-                    TensorParallelLayerTest.HIDDEN_SIZE,
+                    self.VOCAB_SIZE,
+                    self.HIDDEN_SIZE,
                     init_method=nn.init.normal_,
                     use_cpu_initialization=True,
                 ).cuda()
@@ -89,7 +90,7 @@ class TensorParallelLayerTest(NcclDistributedTestBase):
 
                 splitted_weight_torch = torch.split(
                     embedding_torch.weight.grad,
-                    TensorParallelLayerTest.VOCAB_SIZE
+                    self.VOCAB_SIZE
                     // tensor_model_parallel_world_size,
                     0,
                 )[parallel_state.get_tensor_model_parallel_rank()]
@@ -112,21 +113,21 @@ class TensorParallelLayerTest(NcclDistributedTestBase):
                 parallel_state.initialize_model_parallel(
                     tensor_model_parallel_size_=tensor_model_parallel_world_size
                 )
-                input_size: int = TensorParallelLayerTest.INPUT_SIZE_COEFF * tensor_model_parallel_world_size
-                output_size: int = TensorParallelLayerTest.OUTPUT_SIZE_COEFF * tensor_model_parallel_world_size
+                input_size: int = self.INPUT_SIZE_COEFF * tensor_model_parallel_world_size
+                output_size: int = self.OUTPUT_SIZE_COEFF * tensor_model_parallel_world_size
 
                 weight_shape = (
-                    (TensorParallelLayerTest.OUTPUT_SIZE_COEFF, input_size)
+                    (self.OUTPUT_SIZE_COEFF, input_size)
                     if is_column_parallel
-                    else (output_size, TensorParallelLayerTest.INPUT_SIZE_COEFF)
+                    else (output_size, self.INPUT_SIZE_COEFF)
                 )
                 weight = torch.empty(weight_shape)
-                set_random_seed(TensorParallelLayerTest.SEED)
+                set_random_seed(self.SEED)
 
                 sharding_dim_size = (
-                    TensorParallelLayerTest.OUTPUT_SIZE_COEFF
+                    self.OUTPUT_SIZE_COEFF
                     if is_column_parallel
-                    else TensorParallelLayerTest.INPUT_SIZE_COEFF
+                    else self.INPUT_SIZE_COEFF
                 )
 
                 if init_device == "cpu":
@@ -144,7 +145,7 @@ class TensorParallelLayerTest(NcclDistributedTestBase):
                         weight, torch.nn.init.normal_, dim
                     )
                 # Target
-                set_random_seed(TensorParallelLayerTest.SEED)
+                set_random_seed(self.SEED)
                 if init_device == "cpu":
                     main_weight = torch.empty(output_size, input_size)
                     nn.init.normal_(main_weight)
@@ -180,10 +181,10 @@ class TensorParallelLayerTest(NcclDistributedTestBase):
                     tensor_model_parallel_size_=tensor_model_parallel_world_size
                 )
 
-                input_size: int = TensorParallelLayerTest.INPUT_SIZE_COEFF * tensor_model_parallel_world_size
-                output_size: int = TensorParallelLayerTest.OUTPUT_SIZE_COEFF * tensor_model_parallel_world_size
+                input_size: int = self.INPUT_SIZE_COEFF * tensor_model_parallel_world_size
+                output_size: int = self.OUTPUT_SIZE_COEFF * tensor_model_parallel_world_size
 
-                set_random_seed(TensorParallelLayerTest.SEED)
+                set_random_seed(self.SEED)
                 linear_layer = layers.RowParallelLinear(
                     input_size,
                     output_size,
@@ -192,12 +193,12 @@ class TensorParallelLayerTest(NcclDistributedTestBase):
                     use_cpu_initialization=True,
                 ).cuda()
                 loss_weight = torch.randn(
-                    (TensorParallelLayerTest.BATCH_SIZE, output_size)
+                    (self.BATCH_SIZE, output_size)
                 ).cuda()
 
                 # Forward and backward
                 input_tensor = torch.randn(
-                    TensorParallelLayerTest.BATCH_SIZE, input_size, requires_grad=True
+                    self.BATCH_SIZE, input_size, requires_grad=True
                 ).cuda()
                 input_tensor.retain_grad()
                 output, _ = linear_layer(input_tensor)
@@ -211,13 +212,13 @@ class TensorParallelLayerTest(NcclDistributedTestBase):
                     a = linear_layer.master_weight.cuda()
                 dlda = torch.matmul(dldy.t(), x)
                 dldb = torch.matmul(
-                    torch.ones(TensorParallelLayerTest.BATCH_SIZE, 1).cuda().t(), dldy
+                    torch.ones(self.BATCH_SIZE, 1).cuda().t(), dldy
                 ).view(-1)
                 dldx = torch.matmul(dldy, a)
 
                 with torch.no_grad():
                     curr_dlda = torch.split(
-                        dlda, TensorParallelLayerTest.INPUT_SIZE_COEFF, dim=1
+                        dlda, self.INPUT_SIZE_COEFF, dim=1
                     )[parallel_state.get_tensor_model_parallel_rank()].clone()
                 self.assertEqual(linear_layer.weight.grad, curr_dlda)
                 self.assertEqual(input_tensor.grad, dldx)
@@ -240,9 +241,6 @@ class TensorParallelLayerTest(NcclDistributedTestBase):
         gradient_accumulation_fusion: bool,
     ):
         for tensor_model_parallel_world_size in range(1, self.world_size + 1):
-            print(
-                f"tensor_model_parallel_world_size={tensor_model_parallel_world_size}"
-            )
             with self.subTest(
                 tensor_model_parallel_world_size=tensor_model_parallel_world_size
             ):
@@ -252,13 +250,13 @@ class TensorParallelLayerTest(NcclDistributedTestBase):
                     tensor_model_parallel_size_=tensor_model_parallel_world_size,
                 )
 
-                feature_size_coeff = TensorParallelLayerTest.INPUT_SIZE_COEFF
+                feature_size_coeff = self.INPUT_SIZE_COEFF
                 feature_size = feature_size_coeff * tensor_model_parallel_world_size
                 hidden_size = feature_size
 
-                set_random_seed(TensorParallelLayerTest.SEED)
+                set_random_seed(self.SEED)
                 input_tensor = torch.randn(
-                    TensorParallelLayerTest.BATCH_SIZE,
+                    self.BATCH_SIZE,
                     hidden_size,
                     feature_size,
                     device="cuda",
@@ -266,7 +264,7 @@ class TensorParallelLayerTest(NcclDistributedTestBase):
                 )
                 input_tensor.retain_grad()
                 loss_weight = torch.randn(
-                    (TensorParallelLayerTest.BATCH_SIZE, hidden_size, feature_size,),
+                    (self.BATCH_SIZE, hidden_size, feature_size,),
                     device="cuda",
                 )
                 linear = layers.ColumnParallelLinear(
@@ -285,7 +283,7 @@ class TensorParallelLayerTest(NcclDistributedTestBase):
                 output, _ = linear(input_tensor)
                 self.assertEqual(
                     output.shape,
-                    (TensorParallelLayerTest.BATCH_SIZE, hidden_size, feature_size,),
+                    (self.BATCH_SIZE, hidden_size, feature_size,),
                 )
                 loss = torch.mul(output, loss_weight).sum()
                 loss.backward()
@@ -296,7 +294,7 @@ class TensorParallelLayerTest(NcclDistributedTestBase):
                     a = linear.master_weight.cuda().clone()
                 dldx = torch.matmul(dldy, a)
                 self.assertEqual(input_tensor.grad, dldx)
-                # TODO (mkozuki): Cover the other cases.
+                # TODO(mkozuki): Cover the other cases.
                 if (
                     tensor_model_parallel_world_size == 1
                     and not gradient_accumulation_fusion
@@ -308,6 +306,14 @@ class TensorParallelLayerTest(NcclDistributedTestBase):
                     self.assertEqual(linear.weight.grad, curr_dlda)
 
                 parallel_state.destroy_model_parallel()
+
+
+class NcclTensorParallelLayerTest(TensorParallelLayerTestBase, NcclDistributedTestBase):
+    pass
+
+
+class UccTensorParallelLayerTest(TensorParallelLayerTestBase, UccDistributedTestBase):
+    pass
 
 
 if __name__ == "__main__":

--- a/tests/L0/run_transformer/test_layers.py
+++ b/tests/L0/run_transformer/test_layers.py
@@ -9,7 +9,7 @@ logging.getLogger("torch").setLevel(logging.WARNING)
 from apex.transformer import parallel_state
 from apex.transformer.tensor_parallel import layers
 from apex.transformer.testing.commons import set_random_seed
-from apex.transformer.testing.distributed_test_base import DistributedTestBase
+from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
 
 logging.getLogger("apex").setLevel(logging.WARNING)
 
@@ -20,7 +20,7 @@ logging.getLogger("apex").setLevel(logging.WARNING)
 torch.backends.cuda.matmul.allow_tf32 = False
 
 
-class TensorParallelLayerTest(DistributedTestBase):
+class TensorParallelLayerTest(NcclDistributedTestBase):
 
     BATCH_SIZE: int = 17
     SEQUENCE_LENGTH: int = 23

--- a/tests/L0/run_transformer/test_mapping.py
+++ b/tests/L0/run_transformer/test_mapping.py
@@ -8,11 +8,12 @@ logging.getLogger("torch").setLevel(logging.WARNING)
 from apex.transformer import parallel_state
 from apex.transformer.tensor_parallel import mappings
 from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
+from apex.transformer.testing.distributed_test_base import UccDistributedTestBase
 
 logging.getLogger("apex").setLevel(logging.WARNING)
 
 
-class MappingTest(NcclDistributedTestBase):
+class MappingTestBase:
     def test_reduce(self):
         for tensor_model_paralell_world_size in range(1, self.world_size + 1):
             if self.world_size % tensor_model_paralell_world_size > 0:
@@ -78,6 +79,10 @@ class MappingTest(NcclDistributedTestBase):
                 )
                 self.assertTrue(torch.equal(gathered, expected))
                 parallel_state.destroy_model_parallel()
+
+
+class NcclMappingTest(MappingTestBase, NcclDistributedTestBase): pass
+class UccMappingTest(MappingTestBase, UccDistributedTestBase): pass
 
 
 if __name__ == "__main__":

--- a/tests/L0/run_transformer/test_mapping.py
+++ b/tests/L0/run_transformer/test_mapping.py
@@ -7,12 +7,12 @@ logging.getLogger("torch").setLevel(logging.WARNING)
 
 from apex.transformer import parallel_state
 from apex.transformer.tensor_parallel import mappings
-from apex.transformer.testing.distributed_test_base import DistributedTestBase
+from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
 
 logging.getLogger("apex").setLevel(logging.WARNING)
 
 
-class MappingTest(DistributedTestBase):
+class MappingTest(NcclDistributedTestBase):
     def test_reduce(self):
         for tensor_model_paralell_world_size in range(1, self.world_size + 1):
             if self.world_size % tensor_model_paralell_world_size > 0:

--- a/tests/L0/run_transformer/test_microbatches.py
+++ b/tests/L0/run_transformer/test_microbatches.py
@@ -13,12 +13,12 @@ from apex.transformer.pipeline_parallel.utils import (
     get_current_global_batch_size,
     update_num_microbatches,
 )
-from apex.transformer.testing.distributed_test_base import DistributedTestBase
+from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
 
 logging.getLogger("apex").setLevel(logging.WARNING)
 
 
-class MicrobatchCalculatorTest(DistributedTestBase):
+class MicrobatchCalculatorTest(NcclDistributedTestBase):
 
     GLOBAL_BATCH_SIZE: int = 1024
     MICRO_BATCH_SIZE: int = 1

--- a/tests/L0/run_transformer/test_microbatches.py
+++ b/tests/L0/run_transformer/test_microbatches.py
@@ -14,11 +14,12 @@ from apex.transformer.pipeline_parallel.utils import (
     update_num_microbatches,
 )
 from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
+from apex.transformer.testing.distributed_test_base import UccDistributedTestBase
 
 logging.getLogger("apex").setLevel(logging.WARNING)
 
 
-class MicrobatchCalculatorTest(NcclDistributedTestBase):
+class MicrobatchCalculatorTestBase:
 
     GLOBAL_BATCH_SIZE: int = 1024
     MICRO_BATCH_SIZE: int = 1
@@ -26,8 +27,8 @@ class MicrobatchCalculatorTest(NcclDistributedTestBase):
     def _test(self, rampup_batch_size: Optional[List[int]]) -> None:
         for data_parallel_size in range(1, self.world_size + 1):
 
-            expected_global_batch_size = MicrobatchCalculatorTest.GLOBAL_BATCH_SIZE
-            expected_micro_batch_size = MicrobatchCalculatorTest.MICRO_BATCH_SIZE
+            expected_global_batch_size = self.GLOBAL_BATCH_SIZE
+            expected_micro_batch_size = self.MICRO_BATCH_SIZE
             if rampup_batch_size:
                 expected_global_batch_size = rampup_batch_size[0]
                 num_consumed_samples = 0
@@ -48,8 +49,8 @@ class MicrobatchCalculatorTest(NcclDistributedTestBase):
                 _reconfigure_microbatch_calculator(
                     self.rank,
                     rampup_batch_size,
-                    MicrobatchCalculatorTest.GLOBAL_BATCH_SIZE,
-                    MicrobatchCalculatorTest.MICRO_BATCH_SIZE,
+                    self.GLOBAL_BATCH_SIZE,
+                    self.MICRO_BATCH_SIZE,
                     data_parallel_size,
                 )
 
@@ -66,7 +67,7 @@ class MicrobatchCalculatorTest(NcclDistributedTestBase):
                         current_global_batch_size = get_current_global_batch_size()
                         update_num_microbatches(current_global_batch_size)
                     current_global_batch_size = get_current_global_batch_size()
-                    self.assertEqual(get_current_global_batch_size(), MicrobatchCalculatorTest.GLOBAL_BATCH_SIZE)
+                    self.assertEqual(get_current_global_batch_size(), self.GLOBAL_BATCH_SIZE)
                 parallel_state.destroy_model_parallel()
 
     def test_constant_microbatch_calculator(self):
@@ -74,6 +75,10 @@ class MicrobatchCalculatorTest(NcclDistributedTestBase):
 
     def test_dynamic_microbatch_calculator(self):
         self._test(rampup_batch_size=[256, 128, 500])
+
+
+class NcclMicrobatchCalculatorTest(MicrobatchCalculatorTestBase, NcclDistributedTestBase): pass
+class UccMicrobatchCalculatorTest(MicrobatchCalculatorTestBase, UccDistributedTestBase): pass
 
 
 if __name__ == "__main__":

--- a/tests/L0/run_transformer/test_p2p_comm.py
+++ b/tests/L0/run_transformer/test_p2p_comm.py
@@ -1,0 +1,122 @@
+import logging
+import unittest
+
+import torch
+from torch.testing._internal import common_utils
+
+logging.getLogger("torch").setLevel(logging.WARNING)
+
+from apex.transformer import parallel_state
+from apex.transformer.pipeline_parallel import p2p_communication
+from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
+from apex.transformer.testing.distributed_test_base import UccDistributedTestBase
+
+logging.getLogger("apex").setLevel(logging.DEBUG)
+
+
+# [P2P Ops Involved in Pipeline Model Parallel forward/backward]
+# **forward_backward_pipelining_without_interleaving**
+# - send_forward  / recv_forward
+# - send_backward / recv_backward
+# - send_forward_recv_backward
+# - send_backward_recv_forward
+# **forward_backward_pipelining_with_interleaving**
+# - send_backward_recv_backward
+# - recv_backward
+# - recv_forward
+# - send_forward_backward_recv_forward_backward
+# - send_forward_recv_forward
+class P2PCommTestBase:
+
+    numel = 4
+    shape = (2, 2)
+    dtype = torch.float32
+
+    @property
+    def world_size(self):
+        return min(2, torch.cuda.device_count())
+
+    def _init_model_parallel(self):
+        parallel_state.initialize_model_parallel(
+            tensor_model_parallel_size_=1,
+            pipeline_model_parallel_size_=self.world_size,
+            virtual_pipeline_model_parallel_size_=None,
+        )
+
+    def create_tensor(self, value: int = None):
+        return torch.tensor(
+            [value] * self.numel).view(self.shape).to(device="cuda", dtype=self.dtype)
+
+    # Brief: Simulate warm-up.
+    # Brief: test `recv_forward` & `send_forward`.
+    def test_no_interleaving_warmup(self):
+        self.assertEqual(self.world_size, 2)
+        self._init_model_parallel()
+        input_tensor = None
+        if parallel_state.is_pipeline_first_stage():
+            tensor = self.create_tensor(self.rank)
+            print(tensor)
+            p2p_communication.send_forward(output_tensor=tensor, tensor_shape=self.shape, dtype=self.dtype)
+        else:
+            input_tensor = p2p_communication.recv_forward(tensor_shape=self.shape, dtype=self.dtype)
+
+        if parallel_state.is_pipeline_first_stage():
+            self.assertIsNone(input_tensor)
+        else:
+            expected_input_tensor = self.create_tensor(self.rank - 1)
+            self.assertEqual(input_tensor, expected_input_tensor)
+
+    # Brief: test `send_forward`, `send_forward_recv_forward`, and `recv_forward`.
+    def test_send_forward_recv_forward(self):
+        self._init_model_parallel()
+        prev_tensor = None
+        tensor = self.create_tensor(self.rank)
+        if parallel_state.is_pipeline_first_stage():
+            p2p_communication.send_forward(output_tensor=tensor, tensor_shape=self.shape, dtype=self.dtype)
+        elif parallel_state.is_pipeline_last_stage():
+            prev_tensor = p2p_communication.recv_forward(tensor_shape=self.shape, dtype=self.dtype)
+        else:
+            prev_tensor = p2p_communication.send_forward_recv_forward(
+                output_tensor=tensor,
+                recv_prev=True,
+                tensor_shape=self.shape,
+                dtype=self.dtype,
+            )
+
+        if parallel_state.is_pipeline_first_stage():
+            self.assertIsNone(prev_tensor)
+        else:
+            expected_prev_tensor = self.create_tensor(self.rank - 1)
+            self.assertEqual(prev_tensor, expected_prev_tensor)
+
+    # Brief: test `send_backward`, `send_backward_recv_backward`, and `recv_backward`.
+    def test_send_backward_recv_backward(self):
+        self._init_model_parallel()
+        tensor = self.create_tensor(self.rank)
+
+        next_tensor = None
+        if parallel_state.is_pipeline_first_stage():
+            next_tensor = p2p_communication.recv_backward(tensor_shape=self.shape, dtype=self.dtype)
+        elif parallel_state.is_pipeline_last_stage():
+            p2p_communication.send_backward(input_tensor_grad=tensor, tensor_shape=self.shape, dtype=self.dtype)
+        else:
+            next_tensor = p2p_communication.send_backward_recv_backward(
+                input_tensor_grad=tensor,
+                recv_next=True,
+                tensor_shape=self.shape,
+                dtype=self.dtype,
+            )
+
+        if parallel_state.is_pipeline_last_stage():
+            self.assertIsNone(next_tensor)
+        else:
+            expected_next_tensor = self.create_tensor(self.rank + 1)
+            self.assertEqual(next_tensor, expected_next_tensor)
+
+
+# n.b.(mkozuki): Intentionally skip NCCL backend tests as I trust pytorch/pytorch repo.
+class UccP2PCommTest(P2PCommTestBase, UccDistributedTestBase): pass
+
+
+if __name__ == "__main__":
+    common_utils.run_tests()

--- a/tests/L0/run_transformer/test_parallel_state.py
+++ b/tests/L0/run_transformer/test_parallel_state.py
@@ -7,6 +7,7 @@ logging.getLogger("torch").setLevel(logging.WARNING)
 
 from apex.transformer import parallel_state
 from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
+from apex.transformer.testing.distributed_test_base import UccDistributedTestBase
 
 logging.getLogger("apex").setLevel(logging.WARNING)
 
@@ -21,7 +22,7 @@ def calc_expected_tensor_model_paralell_rank(
     return rank % tensor_model_parallel_world_size
 
 
-class ParallelStateTest(NcclDistributedTestBase):
+class ParallelStateTestBase:
     def test_initialize_model_parallel(self) -> None:
 
         self.assertFalse(parallel_state.model_parallel_is_initialized())
@@ -120,6 +121,10 @@ class ParallelStateTest(NcclDistributedTestBase):
         )
 
         parallel_state.destroy_model_parallel()
+
+
+class NcclParallelStateTest(ParallelStateTestBase, NcclDistributedTestBase): pass
+class UccParallelStateTest(ParallelStateTestBase, UccDistributedTestBase): pass
 
 
 if __name__ == "__main__":

--- a/tests/L0/run_transformer/test_parallel_state.py
+++ b/tests/L0/run_transformer/test_parallel_state.py
@@ -6,7 +6,7 @@ from torch.testing._internal import common_utils
 logging.getLogger("torch").setLevel(logging.WARNING)
 
 from apex.transformer import parallel_state
-from apex.transformer.testing.distributed_test_base import DistributedTestBase
+from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
 
 logging.getLogger("apex").setLevel(logging.WARNING)
 
@@ -21,7 +21,7 @@ def calc_expected_tensor_model_paralell_rank(
     return rank % tensor_model_parallel_world_size
 
 
-class ParallelStateTest(DistributedTestBase):
+class ParallelStateTest(NcclDistributedTestBase):
     def test_initialize_model_parallel(self) -> None:
 
         self.assertFalse(parallel_state.model_parallel_is_initialized())

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -24,7 +24,7 @@ from apex.transformer.pipeline_parallel.schedules.fwd_bwd_pipelining_with_interl
 from apex.transformer.pipeline_parallel.schedules.fwd_bwd_pipelining_without_interleaving import (
     forward_backward_pipelining_without_interleaving,
 )
-from apex.transformer.testing.distributed_test_base import DistributedTestBase
+from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
 from apex.transformer.testing import commons as testing_utils
 
 logging.getLogger("apex").setLevel(logging.WARNING)
@@ -54,7 +54,7 @@ def get_target_loss(hidden_size: int, microbatch_size: int, parallel_model_world
     return hidden_size * hidden_size * torch.sum(data).item() * microbatch_size / layers_per_rank
 
 
-class PipelineParallelForwardBackwardTest(DistributedTestBase):
+class PipelineParallelForwardBackwardTest(NcclDistributedTestBase):
 
     GLOBAL_BATCH_SIZE = 16
     MICRO_BATCH_SIZE = 2

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -163,8 +163,8 @@ class PipelineParallelForwardBackwardTestBase:
             )
 
             if dtype == torch.float32:
-                hidden_size = PipelineParallelForwardBackwardTest.HIDDEN_SIZE
-                microbatch_size = PipelineParallelForwardBackwardTest.MICRO_BATCH_SIZE
+                hidden_size = self.HIDDEN_SIZE
+                microbatch_size = self.MICRO_BATCH_SIZE
                 target_loss = get_target_loss(hidden_size, microbatch_size, pipeline_model_parallel_world_size, self.world_size)
 
                 for loss_item in loss:

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -28,6 +28,7 @@ from apex.transformer.pipeline_parallel.schedules.fwd_bwd_pipelining_without_int
 from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
 from apex.transformer.testing.distributed_test_base import UccDistributedTestBase
 from apex.transformer.testing.distributed_test_base import HAS_TORCH_UCC
+from apex.transformer.testing.distributed_test_base import HAS_TORCH_UCC_COMPAT_NVIDIA_DRIVER
 from apex.transformer.testing import commons as testing_utils
 
 logging.getLogger("apex").setLevel(logging.WARNING)
@@ -220,7 +221,7 @@ class NcclPipelineParallelForwardBackwardTest(NcclDistributedTestBase, PipelineP
             default_backend="nccl", p2p_backend="ucc",
         )
 
-    # TODO(mkozuki): Investigate why this hybrid path doesn't require 470.42.01.
+    @unittest.skipUnless(HAS_TORCH_UCC_COMPAT_NVIDIA_DRIVER, "Needs driver >= 470.42.01")
     def _test_hybrid_backends(self, forward_only: bool) -> None:
         if HAS_TORCH_UCC:
             self._run_hybrid_distributed_backend(forward_only)

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -5,12 +5,6 @@ from typing import Optional
 
 import torch
 from torch.testing._internal import common_utils
-try:
-    import torch_ucc
-except ImportError:
-    HAS_TORCH_UCC = False
-else:
-    HAS_TORCH_UCC = True
 
 logging.getLogger("torch").setLevel(logging.WARNING)
 
@@ -33,6 +27,7 @@ from apex.transformer.pipeline_parallel.schedules.fwd_bwd_pipelining_without_int
 )
 from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
 from apex.transformer.testing.distributed_test_base import UccDistributedTestBase
+from apex.transformer.testing.distributed_test_base import HAS_TORCH_UCC
 from apex.transformer.testing import commons as testing_utils
 
 logging.getLogger("apex").setLevel(logging.WARNING)
@@ -225,6 +220,7 @@ class NcclPipelineParallelForwardBackwardTest(NcclDistributedTestBase, PipelineP
             default_backend="nccl", p2p_backend="ucc",
         )
 
+    # TODO(mkozuki): Investigate why this hybrid path doesn't require 470.42.01.
     def _test_hybrid_backends(self, forward_only: bool) -> None:
         if HAS_TORCH_UCC:
             self._run_hybrid_distributed_backend(forward_only)

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -2,6 +2,7 @@ import logging
 import itertools
 import re
 from typing import Optional
+import unittest
 
 import torch
 from torch.testing._internal import common_utils

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -68,10 +68,6 @@ class PipelineParallelForwardBackwardTestBase:
     # You can limit the options by overriding the following `dtypes`.
     dtypes = None
 
-    @property
-    def world_size(self) -> int:
-        return min(torch.cuda.device_count(), 8)
-
     def _forward_backward_test_impl(
         self,
         forward_only: bool,
@@ -214,6 +210,10 @@ class PipelineParallelForwardBackwardTestBase:
 
 class NcclPipelineParallelForwardBackwardTest(NcclDistributedTestBase, PipelineParallelForwardBackwardTestBase):
 
+    @property
+    def world_size(self) -> int:
+        return min(torch.cuda.device_count(), 8)
+
     def _run_hybrid_distributed_backend(self, forward_only: bool) -> None:
         self._forward_backward_test_impl(
             forward_only, forward_backward_pipelining_without_interleaving, None, None,
@@ -240,6 +240,10 @@ class NcclPipelineParallelForwardBackwardTest(NcclDistributedTestBase, PipelineP
 
 # n.b.(mkozuki): pipeline parallel w/o interleaving with UCX_TLS=tcp,sm fails.
 class UccPipelineParallelForwardBackwardTest(UccDistributedTestBase, PipelineParallelForwardBackwardTestBase):
+
+    @property
+    def world_size(self) -> int:
+        return min(torch.cuda.device_count(), 8)
 
     deallocate_options = (False,)
     dtypes = (torch.float32,)

--- a/tests/L0/run_transformer/test_random.py
+++ b/tests/L0/run_transformer/test_random.py
@@ -7,12 +7,12 @@ logging.getLogger("torch").setLevel(logging.WARNING)
 
 from apex.transformer import parallel_state
 from apex.transformer import tensor_parallel
-from apex.transformer.testing.distributed_test_base import DistributedTestBase
+from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
 
 logging.getLogger("apex").setLevel(logging.WARNING)
 
 
-class TransformerRandomTest(DistributedTestBase):
+class TransformerRandomTest(NcclDistributedTestBase):
     def test_set_cuda_rng_state(self):
         for tensor_model_parallel_world_size in range(1, self.world_size + 1):
             if self.world_size % tensor_model_parallel_world_size:

--- a/tests/L0/run_transformer/test_random.py
+++ b/tests/L0/run_transformer/test_random.py
@@ -8,11 +8,12 @@ logging.getLogger("torch").setLevel(logging.WARNING)
 from apex.transformer import parallel_state
 from apex.transformer import tensor_parallel
 from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
+from apex.transformer.testing.distributed_test_base import UccDistributedTestBase
 
 logging.getLogger("apex").setLevel(logging.WARNING)
 
 
-class TransformerRandomTest(NcclDistributedTestBase):
+class TransformerRandomTestBase:
     def test_set_cuda_rng_state(self):
         for tensor_model_parallel_world_size in range(1, self.world_size + 1):
             if self.world_size % tensor_model_parallel_world_size:
@@ -109,6 +110,10 @@ class TransformerRandomTest(NcclDistributedTestBase):
 
                 tensor_parallel.random.get_cuda_rng_tracker().reset()
                 parallel_state.destroy_model_parallel()
+
+
+class NcclTransformerRandomTest(TransformerRandomTestBase, NcclDistributedTestBase): pass
+class UccTransformerRandomTest(TransformerRandomTestBase, UccDistributedTestBase): pass
 
 
 if __name__ == "__main__":

--- a/tests/L0/run_transformer/test_transformer_module.py
+++ b/tests/L0/run_transformer/test_transformer_module.py
@@ -63,7 +63,9 @@ def run_transformer_tests():
             import torch
 
             num_devices = torch.cuda.device_count()
-            test_run_cmd += f" --pipeline-model-parallel-size {num_devices}"
+            tensor_model_parallel_size = 1 + (1 - (num_devices % 2))
+            pipeline_model_parallel_size = num_devices // tensor_model_parallel_size
+            test_run_cmd += f" --pipeline-model-parallel-size {pipeline_model_parallel_size} --tensor-model-parallel-size {tensor_model_parallel_size}"
         else:
             test_run_cmd += f" --use-cpu-initialization"
         print(f"### {i} / {len(files)}: cmd: {test_run_cmd}")

--- a/tests/L0/run_transformer/test_transformer_module.py
+++ b/tests/L0/run_transformer/test_transformer_module.py
@@ -63,7 +63,7 @@ def run_transformer_tests():
             import torch
 
             num_devices = torch.cuda.device_count()
-            tensor_model_parallel_size = 1 + (1 - (num_devices % 2))
+            tensor_model_parallel_size = 1 + (1 - (num_devices % 2 and num_devices > 4))
             pipeline_model_parallel_size = num_devices // tensor_model_parallel_size
             test_run_cmd += f" --pipeline-model-parallel-size {pipeline_model_parallel_size} --tensor-model-parallel-size {tensor_model_parallel_size}"
         else:

--- a/tests/L0/run_transformer/test_transformer_utils.py
+++ b/tests/L0/run_transformer/test_transformer_utils.py
@@ -7,12 +7,12 @@ logging.getLogger("torch").setLevel(logging.WARNING)
 
 from apex.transformer import parallel_state
 from apex.transformer.tensor_parallel import utils
-from apex.transformer.testing.distributed_test_base import DistributedTestBase
+from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
 
 logging.getLogger("apex").setLevel(logging.WARNING)
 
 
-class TransformerUtilsTest(DistributedTestBase):
+class TransformerUtilsTest(NcclDistributedTestBase):
     def test_split_tensor_along_last_dim(self):
         for tensor_model_paralell_world_size in range(1, self.world_size + 1):
             if self.world_size % tensor_model_paralell_world_size > 0:


### PR DESCRIPTION
This PR enables us to specify `torch.distributed.Backend` for PipelineParallel Process Groups and the other PGs by adding keyword arguments of `"default_backend"` and `"p2p_backend"` to `apex.transformer.parallel_state.initialize_model_parallel`.

<!--
By running `tests/L0/run_transformer/run_gpt_minimal_test.py` with various tensor|pipeline parallel size on a node of 8 GPUs, I've verified UCC for Pipeline Parallel PGs and NCCL for the others can be usable while NCCL for PP PGs and UCC for PP PGs don't seem so, which is why these warnings exist [here](https://github.com/NVIDIA/apex/compare/master...crcrpar:pipelineparallel_ucc_backend?expand=1#diff-bb2dfca8484e986cfb3277f966640c6af6f214aa6f3c5cb713994c72c67f7addR119-R126).
-->

By running `tests/L0/run_transformer/run_gpt_minimal_test.py` with various tensor|pipeline parallel size on a node of 8 GPUs, I've verified UCC for Pipeline Parallel PGs and NCCL for any others is functional. NCCL for PP PGs and UCC for the other PGs is not verified and may have bugs, which is why these warnings exist [here](https://github.com/NVIDIA/apex/compare/master...crcrpar:pipelineparallel_ucc_backend?expand=1#diff-bb2dfca8484e986cfb3277f966640c6af6f214aa6f3c5cb713994c72c67f7addR119-R126).
<!-- Thanks Christian for suggestion -->

The main changes are in `apex/transformer/parallel_state.py` and most of changes are in testing code/unittests.

## Known limitations
- NCCL for Pipeline Parallel PG & UCC for the others don't seem to work
- `_forward_backward_pipelining_with_interleaving` hasn't been tested well with hybrid backends

## Development environment
- nvcr.io/nvidia/pytorch:22.04-py3 with UCC v1.0.0 and torch_ucc of 426de4a0eb9059760967c06491598ec194150395
- host with a driver >= 470.42.01 due to https://github.com/NVIDIA/nvidia-settings/blame/5b455b89bb73f56818c84444806bc9c928da67ac/src/nvml.h#L6009-L6026. Even if you'll use a container the driver's version seems to matter in my experience.

## TODOs
Okay to access in follow-up PRs.
- Improve docstring
- Figure out limitations


cc @eqy @ptrblck @csarofeen @zasdfgbnm @Aidyn-A