### PR TITLE
support for full mask in fused softmax kernel + avoiding inplace operation in bwd pass

### DIFF
--- a/csrc/megatron/scaled_masked_softmax.h
+++ b/csrc/megatron/scaled_masked_softmax.h
@@ -182,6 +182,13 @@ __global__ void scaled_masked_softmax_warp_forward(
     }
     warp_reduce<acc_t, WARP_BATCH, WARP_SIZE, Max>(max_value);
 
+    // compute scale value to account for full mask
+    acc_t scale_value[WARP_BATCH];
+    #pragma unroll
+    for (int i = 0;  i < WARP_BATCH;  ++i) {
+        scale_value[i] = (max_value[i] == -10000.0) ? 0.0 : 1.0;
+    }
+ 
     acc_t sum[WARP_BATCH] { 0.0f };
     #pragma unroll
     for (int i = 0;  i < WARP_BATCH;  ++i) {
@@ -205,7 +212,7 @@ __global__ void scaled_masked_softmax_warp_forward(
             if (element_index < element_count) {
                 #pragma unroll
                 for (int element = 0; element < ELEMENTS_PER_LDG_STG; ++element) {
-                    out[element] = elements[i][it + element] / sum[i];
+                    out[element] = elements[i][it + element] * scale_value[i]/ sum[i];
                 }
                 copy_vector<output_t, ELEMENTS_PER_LDG_STG>(dst + i * element_count + it * WARP_SIZE, out);  
             } else {

--- a/csrc/megatron/scaled_masked_softmax_cuda.cu
+++ b/csrc/megatron/scaled_masked_softmax_cuda.cu
@@ -66,15 +66,16 @@ torch::Tensor fwd_cuda(
       "dispatch_scaled_masked_softmax_forward",
       dispatch_scaled_masked_softmax_forward<scalar_t, scalar_t, float>(
           reinterpret_cast<scalar_t*>(softmax_results_ptr),
-	  reinterpret_cast<const scalar_t*>(input_ptr),
-	  reinterpret_cast<const uint8_t*>(mask_ptr),
-	  scale_factor,
-	  query_seq_len,
-	  key_seq_len,
-	  batches,
-	  attn_heads,
-	  pad_batches);
+          reinterpret_cast<const scalar_t*>(input_ptr),
+          reinterpret_cast<const uint8_t*>(mask_ptr),
+          scale_factor,
+          query_seq_len,
+          key_seq_len,
+          batches,
+          attn_heads,
+          pad_batches
       );
+  );
   return softmax_results;
 }
 
@@ -82,7 +83,7 @@ torch::Tensor bwd_cuda(
     torch::Tensor const& output_grads_, 
     torch::Tensor const& softmax_results_, 
     float scale_factor)  {
-	
+    
   auto output_grads = output_grads_.contiguous();
   auto softmax_results = softmax_results_.contiguous();
 
@@ -92,6 +93,10 @@ torch::Tensor bwd_cuda(
   const int query_seq_len = output_grads.size(2);
   const int key_seq_len = output_grads.size(3);
 
+  auto act_options = output_grads.options().requires_grad(false);
+  torch::Tensor input_grads = 
+      torch::empty({batches, attn_heads, query_seq_len, key_seq_len}, act_options);
+  void* input_grads_ptr = static_cast<void*>(input_grads.data_ptr());
   void* output_grads_ptr = static_cast<void*>(output_grads.data_ptr());
 
   //Softmax Grad
@@ -99,18 +104,17 @@ torch::Tensor bwd_cuda(
       output_grads_.scalar_type(),
       "dispatch_scaled_masked_softmax_backward",
       dispatch_scaled_masked_softmax_backward<scalar_t, scalar_t, float>(
+          reinterpret_cast<scalar_t*>(input_grads_ptr), 
           reinterpret_cast<scalar_t*>(output_grads_ptr), 
-	  reinterpret_cast<scalar_t*>(output_grads_ptr), 
-	  reinterpret_cast<scalar_t const*>(softmax_results.data_ptr()),
-	  scale_factor,
-	  query_seq_len,
-	  key_seq_len,
-	  batches,
-	  attn_heads);
-			   );
-  
-  //backward pass is completely in-place
-  return output_grads;
+          reinterpret_cast<scalar_t const*>(softmax_results.data_ptr()),
+          scale_factor,
+          query_seq_len,
+          key_seq_len,
+          batches,
+          attn_heads
+      );
+  );
+  return input_grads;
 }
 }
 }


### PR DESCRIPTION
This adds the following features to the softmax fused kernel

1. Full mask support
2. Avoiding in place backward operation as suggested in the Pytorch documentation

Background: The fused kernel outputs uniform distribution When the mask is all 1 (all values are masked). This led to wrong semantics during the backward pass. We implicitly obtain the mask using fwd softmax output (softmax_output == 0) during backward computation. This assumption does not hold true for the corner case of the mask being all 1. This change outputs 0 whenever the mask is all 1. Conceptually, it makes sense to output 0 if you are not attending to any of the keys. We now match PyTorch (non-fused flow) bwd pass with this change for the full mask case.

Fixes: https://github.com/NVIDIA/apex/issues/1430, https://github.com/NVIDIA/apex/issues/1390

co-authored by:  Vijay Korthikanti <vkorthikanti@nvidia.com> (ADLR team)