### PR TITLE
Store distributed Adam state_dict in uint8 tensors

### DIFF
--- a/apex/contrib/test/optimizers/test_dist_adam.py
+++ b/apex/contrib/test/optimizers/test_dist_adam.py
@@ -337,7 +337,7 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
             state_bytes = [None]
         torch.distributed.broadcast_object_list(state_bytes, src=0)
         state_bytes = io.BytesIO(state_bytes[0])
-        state_dict = torch.load(state_bytes, map_location='cuda')
+        state_dict = torch.load(state_bytes)
         model_load.load_state_dict(state_dict['model'])
         optim_load.load_state_dict(state_dict['optim'])
 


### PR DESCRIPTION
Checkpointing failed with large models since pickle doesn't support >4 GB byetarrays by default (requires pickle protocol >=4). pickle can handle large PyTorch tensors without problems though. With this change, I've been able to successfully checkpoint GPT-3 175B.

I've also fixed a device mismatch error that I was experiencing because `'cuda' != 'cuda:{device_id}'`. To get around this, I've forced the optimizer device to be in `'cuda:{device_id}'` format.