### PR TITLE
Add a generic fused softmax

### DIFF
--- a/csrc/megatron/generic_scaled_masked_softmax.cpp
+++ b/csrc/megatron/generic_scaled_masked_softmax.cpp
@@ -1,0 +1,83 @@
+/* coding=utf-8
+ * Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuda_fp16.h>
+#include <torch/extension.h>
+#include <vector>
+
+namespace multihead_attn
+{
+  namespace fused_softmax
+  {
+    namespace generic_scaled_masked_softmax
+    {
+
+      torch::Tensor fwd_cuda(
+          torch::Tensor const &input,
+          torch::Tensor const &mask,
+          float scale_factor);
+
+      torch::Tensor bwd_cuda(
+          torch::Tensor const &output_grads,
+          torch::Tensor const &softmax_results,
+          float scale_factor);
+
+      torch::Tensor fwd(
+          torch::Tensor const &input,
+          torch::Tensor const &mask,
+          float scale_factor)
+      {
+        AT_ASSERTM(input.dim() == 4, "expected 4D tensor");
+        AT_ASSERTM((input.scalar_type() == at::ScalarType::Half) ||
+                       (input.scalar_type() == at::ScalarType::BFloat16),
+                   "Only fp16 and bf16 are supported");
+        AT_ASSERTM(mask.dim() == 4, "expected 4D tensor");
+
+        return fwd_cuda(input, mask, scale_factor);
+      }
+
+      torch::Tensor bwd(
+          torch::Tensor const &output_grads,
+          torch::Tensor const &softmax_results,
+          float scale_factor)
+      {
+
+        AT_ASSERTM(output_grads.dim() == 4, "expected 3D tensor");
+        AT_ASSERTM(softmax_results.dim() == 4, "expected 3D tensor");
+
+        AT_ASSERTM((output_grads.scalar_type() == at::ScalarType::Half) ||
+                       (output_grads.scalar_type() == at::ScalarType::BFloat16),
+                   "Only fp16 and bf16 are supported");
+        AT_ASSERTM((softmax_results.scalar_type() == at::ScalarType::Half) ||
+                       (softmax_results.scalar_type() == at::ScalarType::BFloat16),
+                   "Only fp16 and bf16 are supported");
+
+        return bwd_cuda(output_grads, softmax_results, scale_factor);
+      }
+
+    } // end namespace generic_scaled_masked_softmax
+  }   // end namespace fused_softmax
+} // end namespace multihead_attn
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("forward", 
+        &multihead_attn::fused_softmax::generic_scaled_masked_softmax::fwd, 
+	"Self Multihead Attention scaled, time masked softmax -- Forward.");
+
+  m.def("backward",
+        &multihead_attn::fused_softmax::generic_scaled_masked_softmax::bwd,
+	"Self Multihead Attention scaled, time masked softmax -- Backward.");
+}

--- a/csrc/megatron/generic_scaled_masked_softmax.h
+++ b/csrc/megatron/generic_scaled_masked_softmax.h
@@ -1,0 +1,384 @@
+/* coding=utf-8
+ * Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <assert.h>
+#include <cuda_fp16.h>
+#include <cfloat>
+#include <limits>
+#include <stdint.h>
+#include <cuda_fp16.h>
+#include <c10/macros/Macros.h>
+
+namespace {
+
+template<typename T>
+struct Add {
+  __device__ __forceinline__ T operator()(T a, T b) const {
+    return a + b;
+  }
+};
+
+template<typename T>
+struct Max {
+  __device__ __forceinline__ T operator()(T a, T b) const {
+    return a < b ? b : a;
+  }
+};
+
+template <typename T>
+__device__ __forceinline__ T WARP_SHFL_DOWN_NATIVE(T value, int laneMask, int width = warpSize, unsigned int mask = 0xffffffff)
+{
+#if CUDA_VERSION >= 9000
+    return __shfl_down_sync(mask, value, laneMask, width);
+#else
+    return __shfl_down(value, laneMask, width);
+#endif
+}
+
+template <typename acc_t, int WARP_SIZE, template<typename> class ReduceOp>
+__device__ __forceinline__ acc_t warp_reduce_new(acc_t val) {
+  ReduceOp<acc_t> r;
+  #pragma unroll
+  for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2)
+  {
+      val = r(val, WARP_SHFL_DOWN_NATIVE(val, offset, WARP_SIZE));
+  }
+  return val;
+}
+
+
+template <typename input_t, typename output_t, typename acc_t, int log2_elements>
+__global__ void scaled_masked_softmax_warp_backward_new(
+    output_t *gradInput, //[batches, attn_heads, q_len, k_len]
+    input_t *grad, 
+    const input_t *output, //[batches, attn_heads, q_len, k_len]
+    acc_t scale, 
+    int element_count)
+{
+    int threads_per_block = blockDim.x; 
+    //the first element_count*2 elements are used for cache, the last 128 is used for reduction
+    extern __shared__ acc_t shared_data[];
+    input_t *local_data = (input_t *)shared_data;
+    input_t *output_data = &local_data[element_count];
+    // maximum shared cached 128, enough for 4096 elements reduction into 4096/32= 128 elements
+    acc_t *shared = (acc_t *)(&(local_data[element_count*2]));
+
+    int num_reductions =  (element_count - 1) / threads_per_block + 1;
+
+    int offset = blockIdx.x * element_count;
+
+    int local_idx = threadIdx.x;
+    int lane = threadIdx.x % C10_WARP_SIZE;
+    int wid = threadIdx.x / C10_WARP_SIZE;
+    int warps_per_thread_block = threads_per_block / C10_WARP_SIZE; 
+
+    // load the data to local data
+    acc_t val = 0.0;
+    for (int i = 0; i < num_reductions; i++){
+        if (i*threads_per_block + local_idx < element_count){
+            val = output[offset + i*threads_per_block + local_idx];
+            output_data[i*threads_per_block + local_idx] = val;
+            local_data[i*threads_per_block + local_idx] = val * grad[offset + i*threads_per_block + local_idx];
+        }
+        __syncthreads();
+    }
+
+    // find the sum 
+    for (int i = local_idx; i < (element_count - 1) / C10_WARP_SIZE + 1; i += threads_per_block){
+        shared[i] = 0.0;
+    }
+    __syncthreads();
+
+    #pragma unroll
+    for (int i = 0; i < num_reductions; i++){
+        if (i*threads_per_block + local_idx < element_count){
+            val = local_data[i*threads_per_block + local_idx];
+        }
+        else{
+            val = 0.0;
+        }
+        __syncthreads();
+        val = warp_reduce_new<acc_t, C10_WARP_SIZE, Add>(val);
+        if (lane==0 && wid + warps_per_thread_block * i < (element_count - 1) / C10_WARP_SIZE + 1) {
+            shared[wid + warps_per_thread_block*i] = val;
+        }
+        __syncthreads();
+    }
+
+    // final shared reduction
+
+    int shared_mem_len = (element_count - 1) / C10_WARP_SIZE + 1;
+    int num_warps = (shared_mem_len - 1) / C10_WARP_SIZE + 1;
+    while ( shared_mem_len > 1 ){
+        #pragma unroll
+        for (int i = 0; i < num_reductions; i++){
+            if (i*threads_per_block + local_idx < shared_mem_len){
+                val = shared[i*threads_per_block + local_idx];
+            }
+            else{
+                val = 0.0;
+            }
+            __syncthreads();
+            val = warp_reduce_new<acc_t, C10_WARP_SIZE, Add>(val);
+            if (lane==0) {
+                shared[wid + warps_per_thread_block * i] = val;
+            }
+            __syncthreads();
+        }
+        shared_mem_len = num_warps;
+        num_warps = (shared_mem_len - 1) / C10_WARP_SIZE + 1;
+    }
+    val = shared[0];
+    #pragma unroll
+    for (int i = local_idx; i < element_count; i += threads_per_block){
+        gradInput[offset + i] = (output_t)(scale*(local_data[i] - output_data[i]*val)); 
+    }
+}
+
+} // end of anonymous namespace
+
+template<typename input_t, typename output_t, typename acc_t>
+void dispatch_scaled_masked_softmax_backward_new(
+    output_t *grad_input, 
+    input_t *grad, 
+    const input_t *output, 
+    const acc_t scale, 
+    int query_seq_len, 
+    int key_seq_len, 
+    int batches,
+    int attn_heads)
+{
+    if (key_seq_len == 0)
+    {
+        return;
+    }
+    else
+    {
+        int batch_count = batches * attn_heads * query_seq_len;
+        // use 128 threads per block to maximimize gpu utilization
+        constexpr int threads_per_block = 128;
+        int num_warps = (key_seq_len - 1) / C10_WARP_SIZE + 1;
+        dim3 blocks(batch_count, 1, 1);
+        dim3 threads(threads_per_block, 1, 1);
+
+        scaled_masked_softmax_warp_backward_new<input_t, output_t, acc_t, 12>
+            <<<blocks, threads, sizeof(input_t)*key_seq_len*2 + sizeof(acc_t)*num_warps, at::cuda::getCurrentCUDAStream()>>>(grad_input, grad, output, scale, key_seq_len);
+    }
+}
+
+/*
+ * Extended softmax (from native aten pytorch) with following additional features
+ * 1) input scaling
+ * 2) Explicit masking
+ */	
+template <typename input_t, typename output_t, typename acc_t>
+__global__ void scaled_masked_softmax_warp_forward_new(
+    output_t *dst, 
+    const input_t *src,
+    const uint8_t *mask, 
+    const acc_t scale, 
+    int query_len,          // query_len
+    int attn_heads,
+    int element_count,      // key_len
+    int pad_batches)        // mask batch size 
+{
+    // min threawds_per_block has to be bigger than 128
+    int threads_per_block = blockDim.x; 
+    //  the first element_count is used for cache, the last 128 is used for reduction
+    extern __shared__ acc_t local_data[];
+    // maximum shared cached 128, enough for 4096 elements reduction into 4096/32= 128 elements
+    acc_t *shared = &(local_data[element_count]);
+    // number of 1024 threads reductions 
+    int num_reductions =  (element_count - 1) / threads_per_block + 1;
+
+    int offset = blockIdx.x * element_count;
+    int mask_offset;
+    int query_id = blockIdx.x % query_len; 
+    if (pad_batches == 1){
+        // broadcaste the mask tensor 
+        mask_offset = query_id * element_count; 
+    }
+    else{
+        int mask_batch_id = blockIdx.x / attn_heads / query_len;
+        mask_offset = (mask_batch_id * query_len + query_id) * element_count;
+    }
+
+    int local_idx = threadIdx.x;
+    int lane = threadIdx.x % C10_WARP_SIZE;
+    int wid = threadIdx.x / C10_WARP_SIZE;
+    int warps_per_thread_block = threads_per_block / C10_WARP_SIZE; 
+
+    // load the data to local data
+    for (int i = local_idx; i < element_count; i += threads_per_block)
+    {
+        // TODO, use the copy vector method
+        if (mask[mask_offset + i] == 1)
+        {
+            local_data[i] = -10000.0;
+        }
+        else
+        {
+            local_data[i] = src[offset + i] * scale;
+        }
+    }
+
+    // first find the max value
+    for (int i = local_idx; i < (element_count - 1) / C10_WARP_SIZE + 1; i += threads_per_block){
+        shared[i] = -10000.0;
+    }
+    __syncthreads();
+    acc_t val = -10000.0;
+    #pragma unroll
+    for (int i = 0; i < num_reductions; i++){
+        if (i*threads_per_block + local_idx < element_count){
+            val = local_data[i*threads_per_block + local_idx];
+        }
+        else{
+            val = -10000.0;
+        }
+        __syncthreads();
+        val = warp_reduce_new<acc_t, C10_WARP_SIZE, Max>(val);
+
+        if (lane==0 && wid + warps_per_thread_block * i < (element_count - 1) / C10_WARP_SIZE + 1) {
+            shared[wid + warps_per_thread_block*i] = val;
+        }
+        __syncthreads();
+    }
+
+    // final shared reduction
+    int shared_mem_len = (element_count - 1) / C10_WARP_SIZE + 1;
+    int num_warps = (shared_mem_len - 1) / C10_WARP_SIZE + 1;
+    while ( shared_mem_len > 1 ){
+        #pragma unroll
+        for (int i = 0; i < num_reductions; i++){
+            if (i*threads_per_block + local_idx < shared_mem_len){
+                val = shared[i*threads_per_block + local_idx];
+            }
+            else{
+                val = -10000.0;
+            }
+            __syncthreads();
+            val = warp_reduce_new<acc_t, C10_WARP_SIZE, Max>(val);
+            if (lane==0) {
+                shared[wid + warps_per_thread_block * i] = val;
+            }
+            __syncthreads();
+        }
+        shared_mem_len = num_warps;
+        num_warps = (shared_mem_len - 1) / C10_WARP_SIZE + 1;
+    }
+
+    acc_t reduced_val = shared[0];
+    if (reduced_val < -10000.0 + 0.1){
+        // if everything is masked, pay attention to nothing
+        #pragma unroll
+        for (int i = local_idx; i < element_count; i += threads_per_block){
+             dst[offset + i] = 0.0;
+        }
+        return;
+    }
+
+    // update the values
+    #pragma unroll
+    for (int i = local_idx; i < element_count; i += threads_per_block){
+        local_data[i] = std::exp(local_data[i] - reduced_val);
+    }
+
+    // find the sum 
+    for (int i = local_idx; i < (element_count - 1) / C10_WARP_SIZE + 1; i += threads_per_block){
+        shared[i] = 0.0;
+    }
+    __syncthreads();
+
+    #pragma unroll
+    for (int i = 0; i < num_reductions; i++){
+        if (i*threads_per_block + local_idx < element_count){
+            val = local_data[i*threads_per_block + local_idx];
+        }
+        else{
+            val = 0.0;
+        }
+        __syncthreads();
+
+        val = warp_reduce_new<acc_t, C10_WARP_SIZE, Add>(val);
+        if (lane==0 && wid + warps_per_thread_block * i < (element_count - 1) / C10_WARP_SIZE + 1) {
+            shared[wid + warps_per_thread_block*i] = val;
+        }
+        __syncthreads();
+    }
+
+    shared_mem_len = (element_count - 1) / C10_WARP_SIZE + 1;
+    num_warps = (shared_mem_len - 1) / C10_WARP_SIZE + 1;
+    while ( shared_mem_len > 1 ){
+        #pragma unroll
+        for (int i = 0; i < num_reductions; i++){
+            if (i*threads_per_block + local_idx < shared_mem_len){
+                val = shared[i*threads_per_block + local_idx];
+            }
+            else{
+                val = 0.0;
+            }
+            __syncthreads();
+            val = warp_reduce_new<acc_t, C10_WARP_SIZE, Add>(val);
+            if (lane==0) {
+                shared[wid + warps_per_thread_block * i] = val;
+            }
+            __syncthreads();
+        }
+        shared_mem_len = num_warps;
+        num_warps = (shared_mem_len - 1) / C10_WARP_SIZE + 1;
+    }
+
+    reduced_val = shared[0];
+
+    #pragma unroll
+    for (int i = local_idx; i < element_count; i += threads_per_block){
+         dst[offset + i] = local_data[i] / reduced_val;
+    }
+}
+
+
+template<typename input_t, typename output_t, typename acc_t>
+void dispatch_scaled_masked_softmax_forward_new(
+    output_t *dst, 
+    const input_t *src, 
+    const uint8_t *mask,
+    const input_t scale, 
+    int query_seq_len, 
+    int key_seq_len, 
+    int batches,
+    int attn_heads,
+    int pad_batches)
+{
+    if (key_seq_len == 0) {
+        return;
+    } else {
+        int batch_count = batches * attn_heads * query_seq_len;
+
+        // use 128 threads per block to maximimize gpu utilization
+        constexpr int threads_per_block = 128;
+
+        // calculate the needed shared memory
+        int num_warps = (key_seq_len - 1) / C10_WARP_SIZE + 1;
+
+        dim3 blocks(batch_count, 1, 1);
+        dim3 threads(threads_per_block, 1, 1);
+        scaled_masked_softmax_warp_forward_new<input_t, output_t, acc_t>
+            <<<blocks, threads, sizeof(acc_t) * (key_seq_len + num_warps), at::cuda::getCurrentCUDAStream()>>>(dst, src, mask, scale, query_seq_len, attn_heads, key_seq_len, pad_batches);
+    }
+}

