### PR TITLE
Change the timing of warning

### DIFF
--- a/apex/__init__.py
+++ b/apex/__init__.py
@@ -20,7 +20,7 @@ from . import fp16_utils
 # load time) the error message is timely and visible.
 from . import optimizers
 from . import normalization
-from . import pyprof
+# from . import pyprof
 from . import transformer
 
 


### PR DESCRIPTION
- https://github.com/NVIDIA/apex/pull/1348
- https://github.com/NVIDIA/apex/issues/1372

```bash
root@89944af7ec95:/opt/pytorch/apex# python -c 'import apex'
root@89944af7ec95:/opt/pytorch/apex# python -c 'import apex.pyprof'
/opt/pytorch/apex/apex/pyprof/__init__.py:5: FutureWarning: pyprof will be removed by the end of June, 2022
  warnings.warn("pyprof will be removed by the end of June, 2022", FutureWarning)
```