### PR TITLE
Test `len(model) > 1` in `test_pipelining_with_interleaving`

### DIFF
--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -70,8 +70,8 @@ class PipelineParallelForwardBackwardTest(DistributedTestBase):
         async_comm: bool = False,
     ) -> None:
         if fwd_bwd_func == _forward_backward_pipelining_with_interleaving:
-            assert virtual_pipeline_model_parallel_size is not None
-            assert virtual_pipeline_model_parallel_size > 1
+            self.assertIsNotNone(virtual_pipeline_model_parallel_size)
+            self.assertGreater(virtual_pipeline_model_parallel_size, 1)
 
         for dtype, deallocate_pipeline_outputs in itertools.product(
             [torch.float32] + _get_autocast_dtypes(), (True, False),

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -110,7 +110,7 @@ class PipelineParallelForwardBackwardTest(DistributedTestBase):
             )
 
             batch = None
-            if parallel_state.is_pipeline_first_stage:
+            if parallel_state.is_pipeline_first_stage():
                 batch = (torch.ones(global_batch_shape, dtype=torch.float).cuda(), )
 
             model = build_model(

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -2,8 +2,6 @@ import logging
 import itertools
 from typing import Optional
 
-import numpy as np
-
 import torch
 from torch.testing._internal import common_utils
 

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -36,7 +36,7 @@ def get_init_weights_func(offset: int = 0):
     def init_weights(m):
         rank = parallel_state.get_pipeline_model_parallel_rank()
         if isinstance(m, torch.nn.Linear):
-            m.weight.fill_((rank + offset + 1.0)/weight_coeff)
+            m.weight.fill_((rank + offset + 1.0) / weight_coeff)
             m.bias.fill_(1.0)
     return init_weights
 
@@ -45,7 +45,7 @@ def get_target_loss(global_batch_shape: tuple, hidden_size: int, total_layers: i
     with torch.no_grad():
         data = torch.ones(global_batch_shape, dtype=torch.float)
         for i in range(total_layers):
-            w = torch.ones(hidden_size, hidden_size)*(i + 1.0)/weight_coeff
+            w = torch.ones(hidden_size, hidden_size) * (i + 1.0) / weight_coeff
             # don't need to care about transpose semantics as all values are the same
             data = torch.matmul(w, data)
             data += 1.0

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -33,7 +33,7 @@ logging.getLogger("apex").setLevel(logging.WARNING)
 
 weight_coeff = 1024
 
-def get_init_weights_func(offset=0):
+def get_init_weights_func(offset: int = 0):
     @torch.no_grad()
     def init_weights(m):
         rank = parallel_state.get_pipeline_model_parallel_rank()


### PR DESCRIPTION
As noticed by @crcrpar, after the refactor in #1325 the interleaved test was not setting the virtual pipeline pipeline model parallel size which results in interleaving not being fully exercised.

This PR sets the virtual pipeline model parallel size and revises the numerical check to simplify the logic for various configurations as the number of layers per pipeline stage changes with interleaving.

CC @Aidyn-A 