### PR TITLE
[transformer] Specify process group of `batch_isend_irecv`

### DIFF
--- a/apex/transformer/pipeline_parallel/p2p_communication.py
+++ b/apex/transformer/pipeline_parallel/p2p_communication.py
@@ -53,32 +53,37 @@ def _run_p2pops(
     async_comm: bool = False
 ):
     ops = []
+    group = parallel_state.get_pipeline_model_parallel_group()
     if tensor_send_prev is not None:
         send_prev_op = torch.distributed.P2POp(
-            torch.distributed.isend,
-            tensor_send_prev,
-            parallel_state.get_pipeline_model_parallel_prev_rank(),
+            op=torch.distributed.isend,
+            tensor=tensor_send_prev,
+            peer=parallel_state.get_pipeline_model_parallel_prev_rank(),
+            group=group,
         )
         ops.append(send_prev_op)
     if tensor_recv_prev is not None:
         recv_prev_op = torch.distributed.P2POp(
-            torch.distributed.irecv,
-            tensor_recv_prev,
-            parallel_state.get_pipeline_model_parallel_prev_rank(),
+            op=torch.distributed.irecv,
+            tensor=tensor_recv_prev,
+            peer=parallel_state.get_pipeline_model_parallel_prev_rank(),
+            group=group,
         )
         ops.append(recv_prev_op)
     if tensor_send_next is not None:
         send_next_op = torch.distributed.P2POp(
-            torch.distributed.isend,
-            tensor_send_next,
-            parallel_state.get_pipeline_model_parallel_next_rank(),
+            op=torch.distributed.isend,
+            tensor=tensor_send_next,
+            peer=parallel_state.get_pipeline_model_parallel_next_rank(),
+            group=group,
         )
         ops.append(send_next_op)
     if tensor_recv_next is not None:
         recv_next_op = torch.distributed.P2POp(
-            torch.distributed.irecv,
-            tensor_recv_next,
-            parallel_state.get_pipeline_model_parallel_next_rank(),
+            op=torch.distributed.irecv,
+            tensor=tensor_recv_next,
+            peer=parallel_state.get_pipeline_model_parallel_next_rank(),
+            group=group,
         )
         ops.append(recv_next_op)
     if len(ops) > 0:

--- a/apex/transformer/pipeline_parallel/p2p_communication.py
+++ b/apex/transformer/pipeline_parallel/p2p_communication.py
@@ -54,7 +54,6 @@ class FutureTensor:
 # TODO(mkozuki): Think about a way to tell P2P functions whether or not
 # various torch.distributed backends are used via `_different_pg`
 def _run_p2pops(
-<<<<<<< HEAD
     tensor_send_prev: Union[torch.Tensor, None],
     tensor_send_next: Union[torch.Tensor, None],
     tensor_recv_prev: Union[torch.Tensor, None],
@@ -63,13 +62,6 @@ def _run_p2pops(
     *,
     # `_different_pg` is a placeholder argument and is not effective at all at the moment.
     _different_pg: Union[bool] = None,
-=======
-        tensor_send_prev: Union[torch.Tensor, None],
-        tensor_send_next: Union[torch.Tensor, None],
-        tensor_recv_prev: Union[torch.Tensor, None],
-        tensor_recv_next: Union[torch.Tensor, None],
-        async_comm: bool = False,
->>>>>>> 7aa6e1c5... `torch.cuda.synchronize()` before `torch.distributed.batch_isend_irecv`
 ):
     """Helper function of `torch.distributed.distributed_c10d.batch_isend_irecv`.
 
@@ -155,6 +147,7 @@ def _communicate(
     fp32_residual_connection: bool = False,
     async_comm: bool = False,
     sequence_parallel_enabled: bool = False,
+    _different_pg: Optional[bool],
 ) -> Tuple[Union[torch.Tensor, FutureTensor, None], Union[torch.Tensor, FutureTensor, None]]:
     """Base function for communication of tensors between stages.
 
@@ -276,7 +269,7 @@ def _communicate(
             tensor_send_prev = split_tensor_into_1d_equal_chunks(tensor_send_prev)
 
     # Send tensors in both the forward and backward directions as appropriate.
-    tensor_send_prev_req, tensor_recv_prev_req, tensor_send_next_req, tensor_recv_next_req = _run_p2pops(tensor_send_prev, tensor_send_next, tensor_recv_prev, tensor_recv_next, async_comm=async_comm)
+    tensor_send_prev_req, tensor_recv_prev_req, tensor_send_next_req, tensor_recv_next_req = _run_p2pops(tensor_send_prev, tensor_send_next, tensor_recv_prev, tensor_recv_next, async_comm=async_comm, _different_pg=_different_pg)
 
     if async_comm:
         tensor_recv_prev_waitfunc = None
@@ -351,6 +344,7 @@ def recv_forward(
     *,
     dtype: Optional[torch.dtype] = None,
     async_comm: bool = False,
+    _different_pg: Optional[bool] = None,
     sequence_parallel_enabled: bool = False,
     timers: _Timers = None,
 ) -> Union[torch.Tensor, FutureTensor, None]:
@@ -369,6 +363,7 @@ def recv_forward(
         dtype_=dtype,
         async_comm=async_comm,
         sequence_parallel_enabled=sequence_parallel_enabled,
+        _different_pg=_different_pg,
     )
     # if timers is not None:
     #     timers("forward-recv").stop()
@@ -380,6 +375,7 @@ def recv_backward(
     *,
     dtype: Optional[torch.dtype] = None,
     async_comm: bool = False,
+    _different_pg: Optional[bool] = None,
     sequence_parallel_enabled: bool = False,
     timers: _Timers = None,
 ) -> Union[torch.Tensor, FutureTensor, None]:
@@ -397,6 +393,7 @@ def recv_backward(
         dtype_=dtype,
         async_comm=async_comm,
         sequence_parallel_enabled=sequence_parallel_enabled,
+        _different_pg=_different_pg,
     )
     # if timers is not None:
     #     timers("backward-recv").stop()
@@ -410,6 +407,7 @@ def send_forward(
     *,
     dtype: Optional[torch.dtype] = None,
     async_comm: bool = False,
+    _different_pg: Optional[bool] = None,
     sequence_parallel_enabled: bool = False,
     timers: _Timers = None,
 ) -> None:
@@ -428,6 +426,7 @@ def send_forward(
         dtype_=dtype,
         async_comm=async_comm,
         sequence_parallel_enabled=sequence_parallel_enabled,
+        _different_pg=_different_pg,
     )
     # if timers is not None:
     #     timers("forward-send").stop()
@@ -439,6 +438,7 @@ def send_backward(
     *,
     dtype: Optional[torch.dtype] = None,
     async_comm: bool = False,
+    _different_pg: Optional[bool] = None,
     sequence_parallel_enabled: bool = False,
     timers: _Timers = None,
 ) -> None:
@@ -456,6 +456,7 @@ def send_backward(
         dtype_=dtype,
         async_comm=async_comm,
         sequence_parallel_enabled=sequence_parallel_enabled,
+        _different_pg=_different_pg,
     )
     # if timers is not None:
     #     timers("backward-send").stop()
@@ -467,6 +468,7 @@ def send_forward_recv_backward(
     *,
     dtype: Optional[torch.dtype] = None,
     async_comm: bool = False,
+    _different_pg: Optional[bool] = None,
     sequence_parallel_enabled: bool = False,
     timers: _Timers = None,
 ) -> Union[torch.Tensor, FutureTensor, None]:
@@ -484,6 +486,7 @@ def send_forward_recv_backward(
         dtype_=dtype,
         async_comm=async_comm,
         sequence_parallel_enabled=sequence_parallel_enabled,
+        _different_pg=_different_pg,
     )
     # if timers is not None:
     #     timers("forward-send-backward-recv").stop()
@@ -496,6 +499,7 @@ def send_backward_recv_forward(
     *,
     dtype: Optional[torch.dtype] = None,
     async_comm: bool = False,
+    _different_pg: Optional[bool] = None,
     sequence_parallel_enabled: bool = False,
     timers: _Timers = None,
 ) -> Union[torch.Tensor, FutureTensor, None]:
@@ -513,6 +517,7 @@ def send_backward_recv_forward(
         dtype_=dtype,
         async_comm=async_comm,
         sequence_parallel_enabled=sequence_parallel_enabled,
+        _different_pg=_different_pg,
     )
     # if timers is not None:
     #     timers("backward-send-forward-recv").stop()
@@ -526,6 +531,7 @@ def send_forward_recv_forward(
     *,
     dtype: Optional[torch.dtype] = None,
     async_comm: bool = False,
+    _different_pg: Optional[bool] = None,
     sequence_parallel_enabled: bool = False,
     timers: _Timers = None,
 ) -> Union[torch.Tensor, FutureTensor]:
@@ -541,6 +547,7 @@ def send_forward_recv_forward(
         dtype_=dtype,
         async_comm=async_comm,
         sequence_parallel_enabled=sequence_parallel_enabled,
+        _different_pg=_different_pg,
     )
     # if timers is not None:
     #     timers("forward-send-forward-recv").stop()
@@ -554,6 +561,7 @@ def send_backward_recv_backward(
     *,
     dtype: Optional[torch.dtype] = None,
     async_comm: bool = False,
+    _different_pg: Optional[bool] = None,
     sequence_parallel_enabled: bool = False,
     timers: _Timers = None,
 ) -> Union[torch.Tensor, FutureTensor]:
@@ -569,6 +577,7 @@ def send_backward_recv_backward(
         dtype_=dtype,
         async_comm=async_comm,
         sequence_parallel_enabled=sequence_parallel_enabled,
+        _different_pg=_different_pg,
     )
     # if timers is not None:
     #     timers("backward-send-backward-recv").stop()
@@ -584,6 +593,7 @@ def send_forward_backward_recv_forward_backward(
     *,
     dtype: Optional[torch.dtype] = None,
     async_comm: bool = False,
+    _different_pg: Optional[bool] = None,
     sequence_parallel_enabled: bool = False,
     timers: _Timers = None,
 ) -> Tuple[Union[torch.Tensor, FutureTensor], Union[torch.Tensor, FutureTensor]]:
@@ -599,6 +609,7 @@ def send_forward_backward_recv_forward_backward(
         dtype_=dtype,
         async_comm=async_comm,
         sequence_parallel_enabled=sequence_parallel_enabled,
+        _different_pg=_different_pg,
     )
     # if timers is not None:
     #     timers("forward-backward-send-forward-backward-recv").stop()

--- a/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_without_interleaving.py
+++ b/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_without_interleaving.py
@@ -234,6 +234,9 @@ def send_backward_recv_forward(
     return input_tensors
 
 
+# TODO(mkozuki): Make `_different_pg` public and utilize the argument
+# to avoid a redundant `torch.cuda.synchronize` in p2p_communication.py
+# See [Necessity of `torch.cuda.synchronize()`]
 def forward_backward_pipelining_without_interleaving(
     forward_step_func: FwdStepFunc,
     batch: Optional[Batch],
@@ -276,6 +279,10 @@ def forward_backward_pipelining_without_interleaving(
         disable_autocast:
         deallocate_pipeline_outputs: If :obj:`True`, free the data of the output tensor of
             each pipeline stage. Experimental.
+        async_comm:
+        _different_pg: Set to :obj:`True` if the backend of pipeline model parallel process groups
+            is different from that of the other PGs. For example, `torch_ucc` for Pipeline parallel
+            and NCCL for the rest.
         sequence_parallel_enabled: Set to :obj:`True` for this function to handle sequence length.
             When :obj:`True`, the sequence length on each tensor model parallel rank is updated
             to :math:`original\_sequence\_length / tensor\_model\_parallel\_world\_size`.

--- a/apex/transformer/testing/distributed_test_base.py
+++ b/apex/transformer/testing/distributed_test_base.py
@@ -114,7 +114,7 @@ class UccDistributedTestBase(DistributedTestBase):
 
         self._has_ucx_tls = "UCX_TLS" in os.environ
         if not self._has_ucx_tls:
-            os.environ["UCX_TLS"] = "tcp,cuda_copy"
+            os.environ["UCX_TLS"] = "tcp,cuda"
         print('os.environ[\"UCX_TLS\"] = {}'.format(os.environ["UCX_TLS"]))
 
     def tearDown(self) -> None:


### PR DESCRIPTION
## Summary
- Specify process group in p2p_communication.py
- Add `torch.cuda.synchronize()` as per @Aidyn-A's [comment](https://github.com/NVIDIA/apex/pull/1397#discussion_r899466940)
- as of https://github.com/openucx/ucc/commit/8afd34a11ae961bffc29c44be3a08fb994f53c00, we cannot make true overlapping happen with torch_ucc backend even if we set `async_comm` to `True`.

## TODO
In a follow-up
- [ ] let `_default_pg` argument be a real argument and avoid a redundant `torch.cuda.synchronize()` if `_different_pg` is `False`.

## concerns
- `_different_pg` is not that good name in my humble opinion. The situation is rather Pipeline Model Parallel ProcessGroups depends on a different backend from the other ProcessGroups...
- Whether or not to have users specify `_different_pg`
    - As Aidyn's pointed out, we can tell by comparing Pipeline Model Parallel ProcessGroup and another Model Parallel ProcessGroup

`UCP_TLS=ucp`

---

## Motivation
https://github.com/NVIDIA/apex/blob/5ffb22d0d4ff2b899638b768af13bb1b97cbc923/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py#L262-L289 doesn't show appropriately UCX/UCC warnings as P2P ops implicitly use the default process group, i.e. NCCL Process Group

Tests seem fine with UCC of [a43fad17fa4f1e57a712b6bfb5abcf087d0bb95f](https://github.com/openucx/ucc/commit/a43fad17fa4f1e57a712b6bfb5abcf087d0bb95f) and torch_ucc of [a9451896f2592313322cca04ee0d4e0c5d5f922f](https://github.com/facebookresearch/torch_ucc/commit/a9451896f2592313322cca04ee0d4e0c5d5f922f).