### PR TITLE
Fix an issue where `child_name` can be None and make the overall ASP fail

### DIFF
--- a/apex/contrib/sparsity/permutation_lib.py
+++ b/apex/contrib/sparsity/permutation_lib.py
@@ -661,7 +661,11 @@ class Permutation:
             while has_visit_children_num < len(node_children):
                 for child_name in node_children:
                     if child_name != 'output':    # 'output' node has no 'module_type'
-                        child_module_type = fx_graph.get(child_name).get('module_type')
+                        child = fx_graph.get(child_name)
+                        if child is None:
+                            has_visit_children_num += 1
+
+                        child_module_type = child.get('module_type')
                         if child_module_type in ['torch.nn.modules.conv.Conv2d', 'torch.nn.modules.linear.Linear']:
                             print("[recursive_find_real_children] node_name: \'{:}\', has one real child: \'{:}\', its real child module type: \'{:}\'.".format(node_name, child_name, child_module_type))
                             node_real_children_name.append(child_name)


### PR DESCRIPTION
When attempting to sparsify a transformers model, it appears for some reason `child_name` can be `None` and thus `fx_graph.get(None)` returns `None` and make the overall process crash.

This PR attempts to hotfix this but do no investigate why the FX graph generates such `None` children.

I'm testing the output of the `fx_graph.get(...)` to be non-null rather than `child_name` being null because the first one will cover the second (`fx_graph.get(None) -> None`).