### PR TITLE
[Pipeline-Parallelism][TF32] Disable TF32 for Pipeline-Parallel numerical checks

### DIFF
--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -72,6 +72,8 @@ class PipelineParallelForwardBackwardTest(DistributedTestBase):
         virtual_pipeline_model_parallel_size: Optional[int],
         async_comm: bool = False,
     ) -> None:
+        orig = torch.backends.cuda.matmul.allow_tf32
+        torch.backends.cuda.matmul.allow_tf32 = False
         for dtype, deallocate_pipeline_outputs in itertools.product(
             [torch.float32] + _get_autocast_dtypes(), (True, False),
         ):
@@ -159,6 +161,7 @@ class PipelineParallelForwardBackwardTest(DistributedTestBase):
                 optimizer.zero_grad(set_to_none=True)
 
             parallel_state.destroy_model_parallel()
+        torch.backends.cuda.matmul.allow_tf32 = orig
 
     def test_no_pipelining(self):
         self._forward_backward_test_impl(False, forward_backward_no_pipelining, 1, None)


### PR DESCRIPTION
The numerical checks in #1374 assume typical fp32 exact integer range which isn't supported with TF32. This isn't an issue on Volta and earlier but Ampere devices will dispatch to TF32 by default for the linear layers leading to unexpected mismatches.

See also: #1381

CC @crcrpar @Aidyn-A 