### PR TITLE
Do pipeline parallelism tests in double because TF32 environment variables can be painful to manage across test suites

### DIFF
--- a/apex/transformer/parallel_state.py
+++ b/apex/transformer/parallel_state.py
@@ -154,10 +154,13 @@ def initialize_model_parallel(
     num_data_parallel_groups: int = world_size // data_parallel_size
 
     if virtual_pipeline_model_parallel_size_ is not None:
-        # assert pipeline_model_parallel_size_ > 2, (
-        #     "pipeline-model-parallel size should be greater than 2 with "
-        #     "interleaved schedule"
-        # )
+        # n.b. (eqy) This check was inherited from Megatron-LM, need to revisit
+        # the root cause as we do see numerical mismatches with 2 stages and
+        # the interleaved schedule
+        assert pipeline_model_parallel_size_ > 2, (
+            "pipeline-model-parallel size should be greater than 2 with "
+            "interleaved schedule"
+        )
         global _VIRTUAL_PIPELINE_MODEL_PARALLEL_RANK
         global _VIRTUAL_PIPELINE_MODEL_PARALLEL_WORLD_SIZE
         _VIRTUAL_PIPELINE_MODEL_PARALLEL_RANK = 0

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -48,7 +48,7 @@ def get_init_weights_func(offset: int = 0):
     return init_weights
 
 
-def get_target_loss_and_model(global_batch_shape: tuple, hidden_size: int, total_layers: int) -> Tuple[float, List[torch.nn.Module]]: 
+def get_target_loss_and_model(global_batch_shape: tuple, hidden_size: int, total_layers: int) -> Tuple[torch.Tensor, List[torch.Tensor]]: 
     model = []
     data = torch.ones(global_batch_shape, dtype=torch.double)
     for i in range(total_layers):

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -1,7 +1,7 @@
 import logging
 import itertools
 import re
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 import unittest
 
 import torch
@@ -48,7 +48,7 @@ def get_init_weights_func(offset: int = 0):
     return init_weights
 
 
-def get_target_loss_and_model(global_batch_shape: tuple, hidden_size: int, total_layers: int) -> float:  
+def get_target_loss_and_model(global_batch_shape: tuple, hidden_size: int, total_layers: int) -> Tuple[float, List[torch.nn.Module]]: 
     model = []
     data = torch.ones(global_batch_shape, dtype=torch.double)
     for i in range(total_layers):


### PR DESCRIPTION
CC @Aidyn-A @crcrpar 