### PR TITLE
Improvements in distributed Adam optimizer for Megatron

### DIFF
--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -96,7 +96,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
     """
 
-    class ParameterFragment():
+    class ParameterFragment:
         """Buffer ranges for a parameter fragment
 
         Describes corresponding regions in parameter buffer and
@@ -134,7 +134,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             # Range of local fragment shard within parameter
             self.shard_param_range = shard_param_range
 
-    class StateBucket():
+    class StateBucket:
         def __init__(self, shard_size, dtype, device):
             """Optimizer state for a bucket"""
             # Buffer ranges corresponding to parameter fragments
@@ -157,7 +157,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         # Asynchronous reduction is in progress
         SYNCING = enum.auto()
 
-    class GradientBucket():
+    class GradientBucket:
         """Gradient buffers and state for a bucket"""
         def __init__(self):
             # Local shard of gradients


### PR DESCRIPTION
This PR has several optimizations to enable good memory scaling in Megatron:
- Add option to allocate gradient buckets out of one large buffer. This makes it easier to access these buffers externally, e.g. for model-parallel communication, at the expense of preventing ZeRO-2 memory scaling.
- Add option to manually initialize params instead of waiting for first backward pass.
- Support param allgathers with any dtype.
- Avoid allocating temporary buffers in side streams, since it made memory pool less efficient.
- When saving state for checkpointing, gather all state on root rank.
- Replace internal dicts with container classes.

The tests pass for me when running on 4 V100s.