--- a/csrc/megatron/generic_scaled_masked_softmax_cuda.cu
+++ b/csrc/megatron/generic_scaled_masked_softmax_cuda.cu
@@ -1,0 +1,114 @@
+/* coding=utf-8
+ * Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ATen/ATen.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_profiler_api.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+#include "generic_scaled_masked_softmax.h"
+#include "type_shim.h"
+
+namespace multihead_attn {
+namespace fused_softmax {
+namespace generic_scaled_masked_softmax {
+
+torch::Tensor fwd_cuda(
+    torch::Tensor const& input,
+    torch::Tensor const& mask,
+    float scale_factor)
+{
+  // input is a 4d tensor with dimensions [batches, attn_heads, seq_len, seq_len]
+  const int batches = input.size(0);
+  const int pad_batches = mask.size(0);
+  const int attn_heads = input.size(1);
+  const int query_seq_len = input.size(2);
+  const int key_seq_len = input.size(3);
+  TORCH_INTERNAL_ASSERT(pad_batches == 1 || pad_batches == batches);
+  TORCH_INTERNAL_ASSERT(mask.size(1) == 1);
+  TORCH_INTERNAL_ASSERT(mask.size(2) == query_seq_len);
+  TORCH_INTERNAL_ASSERT(mask.size(3) == key_seq_len);
+
+  // Output 
+  auto act_options = input.options().requires_grad(false);
+  torch::Tensor softmax_results = 
+      torch::empty({batches, attn_heads, query_seq_len, key_seq_len}, act_options);
+
+  // Softmax Intermediate Result Ptr
+  void* input_ptr = static_cast<void*>(input.data_ptr());
+  void* mask_ptr = static_cast<void*>(mask.data_ptr());
+  void* softmax_results_ptr = static_cast<void*>(softmax_results.data_ptr());
+
+  DISPATCH_HALF_AND_BFLOAT(
+      input.scalar_type(),
+      "dispatch_scaled_masked_softmax_forward",
+      dispatch_scaled_masked_softmax_forward_new<scalar_t, scalar_t, float>(
+          reinterpret_cast<scalar_t*>(softmax_results_ptr),
+	  reinterpret_cast<const scalar_t*>(input_ptr),
+	  reinterpret_cast<const uint8_t*>(mask_ptr),
+	  scale_factor,
+	  query_seq_len,
+	  key_seq_len,
+	  batches,
+	  attn_heads,
+	  pad_batches);
+      );
+  return softmax_results;
+}
+
+torch::Tensor bwd_cuda(
+    torch::Tensor const& output_grads_, 
+    torch::Tensor const& softmax_results_, 
+    float scale_factor)  {
+
+  auto output_grads = output_grads_.contiguous();
+  auto softmax_results = softmax_results_.contiguous();
+
+  //output grads is a 4d tensor with dimensions [batches, attn_heads, seq_len, seq_len]
+  const int batches = output_grads.size(0);
+  const int attn_heads = output_grads.size(1);
+  const int query_seq_len = output_grads.size(2);
+  const int key_seq_len = output_grads.size(3);
+
+  auto act_options = output_grads.options();
+  torch::Tensor input_grad = 
+      torch::empty({batches, attn_heads, query_seq_len, key_seq_len}, act_options);
+
+  void* output_grads_ptr = static_cast<void*>(output_grads.data_ptr());
+
+  //Softmax Grad
+  DISPATCH_HALF_AND_BFLOAT(
+      output_grads_.scalar_type(),
+      "dispatch_scaled_masked_softmax_backward",
+      dispatch_scaled_masked_softmax_backward_new<scalar_t, scalar_t, float>(
+          reinterpret_cast<scalar_t*>(static_cast<void*>(input_grad.data_ptr())), 
+	  reinterpret_cast<scalar_t*>(output_grads_ptr), 
+	  reinterpret_cast<scalar_t const*>(softmax_results.data_ptr()),
+	  scale_factor,
+	  query_seq_len,
+	  key_seq_len,
+	  batches,
+	  attn_heads);
+			   );
+  
+  //backward pass is completely in-place
+  return input_grad;
+}
+}
+}
+}

--- a/setup.py
+++ b/setup.py
@@ -276,6 +276,30 @@ if "--cuda_ext" in sys.argv:
 
     ext_modules.append(
         CUDAExtension(
+            name="generic_scaled_masked_softmax_cuda",
+            sources=[
+                "csrc/megatron/generic_scaled_masked_softmax.cpp",
+                "csrc/megatron/generic_scaled_masked_softmax_cuda.cu",
+            ],
+            include_dirs=[os.path.join(this_dir, "csrc")],
+            extra_compile_args={
+                "cxx": ["-O3"] + version_dependent_macros,
+                "nvcc": append_nvcc_threads(
+                    [
+                        "-O3",
+                        "-U__CUDA_NO_HALF_OPERATORS__",
+                        "-U__CUDA_NO_HALF_CONVERSIONS__",
+                        "--expt-relaxed-constexpr",
+                        "--expt-extended-lambda",
+                    ]
+                    + version_dependent_macros
+                ),
+            },
+        )
+    )
+
+    ext_modules.append(
+        CUDAExtension(
             name="scaled_masked_softmax_cuda",
             sources=["csrc/megatron/scaled_masked_softmax.cpp", "csrc/megatron/scaled_masked_softmax_cuda.cu"],
             include_dirs=[os.path.join(this_dir, "csrc")],

--- a/tests/L0/run_transformer/test_fused_softmax.py
+++ b/tests/L0/run_transformer/test_fused_softmax.py
@@ -232,11 +232,15 @@ class TestGenericFusedSoftmaxKernel(common_utils.TestCase):
         klen = [1, 2, 3, 4, 5, 8, 10, 11, 13, 128, 256, 1200, 1234, 2048, 3123, 4096, 4128, 7234, 8192, 10232]
         return itertools.product(qlen, klen)
 
-    def test_forward(self):
-        import generic_scaled_masked_softmax_cuda
+    def _setup_batch_attn_scalar(self):
         batch = 2
         attn = 16
         scale_t = 1.0
+        return batch, attn, scale_t
+
+    def test_forward(self):
+        import generic_scaled_masked_softmax_cuda
+        batch, attn, scale_t = self._setup_batch_attn_scalar()
         for qlen, klen in self._setup_qk():
             inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
             masks = torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
@@ -246,10 +250,7 @@ class TestGenericFusedSoftmaxKernel(common_utils.TestCase):
 
     def test_backward(self):
         import generic_scaled_masked_softmax_cuda
-
-        batch = 2
-        attn = 16
-        scale_t = 1.0
+        batch, attn, scale_t = self._setup_batch_attn_scalar()
         for qlen, klen in self._setup_qk():
             inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
             backward = torch.rand_like(inputs, dtype=torch.float16, device='cuda:0')
@@ -263,9 +264,7 @@ class TestGenericFusedSoftmaxKernel(common_utils.TestCase):
 
     def test_allmasked(self):
         import generic_scaled_masked_softmax_cuda
-        batch = 2
-        attn = 16
-        scale_t = 1.0
+        batch, attn, scale_t = self._setup_batch_attn_scalar()
         for qlen, klen in self._setup_qk():
             inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
             masks = torch.ones((batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
@@ -275,10 +274,7 @@ class TestGenericFusedSoftmaxKernel(common_utils.TestCase):
 
     def test_allmask_backward(self):
         import generic_scaled_masked_softmax_cuda
-
-        batch = 2
-        attn = 16
-        scale_t = 1.0
+        batch, attn, scale_t = self._setup_batch_attn_scalar()
         for qlen, klen in self._setup_qk():
             inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
             backward = torch.rand_like(inputs, dtype=torch.float16, device='cuda:0')

--- a/tests/L0/run_transformer/test_fused_softmax.py
+++ b/tests/L0/run_transformer/test_fused_softmax.py
@@ -229,7 +229,7 @@ class TestGenericFusedSoftmaxKernel(common_utils.TestCase):
 
     def _setup_qk(self):
         qlen = [1, 2, 1234, 2322, 2348]
-        klen = [1, 2, 3, 4, 5, 8, 10, 11, 13, 128, 256, 1200, 1234, 2048, 3123, 4096, 4128, 7234, 8192, 10232]
+        klen = [1, 2, 3, 4, 5, 8, 10, 11, 13, 128, 256, 1200, 1234, 2048, 3123, 4096, 4128, 7234, 8192]
         return itertools.product(qlen, klen)
 
     def _setup_batch_attn_scalar(self):

--- a/tests/L0/run_transformer/test_fused_softmax.py
+++ b/tests/L0/run_transformer/test_fused_softmax.py
@@ -231,17 +231,17 @@ class TestGenericFusedSoftmaxKernel(common_utils.TestCase):
         qlen = [1, 2, 1234, 2322, 2348]
         klen = [1, 2, 3, 4, 5, 8, 10, 11, 13, 128, 256, 1200, 1234, 2048, 3123, 4096, 4128, 7234, 8192, 10232]
         return itertools.product(qlen, klen)
- 
+
     def test_forward(self):
         import generic_scaled_masked_softmax_cuda
         batch = 2
         attn = 16
-        scale_t = torch.tensor([1.0])
+        scale_t = 1.0
         for qlen, klen in self._setup_qk():
             inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
             masks = torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
-            softmax_results = generic_scaled_masked_softmax_cuda.forward(inputs, masks, scale_t[0].item())
-            softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
+            softmax_results = generic_scaled_masked_softmax_cuda.forward(inputs, masks, scale_t)
+            softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t)
             self.assertEqual(softmax_results_torch.type(torch.float16), softmax_results, atol=1e-3, rtol=1e-3)
 
     def test_backward(self):
@@ -249,16 +249,15 @@ class TestGenericFusedSoftmaxKernel(common_utils.TestCase):
 
         batch = 2
         attn = 16
-        scale_t = torch.tensor([1.0])
+        scale_t = 1.0
         for qlen, klen in self._setup_qk():
             inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
             backward = torch.rand_like(inputs, dtype=torch.float16, device='cuda:0')
             masks = torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
-            softmax_results = generic_scaled_masked_softmax_cuda.forward(inputs, masks, scale_t[0].item())
-            back_grad = generic_scaled_masked_softmax_cuda.backward(backward, softmax_results, scale_t[0].item())
-
+            softmax_results = generic_scaled_masked_softmax_cuda.forward(inputs, masks, scale_t)
+            back_grad = generic_scaled_masked_softmax_cuda.backward(backward, softmax_results, scale_t)
             inputs.requires_grad = True
-            softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
+            softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t)
             softmax_results_torch.backward(backward)
             self.assertEqual(back_grad, inputs.grad, atol=1e-3, rtol=1e-3)
 
@@ -266,12 +265,12 @@ class TestGenericFusedSoftmaxKernel(common_utils.TestCase):
         import generic_scaled_masked_softmax_cuda
         batch = 2
         attn = 16
-        scale_t = torch.tensor([1.0])
+        scale_t = 1.0
         for qlen, klen in self._setup_qk():
             inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
             masks = torch.ones((batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
-            softmax_results = generic_scaled_masked_softmax_cuda.forward(inputs, masks, scale_t[0].item())
-            softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
+            softmax_results = generic_scaled_masked_softmax_cuda.forward(inputs, masks, scale_t)
+            softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t)
             self.assertEqual(softmax_results_torch.type(torch.float16), softmax_results, atol=1e-3, rtol=1e-3)
 
     def test_allmask_backward(self):
@@ -279,16 +278,16 @@ class TestGenericFusedSoftmaxKernel(common_utils.TestCase):
 
         batch = 2
         attn = 16
-        scale_t = torch.tensor([1.0])
+        scale_t = 1.0
         for qlen, klen in self._setup_qk():
             inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
             backward = torch.rand_like(inputs, dtype=torch.float16, device='cuda:0')
             masks = torch.ones((batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
-            softmax_results = generic_scaled_masked_softmax_cuda.forward(inputs, masks, scale_t[0].item())
-            back_grad = generic_scaled_masked_softmax_cuda.backward(backward, softmax_results, scale_t[0].item())
+            softmax_results = generic_scaled_masked_softmax_cuda.forward(inputs, masks, scale_t)
+            back_grad = generic_scaled_masked_softmax_cuda.backward(backward, softmax_results, scale_t)
 
             inputs.requires_grad = True
-            softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
+            softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t)
             softmax_results_torch.backward(backward)
             self.assertEqual(back_grad, inputs.grad, atol=1e-3, rtol=1e-3)
 

--- a/tests/L0/run_transformer/test_fused_softmax.py
+++ b/tests/L0/run_transformer/test_fused_softmax.py
@@ -14,6 +14,14 @@ from apex.transformer.functional import FusedScaleMaskSoftmax
 def attention_mask_func(attention_scores, attention_mask):
     return attention_scores.masked_fill(attention_mask, -10000.0)
 
+def forward_torch_softmax(input, mask, scale):
+    input = input * scale
+    mask_output = attention_mask_func(input, mask) if mask is not None else input
+    probs = torch.nn.Softmax(dim=-1)(mask_output)
+    all_k_masked = mask.all(axis=-1)
+    zero_attention_mask = (1.0 - all_k_masked.float())[:, :, :, None]
+    probs = probs * zero_attention_mask
+    return probs
 
 autocast_dtypes = (
     (torch.half, torch.bfloat16) if torch.cuda.is_bf16_supported() else (torch.half,)
@@ -215,6 +223,172 @@ class TestFusedScaleMaskSoftmax(common_utils.TestCase):
                     g1 = g0.clone()
                 actual.backward(g0)
                 expected.backward(g1)
+
+
+class TestGenericFusedSoftmaxKernel(common_utils.TestCase):
+
+    def test_forward(self):
+        import generic_scaled_masked_softmax_cuda
+
+        batch = 2
+        attn = 16
+        qlen = 2348
+        klen = 3123
+        scale_t = torch.tensor([1.0])
+        for qlen in [2348, 2322, 1234, 1, 2]:
+            for klen in [
+                3123,
+                1234,
+                2,
+                4,
+                8,
+                3,
+                1,
+                5,
+                10,
+                11,
+                13,
+                128,
+                256,
+                1200,
+                2048,
+                4096,
+                7234,
+                8192,
+                10232,
+                4128,
+            ]:
+                inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
+                masks = torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
+                softmax_results = generic_scaled_masked_softmax_cuda.forward(inputs, masks, scale_t[0].item())
+                softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
+                error = (softmax_results_torch - softmax_results).abs().max()
+                assert error < 1e-3
+
+    def test_backward(self):
+        import generic_scaled_masked_softmax_cuda
+
+        batch = 2
+        attn = 16
+        qlen = 2348
+        klen = 3123
+        scale_t = torch.tensor([1.0])
+        for qlen in [2348, 2322, 1234, 1, 2]:
+            for klen in [
+                3123,
+                1234,
+                2,
+                4,
+                8,
+                3,
+                1,
+                5,
+                10,
+                11,
+                13,
+                128,
+                256,
+                1200,
+                2048,
+                4096,
+                7234,
+                8192,
+                10232,
+                4128,
+            ]:
+                inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
+                backward = torch.rand_like(inputs, dtype=torch.float16, device='cuda:0')
+                masks = torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
+                softmax_results = generic_scaled_masked_softmax_cuda.forward(inputs, masks, scale_t[0].item())
+                back_grad = generic_scaled_masked_softmax_cuda.backward(backward, softmax_results, scale_t[0].item())
+
+                inputs.requires_grad = True
+                softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
+                softmax_results_torch.backward(backward)
+                error = (back_grad - inputs.grad).abs().max()
+                assert error < 1e-3
+
+    def test_allmasked(self):
+        import generic_scaled_masked_softmax_cuda
+
+        batch = 2
+        attn = 16
+        qlen = 2348
+        klen = 3123
+        scale_t = torch.tensor([1.0])
+        for qlen in [2348, 2322, 1234, 1, 2]:
+            for klen in [
+                3123,
+                1234,
+                2,
+                4,
+                8,
+                3,
+                1,
+                5,
+                10,
+                11,
+                13,
+                128,
+                256,
+                1200,
+                2048,
+                4096,
+                7234,
+                8192,
+                10232,
+                4128,
+            ]:
+                inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
+                masks = torch.ones((batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
+                softmax_results = generic_scaled_masked_softmax_cuda.forward(inputs, masks, scale_t[0].item())
+                softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
+                error = (softmax_results_torch - softmax_results).abs().max()
+                assert error < 2e-3
+
+    def test_allmask_backward(self):
+        import generic_scaled_masked_softmax_cuda
+
+        batch = 2
+        attn = 16
+        qlen = 2348
+        klen = 3123
+        scale_t = torch.tensor([1.0])
+        for qlen in [2348, 2322, 1234, 1, 2]:
+            for klen in [
+                3123,
+                1234,
+                2,
+                4,
+                8,
+                3,
+                1,
+                5,
+                10,
+                11,
+                13,
+                128,
+                256,
+                1200,
+                2048,
+                4096,
+                7234,
+                8192,
+                10232,
+                4128,
+            ]:
+                inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
+                backward = torch.rand_like(inputs, dtype=torch.float16, device='cuda:0')
+                masks = torch.ones((batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
+                softmax_results = generic_scaled_masked_softmax_cuda.forward(inputs, masks, scale_t[0].item())
+                back_grad = generic_scaled_masked_softmax_cuda.backward(backward, softmax_results, scale_t[0].item())
+
+                inputs.requires_grad = True
+                softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
+                softmax_results_torch.backward(backward)
+                error = (back_grad - inputs.grad).abs().max()
+                assert error < 1e-3
+
 
 if __name__ == "__main__":
     common_utils.run_tests()


### PR DESCRIPTION
Originally created the PR for NeMo at https://github.com/NVIDIA/NeMo/pull/4594
@ericharper  suggested to move it here

# What does this PR do ?
Implemented a generic fused softmax GPU kernel that can be a drop-in replacement of the `FusedScaleMaskSoftmax`. It addresses the following issues:
1. Removed the sequence length limitation. It works with tensor of any length.
2. Fix the `grad_input` modification issue https://github.com/NVIDIA/apex/issues/1430
3. Fix the problem when all keys are masked https://github.com/NVIDIA/apex/issues/1390

It includes a unit test to cover a few cases.
The performance is comparable to the apex one. Here is a training step time graph when it is tested with training a RETRO model.
![image](https://user-images.githubusercontent.com/43824965/180662857-712f48e4-dc9b-40f7-aad5-13e82004a30b.png)
The blue curve is pytorch softmax. The bottom red curve is apex fused kernel and the middle red curve the fused kernel in this PR.

