### PR TITLE
Use `xmlrunner.XMLTestRunner` accordingly in `tests/L0/run_test.py`

### DIFF
--- a/tests/L0/run_test.py
+++ b/tests/L0/run_test.py
@@ -66,11 +66,11 @@ def main(args: argparse.Namespace) -> None:
     for test_dir in args.include:
         if args.xml_report:
             this_dir = os.path.abspath(os.path.dirname(__file__))
-            xml_filename = os.path.join(
+            xml_output = os.path.join(
                 this_dir,
-                f"""TEST_{test_dir}_{date.today().strftime("%y%m%d")}.xml""",
+                f"""TEST_{test_dir}_{date.today().strftime("%y%m%d")}""",
             )
-            test_runner_kwargs["output"] = xml_filename
+            test_runner_kwargs["output"] = xml_output
 
         runner = Runner(**test_runner_kwargs)
         test_dir = os.path.join(TEST_ROOT, test_dir)

--- a/tests/L0/run_test.py
+++ b/tests/L0/run_test.py
@@ -66,7 +66,7 @@ def main(args: argparse.Namespace) -> None:
             this_dir,
             f"""{date.today().strftime("%y%m%d")}.xml""",
         )
-        xml_output = open(xml_filename, "w")
+        xml_output = open(xml_filename, "wb")
         test_runner_kwargs["output"] = xml_output
         Runner = xmlrunner.XMLTestRunner
 

--- a/tests/L0/run_test.py
+++ b/tests/L0/run_test.py
@@ -83,10 +83,6 @@ def main(args: argparse.Namespace) -> None:
         if not result.wasSuccessful():
             errcode = 1
 
-    # if xml_output is not None:
-    #     xml_output.close()
-    #     print(f"\n### Report is available at {xml_filename}")
-
     sys.exit(errcode)
 
 

--- a/tests/L0/run_test.py
+++ b/tests/L0/run_test.py
@@ -55,26 +55,25 @@ def parse_args():
 
 
 def main(args: argparse.Namespace) -> None:
-    xml_output, xml_filename = None, None
     test_runner_kwargs = {"verbosity": 2}
     Runner = unittest.TextTestRunner
     if args.xml_report:
         import xmlrunner
         from datetime import date  # NOQA
-        this_dir = os.path.abspath(os.path.dirname(__file__))
-        xml_filename = os.path.join(
-            this_dir,
-            f"""{date.today().strftime("%y%m%d")}.xml""",
-        )
-        xml_output = open(xml_filename, "wb")
-        test_runner_kwargs["output"] = xml_output
         Runner = xmlrunner.XMLTestRunner
 
-    runner = Runner(**test_runner_kwargs)
     errcode = 0
     for test_dir in args.include:
+        if args.xml_report:
+            this_dir = os.path.abspath(os.path.dirname(__file__))
+            xml_filename = os.path.join(
+                this_dir,
+                f"""TEST_{test_dir}_{date.today().strftime("%y%m%d")}.xml""",
+            )
+            test_runner_kwargs["output"] = xml_filename
+
+        runner = Runner(**test_runner_kwargs)
         test_dir = os.path.join(TEST_ROOT, test_dir)
-        print(test_dir)
         suite = unittest.TestLoader().discover(test_dir)
 
         print("\nExecuting tests from " + test_dir)
@@ -84,9 +83,9 @@ def main(args: argparse.Namespace) -> None:
         if not result.wasSuccessful():
             errcode = 1
 
-    if xml_output is not None:
-        xml_output.close()
-        print(f"\n### Report is available at {xml_filename}")
+    # if xml_output is not None:
+    #     xml_output.close()
+    #     print(f"\n### Report is available at {xml_filename}")
 
     sys.exit(errcode)
 

--- a/tests/L0/run_transformer/test_batch_sampler.py
+++ b/tests/L0/run_transformer/test_batch_sampler.py
@@ -1,10 +1,6 @@
-from itertools import product
-
 import torch
 from torch.testing._internal import common_utils
 from torch.utils.data import Dataset
-from torch.utils.data import RandomSampler
-from torch.utils.data import BatchSampler
 from torch.utils.data import DataLoader
 
 from apex.transformer.pipeline_parallel.utils import _split_batch_into_microbatch as split_batch_into_microbatch
@@ -85,23 +81,22 @@ class TestBatchSamplerBehavior(common_utils.TestCase):
         dataset = MyIterableDataset(0, 100)
 
         for num_workers in (1, 2, 4):
-            with self.subTest(f"{num_workers}"):
-                torch.manual_seed(42)
-                loader = DataLoader(dataset, batch_sampler=MegatronPretrainingRandomSampler(100, 0, 4, 0, 1), num_workers=num_workers)
-                samples = []
-                for i, batch in enumerate(loader):
-                    samples.append(batch)
-                    if i == 2 - 1:
-                        break
+            torch.manual_seed(42)
+            loader = DataLoader(dataset, batch_sampler=MegatronPretrainingRandomSampler(100, 0, 4, 0, 1), num_workers=num_workers)
+            samples = []
+            for i, batch in enumerate(loader):
+                samples.append(batch)
+                if i == 2 - 1:
+                    break
 
-                torch.manual_seed(42)
-                loader = DataLoader(dataset, batch_sampler=MegatronPretrainingRandomSampler(100, 0, 2, 0, 1), num_workers=num_workers)
-                samples2 = []
-                for i, batch in enumerate(loader):
-                    samples2.append(batch)
-                    if i == 4 - 1:
-                        break
-                self.assertEqual(torch.cat(samples), torch.cat(samples2))
+            torch.manual_seed(42)
+            loader = DataLoader(dataset, batch_sampler=MegatronPretrainingRandomSampler(100, 0, 2, 0, 1), num_workers=num_workers)
+            samples2 = []
+            for i, batch in enumerate(loader):
+                samples2.append(batch)
+                if i == 4 - 1:
+                    break
+            self.assertEqual(torch.cat(samples), torch.cat(samples2), msg=f"num_workers={num_workers}")
 
     def test_split_batch(self):
 

--- a/tests/L0/run_transformer/test_layers.py
+++ b/tests/L0/run_transformer/test_layers.py
@@ -47,43 +47,43 @@ class TensorParallelLayerTestBase:
         for tensor_model_parallel_world_size in range(1, self.world_size + 1):
             if self.world_size % tensor_model_parallel_world_size:
                 continue
-            with self.subTest(tensor_model_parallel_world_size=tensor_model_parallel_world_size):
-                parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size_=tensor_model_parallel_world_size,
-                )
-                tensor_model_parallel_rank = parallel_state.get_tensor_model_parallel_rank()
-                cur_tensor_model_device = torch.device(f"cuda:{tensor_model_parallel_rank}")
-                with torch.no_grad():
-                    tensor = tensor_model_parallel_rank * torch.ones(
-                        self.tensor_shape, dtype=torch.float32, device=cur_tensor_model_device)
-                numel = tensor.numel()
-                numel_gathered = tensor_model_parallel_world_size * numel
-                gathered = torch.empty(
-                    torch.Size((numel_gathered,)),
-                    device=cur_tensor_model_device,
-                    dtype=torch.float32,
-                    requires_grad=False,
-                )
-                chunks = [
-                    gathered[i * numel : (i + 1) * numel]
-                    for i in range(tensor_model_parallel_world_size)
-                ]
-                all_gather(chunks, tensor, group=parallel_state.get_tensor_model_parallel_group())
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size_=tensor_model_parallel_world_size,
+            )
+            tensor_model_parallel_rank = parallel_state.get_tensor_model_parallel_rank()
+            cur_tensor_model_device = torch.device(f"cuda:{tensor_model_parallel_rank}")
+            with torch.no_grad():
+                tensor = tensor_model_parallel_rank * torch.ones(
+                    self.tensor_shape, dtype=torch.float32, device=cur_tensor_model_device)
+            numel = tensor.numel()
+            numel_gathered = tensor_model_parallel_world_size * numel
+            gathered = torch.empty(
+                torch.Size((numel_gathered,)),
+                device=cur_tensor_model_device,
+                dtype=torch.float32,
+                requires_grad=False,
+            )
+            chunks = [
+                gathered[i * numel : (i + 1) * numel]
+                for i in range(tensor_model_parallel_world_size)
+            ]
+            all_gather(chunks, tensor, group=parallel_state.get_tensor_model_parallel_group())
 
-                gathered_for_base = torch.empty(
-                    torch.Size((numel_gathered,)),
-                    device=cur_tensor_model_device,
-                    dtype=torch.float32,
-                    requires_grad=False,
-                )
-                _all_gather_base(
-                    gathered_for_base,
-                    tensor,
-                    group=parallel_state.get_tensor_model_parallel_group(),
-                )
+            gathered_for_base = torch.empty(
+                torch.Size((numel_gathered,)),
+                device=cur_tensor_model_device,
+                dtype=torch.float32,
+                requires_grad=False,
+            )
+            _all_gather_base(
+                gathered_for_base,
+                tensor,
+                group=parallel_state.get_tensor_model_parallel_group(),
+            )
 
-                self.assertEqual(gathered, gathered_for_base)
-                parallel_state.destroy_model_parallel()
+            msg = f"tensor_model_parallel_world_size: {tensor_model_parallel_world_size}"
+            self.assertEqual(gathered, gathered_for_base, msg=msg)
+            parallel_state.destroy_model_parallel()
 
     @torch.no_grad()
     @unittest.skipIf(torch.cuda.device_count() < 2, "Requires >=2 GPUs")
@@ -95,113 +95,111 @@ class TensorParallelLayerTestBase:
         for tensor_model_parallel_world_size in range(2, self.world_size + 1):
             if self.world_size % tensor_model_parallel_world_size:
                 continue
-            with self.subTest(tensor_model_parallel_world_size=tensor_model_parallel_world_size):
-                parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size_=tensor_model_parallel_world_size,
-                )
-                tensor_model_parallel_rank = parallel_state.get_tensor_model_parallel_rank()
-                cur_tensor_model_device = torch.device(f"cuda:{tensor_model_parallel_rank}")
-                with torch.no_grad():
-                    input = torch.cat([
-                        i * torch.ones(self.tensor_shape, dtype=torch.float32, device=cur_tensor_model_device)
-                        for i in range(tensor_model_parallel_world_size)
-                    ])
-                    input_list = [t.clone() for t in input.chunk(tensor_model_parallel_world_size)]
-                output = torch.empty(
-                    self.tensor_shape,
-                    device=cur_tensor_model_device,
-                    dtype=torch.float32,
-                    requires_grad=False,
-                )
-                reduce_scatter(
-                    output, input_list,
-                    group=parallel_state.get_tensor_model_parallel_group(),
-                )
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size_=tensor_model_parallel_world_size,
+            )
+            tensor_model_parallel_rank = parallel_state.get_tensor_model_parallel_rank()
+            cur_tensor_model_device = torch.device(f"cuda:{tensor_model_parallel_rank}")
+            with torch.no_grad():
+                input = torch.cat([
+                    i * torch.ones(self.tensor_shape, dtype=torch.float32, device=cur_tensor_model_device)
+                    for i in range(tensor_model_parallel_world_size)
+                ])
+                input_list = [t.clone() for t in input.chunk(tensor_model_parallel_world_size)]
+            output = torch.empty(
+                self.tensor_shape,
+                device=cur_tensor_model_device,
+                dtype=torch.float32,
+                requires_grad=False,
+            )
+            reduce_scatter(
+                output, input_list,
+                group=parallel_state.get_tensor_model_parallel_group(),
+            )
 
-                output_for_base = torch.empty(
-                    self.tensor_shape,
-                    device=cur_tensor_model_device,
-                    dtype=torch.float32,
-                    requires_grad=False,
-                )
-                _reduce_scatter_base(
-                    output_for_base,
-                    input,
-                    group=parallel_state.get_tensor_model_parallel_group(),
-                )
+            output_for_base = torch.empty(
+                self.tensor_shape,
+                device=cur_tensor_model_device,
+                dtype=torch.float32,
+                requires_grad=False,
+            )
+            _reduce_scatter_base(
+                output_for_base,
+                input,
+                group=parallel_state.get_tensor_model_parallel_group(),
+            )
 
-                self.assertEqual(output, output_for_base)
-                self.assertEqual(input, torch.cat(input_list))
-                parallel_state.destroy_model_parallel()
+            msg = f"tensor_model_parallel_world_size: {tensor_model_parallel_world_size}"
+            self.assertEqual(output, output_for_base, msg=msg)
+            self.assertEqual(input, torch.cat(input_list), msg=msg)
+            parallel_state.destroy_model_parallel()
 
     def test_parallel_embedding(self) -> None:
         for tensor_model_parallel_world_size in range(1, self.world_size + 1):
             if self.world_size % tensor_model_parallel_world_size:
                 continue
-            with self.subTest(
-                tensor_model_parallel_world_size=tensor_model_parallel_world_size
-            ):
-                parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size_=tensor_model_parallel_world_size,
-                )
-                set_random_seed(self.SEED + 1)
-                input_tensor = torch.randint(
-                    0,
-                    self.VOCAB_SIZE,
-                    (
-                        self.BATCH_SIZE,
-                        self.SEQUENCE_LENGTH,
-                    ),
-                    device="cuda",
-                )
-                loss_weight = torch.randn(
-                    (
-                        self.BATCH_SIZE,
-                        self.SEQUENCE_LENGTH,
-                        self.HIDDEN_SIZE,
-                    ),
-                    device="cuda",
-                )
-
-                set_random_seed(self.SEED)
-                embedding_torch = nn.Embedding(
-                    self.VOCAB_SIZE,
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size_=tensor_model_parallel_world_size,
+            )
+            set_random_seed(self.SEED + 1)
+            input_tensor = torch.randint(
+                0,
+                self.VOCAB_SIZE,
+                (
+                    self.BATCH_SIZE,
+                    self.SEQUENCE_LENGTH,
+                ),
+                device="cuda",
+            )
+            loss_weight = torch.randn(
+                (
+                    self.BATCH_SIZE,
+                    self.SEQUENCE_LENGTH,
                     self.HIDDEN_SIZE,
-                ).cuda()
-                output_torch = embedding_torch(input_tensor)
-                loss_torch = torch.mul(output_torch, loss_weight).sum()
-                loss_torch.backward()
+                ),
+                device="cuda",
+            )
 
-                # N.B.(mkozuki): With affine weight initialization on GPU,
-                # it's super difficult to keep the consistency with nn.Embedding.
-                # Thus, turning on `use_cpu_initialization`.
-                set_random_seed(self.SEED)
-                embedding_vocab_parallel = layers.VocabParallelEmbedding(
-                    self.VOCAB_SIZE,
-                    self.HIDDEN_SIZE,
-                    init_method=nn.init.normal_,
-                    use_cpu_initialization=True,
-                ).cuda()
-                output_vocab_parallel = embedding_vocab_parallel(input_tensor)
-                loss_vocab_parallel = torch.mul(
-                    output_vocab_parallel, loss_weight
-                ).sum()
-                loss_vocab_parallel.backward()
+            set_random_seed(self.SEED)
+            embedding_torch = nn.Embedding(
+                self.VOCAB_SIZE,
+                self.HIDDEN_SIZE,
+            ).cuda()
+            output_torch = embedding_torch(input_tensor)
+            loss_torch = torch.mul(output_torch, loss_weight).sum()
+            loss_torch.backward()
 
-                self.assertEqual(output_torch, output_vocab_parallel)
-                self.assertEqual(loss_torch, loss_vocab_parallel)
+            # N.B.(mkozuki): With affine weight initialization on GPU,
+            # it's super difficult to keep the consistency with nn.Embedding.
+            # Thus, turning on `use_cpu_initialization`.
+            set_random_seed(self.SEED)
+            embedding_vocab_parallel = layers.VocabParallelEmbedding(
+                self.VOCAB_SIZE,
+                self.HIDDEN_SIZE,
+                init_method=nn.init.normal_,
+                use_cpu_initialization=True,
+            ).cuda()
+            output_vocab_parallel = embedding_vocab_parallel(input_tensor)
+            loss_vocab_parallel = torch.mul(
+                output_vocab_parallel, loss_weight
+            ).sum()
+            loss_vocab_parallel.backward()
 
-                splitted_weight_torch = torch.split(
-                    embedding_torch.weight.grad,
-                    self.VOCAB_SIZE
-                    // tensor_model_parallel_world_size,
-                    0,
-                )[parallel_state.get_tensor_model_parallel_rank()]
-                self.assertEqual(
-                    splitted_weight_torch, embedding_vocab_parallel.weight.grad
-                )
+            msg = f"tensor_model_parallel_world_size: {tensor_model_parallel_world_size}"
+            self.assertEqual(output_torch, output_vocab_parallel, msg=msg)
+            self.assertEqual(loss_torch, loss_vocab_parallel, msg=msg)
 
-                parallel_state.destroy_model_parallel()
+            splitted_weight_torch = torch.split(
+                embedding_torch.weight.grad,
+                self.VOCAB_SIZE
+                // tensor_model_parallel_world_size,
+                0,
+            )[parallel_state.get_tensor_model_parallel_rank()]
+            self.assertEqual(
+                splitted_weight_torch, embedding_vocab_parallel.weight.gra, msg=msgd,
+            )
+
+            parallel_state.destroy_model_parallel()
 
     def _affine_weight_init_test_impl(
         self, init_device: str, is_column_parallel: bool
@@ -210,56 +208,55 @@ class TensorParallelLayerTestBase:
         for tensor_model_parallel_world_size in range(1, self.world_size + 1):
             if self.world_size % tensor_model_parallel_world_size:
                 continue
-            with self.subTest(
-                tensor_model_parallel_world_size=tensor_model_parallel_world_size
-            ):
-                parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size_=tensor_model_parallel_world_size
-                )
-                input_size: int = self.INPUT_SIZE_COEFF * tensor_model_parallel_world_size
-                output_size: int = self.OUTPUT_SIZE_COEFF * tensor_model_parallel_world_size
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size_=tensor_model_parallel_world_size
+            )
+            input_size: int = self.INPUT_SIZE_COEFF * tensor_model_parallel_world_size
+            output_size: int = self.OUTPUT_SIZE_COEFF * tensor_model_parallel_world_size
 
-                weight_shape = (
-                    (self.OUTPUT_SIZE_COEFF, input_size)
-                    if is_column_parallel
-                    else (output_size, self.INPUT_SIZE_COEFF)
-                )
-                weight = torch.empty(weight_shape)
-                set_random_seed(self.SEED)
+            weight_shape = (
+                (self.OUTPUT_SIZE_COEFF, input_size)
+                if is_column_parallel
+                else (output_size, self.INPUT_SIZE_COEFF)
+            )
+            weight = torch.empty(weight_shape)
+            set_random_seed(self.SEED)
 
-                sharding_dim_size = (
-                    self.OUTPUT_SIZE_COEFF
-                    if is_column_parallel
-                    else self.INPUT_SIZE_COEFF
-                )
+            sharding_dim_size = (
+                self.OUTPUT_SIZE_COEFF
+                if is_column_parallel
+                else self.INPUT_SIZE_COEFF
+            )
 
-                if init_device == "cpu":
-                    layers._initialize_affine_weight_cpu(
-                        weight,
-                        output_size,
-                        input_size,
-                        sharding_dim_size,
-                        dim,
-                        nn.init.normal_,
-                        params_dtype=torch.float32,
-                    )
-                else:
-                    layers._initialize_affine_weight_gpu(
-                        weight, torch.nn.init.normal_, dim
-                    )
-                # Target
-                set_random_seed(self.SEED)
-                if init_device == "cpu":
-                    main_weight = torch.empty(output_size, input_size)
-                    nn.init.normal_(main_weight)
-                    curr_weight = torch.split(main_weight, sharding_dim_size, dim=dim)[
-                        parallel_state.get_tensor_model_parallel_rank()
-                    ]
-                else:
-                    curr_weight = torch.empty(*weight_shape)
-                    nn.init.normal_(curr_weight)
-                self.assertEqual(curr_weight, weight)
-                parallel_state.destroy_model_parallel()
+            if init_device == "cpu":
+                layers._initialize_affine_weight_cpu(
+                    weight,
+                    output_size,
+                    input_size,
+                    sharding_dim_size,
+                    dim,
+                    nn.init.normal_,
+                    params_dtype=torch.float32,
+                )
+            else:
+                layers._initialize_affine_weight_gpu(
+                    weight, torch.nn.init.normal_, dim
+                )
+            # Target
+            set_random_seed(self.SEED)
+            if init_device == "cpu":
+                main_weight = torch.empty(output_size, input_size)
+                nn.init.normal_(main_weight)
+                curr_weight = torch.split(main_weight, sharding_dim_size, dim=dim)[
+                    parallel_state.get_tensor_model_parallel_rank()
+                ]
+            else:
+                curr_weight = torch.empty(*weight_shape)
+                nn.init.normal_(curr_weight)
+
+            self.assertEqual(
+                curr_weight, weight, msg=f"tensor_model_parallel_world_size: {tensor_model_parallel_world_size}")
+            parallel_state.destroy_model_parallel()
 
     def test_affine_weight_init_column_parallel_cpu(self) -> None:
         self._affine_weight_init_test_impl(init_device="cpu", is_column_parallel=True)
@@ -304,103 +301,105 @@ class TensorParallelLayerTestBase:
         ):
             if self.world_size % tensor_model_parallel_world_size:
                 continue
-            with self.subTest(
-                tensor_model_parallel_world_size=tensor_model_parallel_world_size,
-            ):
-                parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size_=tensor_model_parallel_world_size,
-                )
-                set_random_seed(self.SEED)
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size_=tensor_model_parallel_world_size,
+            )
+            set_random_seed(self.SEED)
 
-                linear = layers.RowParallelLinear(
-                    self.HIDDEN_SIZE,
-                    self.HIDDEN_SIZE,
-                    keep_master_weight_for_test=True,
-                    params_dtype=torch.float32,
-                    use_cpu_initialization=True,
-                    gradient_accumulation_fusion=gradient_accumulation_fusion,
-                    accumulation_in_fp16=accumulation_in_fp16,
-                    sequence_parallel_enabled=sequence_parallel_enabled,
-                    # n.b.(mkozuki): RowParallelLinear is constructed with `input_is_parallel=True`
-                    # by default, e.g. https://github.com/NVIDIA/NeMo/blob/782b4e1652aaa43c8be390d9\
-                    # db0dc89544afa080/nemo/collections/nlp/modules/common/megatron/transformer.py#L204
-                    input_is_parallel=True,
-                ).cuda()
-                if accumulation_in_fp16:
-                    linear = linear.half()
-                # Simulate the situation where fusion of weight grad calculation and gradient accumulation is enabled.
-                if gradient_accumulation_fusion:
-                    with torch.no_grad():
-                        linear.weight.main_grad = torch.zeros_like(linear.weight)
-
+            linear = layers.RowParallelLinear(
+                self.HIDDEN_SIZE,
+                self.HIDDEN_SIZE,
+                keep_master_weight_for_test=True,
+                params_dtype=torch.float32,
+                use_cpu_initialization=True,
+                gradient_accumulation_fusion=gradient_accumulation_fusion,
+                accumulation_in_fp16=accumulation_in_fp16,
+                sequence_parallel_enabled=sequence_parallel_enabled,
+                # n.b.(mkozuki): RowParallelLinear is constructed with `input_is_parallel=True`
+                # by default, e.g. https://github.com/NVIDIA/NeMo/blob/782b4e1652aaa43c8be390d9\
+                # db0dc89544afa080/nemo/collections/nlp/modules/common/megatron/transformer.py#L204
+                input_is_parallel=True,
+            ).cuda()
+            if accumulation_in_fp16:
+                linear = linear.half()
+            # Simulate the situation where fusion of weight grad calculation and gradient accumulation is enabled.
+            if gradient_accumulation_fusion:
                 with torch.no_grad():
-                    orig_input_tensor = torch.randn(tensor_shape, requires_grad=True, device="cuda")
-                    orig_loss_weight = torch.randn(tensor_shape, device="cuda")
-                    input_tensor = orig_input_tensor.chunk(
+                    linear.weight.main_grad = torch.zeros_like(linear.weight)
+
+            msg = f"tensor_model_parallel_world_size: {tensor_model_parallel_world_size}"
+
+            with torch.no_grad():
+                orig_input_tensor = torch.randn(tensor_shape, requires_grad=True, device="cuda")
+                orig_loss_weight = torch.randn(tensor_shape, device="cuda")
+                input_tensor = orig_input_tensor.chunk(
+                    chunks=tensor_model_parallel_world_size,
+                    dim=2,
+                )[parallel_state.get_tensor_model_parallel_rank()].contiguous()
+                if sequence_parallel_enabled:
+                    loss_weight = orig_loss_weight.chunk(
                         chunks=tensor_model_parallel_world_size,
-                        dim=2,
-                    )[parallel_state.get_tensor_model_parallel_rank()].contiguous()
-                    if sequence_parallel_enabled:
-                        loss_weight = orig_loss_weight.chunk(
-                            chunks=tensor_model_parallel_world_size,
-                            dim=0,
-                        )[parallel_state.get_tensor_model_parallel_rank()]
-                    else:
-                        loss_weight = orig_loss_weight
-                    if accumulation_in_fp16:
-                        orig_input_tensor = orig_input_tensor.half()
-                        input_tensor = input_tensor.half()
-                        loss_weight = loss_weight.half()
-                input_tensor.requires_grad_()
-                output, _ = linear(input_tensor)
-                loss = torch.mul(output, loss_weight).sum()
-                loss.backward()
-                self.assertIsNotNone(input_tensor.grad)
+                        dim=0,
+                    )[parallel_state.get_tensor_model_parallel_rank()]
+                else:
+                    loss_weight = orig_loss_weight
+                if accumulation_in_fp16:
+                    orig_input_tensor = orig_input_tensor.half()
+                    input_tensor = input_tensor.half()
+                    loss_weight = loss_weight.half()
+            input_tensor.requires_grad_()
+            output, _ = linear(input_tensor)
+            loss = torch.mul(output, loss_weight).sum()
+            loss.backward()
+            self.assertIsNotNone(input_tensor.grad, msg=msg)
 
-                ref_linear = nn.Linear(
-                    in_features=self.HIDDEN_SIZE,
-                    out_features=self.HIDDEN_SIZE,
-                    bias=False,
-                    device="cuda",
-                )
-                with torch.no_grad():
-                    dldy = orig_loss_weight.clone()
-                    x = orig_input_tensor.clone()
-                    ref_linear.weight.copy_(linear.master_weight)
-                    if accumulation_in_fp16:
-                        ref_linear = ref_linear.half()
-                x.requires_grad_()
-                expected_output = ref_linear(x)
-                expected_loss = torch.mul(expected_output, dldy).sum()
-                expected_loss.backward()
+            ref_linear = nn.Linear(
+                in_features=self.HIDDEN_SIZE,
+                out_features=self.HIDDEN_SIZE,
+                bias=False,
+                device="cuda",
+            )
+            with torch.no_grad():
+                dldy = orig_loss_weight.clone()
+                x = orig_input_tensor.clone()
+                ref_linear.weight.copy_(linear.master_weight)
+                if accumulation_in_fp16:
+                    ref_linear = ref_linear.half()
+            x.requires_grad_()
+            expected_output = ref_linear(x)
+            expected_loss = torch.mul(expected_output, dldy).sum()
+            expected_loss.backward()
 
-                if not accumulation_in_fp16:
-                    if sequence_parallel_enabled:
-                        self.assertEqual(
-                            x=output,
-                            y=expected_output.chunk(
-                                chunks=tensor_model_parallel_world_size,
-                                dim=0,
-                            )[parallel_state.get_tensor_model_parallel_rank()],
-                        )
-                    else:
-                        self.assertEqual(
-                            x=output,
-                            y=expected_output,
-                        )
-
-                grad_attr_name = "main_grad" if gradient_accumulation_fusion else "grad"
-                # NOTE(mkozuki): Numerical errors seems to be enlarged by tensor model parallel.
-                if tensor_model_parallel_world_size == 1:
+            if not accumulation_in_fp16:
+                if sequence_parallel_enabled:
                     self.assertEqual(
-                        x=getattr(linear.weight, grad_attr_name),
-                        y=ref_linear.weight.grad.chunk(
+                        x=output,
+                        y=expected_output.chunk(
                             chunks=tensor_model_parallel_world_size,
                             dim=0,
                         )[parallel_state.get_tensor_model_parallel_rank()],
+                        msg=msg,
+                    )
+                else:
+                    self.assertEqual(
+                        x=output,
+                        y=expected_output,
+                        msg=msg,
                     )
 
-                parallel_state.destroy_model_parallel()
+            grad_attr_name = "main_grad" if gradient_accumulation_fusion else "grad"
+            # NOTE(mkozuki): Numerical errors seems to be enlarged by tensor model parallel.
+            if tensor_model_parallel_world_size == 1:
+                self.assertEqual(
+                    x=getattr(linear.weight, grad_attr_name),
+                    y=ref_linear.weight.grad.chunk(
+                        chunks=tensor_model_parallel_world_size,
+                        dim=0,
+                    )[parallel_state.get_tensor_model_parallel_rank()],
+                    msg=msg,
+                )
+
+            parallel_state.destroy_model_parallel()
 
     def test_column_parallel_linear(self):
         self._column_parallel_linear_test_impl(False, False, False, False)
@@ -438,112 +437,115 @@ class TensorParallelLayerTestBase:
             if async_tensor_model_parallel_allreduce and sequence_parallel_enabled:
                 if tensor_model_parallel_world_size == 1:
                     continue
-            with self.subTest(tensor_model_parallel_world_size=tensor_model_parallel_world_size):
-                if self.world_size % tensor_model_parallel_world_size:
-                    continue
-                parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size_=tensor_model_parallel_world_size,
+            if self.world_size % tensor_model_parallel_world_size:
+                continue
+            msg = f"tensor_model_parallel_world_size: {tensor_model_parallel_world_size}"
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size_=tensor_model_parallel_world_size,
+            )
+
+            input_tensor_shape = self.tensor_shape
+            expected_output_shape = self.tensor_shape
+            # When sequence parallel, `gather_output` is disabled, i.e.,
+            # output of matmul isn't gathered in dimension of feature/hidden (last dim).
+            if sequence_parallel_enabled:
+                expected_output_shape[-1] //= tensor_model_parallel_world_size
+
+            # tensor's shape is [sequence length, batch size, hidden size]
+            set_random_seed(self.SEED)
+            linear = layers.ColumnParallelLinear(
+                self.HIDDEN_SIZE,
+                self.HIDDEN_SIZE,
+                bias=False,
+                keep_master_weight_for_test=True,
+                params_dtype=torch.float32,
+                use_cpu_initialization=True,
+                gather_output=not sequence_parallel_enabled,
+                no_async_tensor_model_parallel_allreduce=not async_tensor_model_parallel_allreduce,
+                gradient_accumulation_fusion=gradient_accumulation_fusion,
+                accumulation_in_fp16=accumulation_in_fp16,
+                sequence_parallel_enabled=sequence_parallel_enabled,
+            ).cuda()
+            if accumulation_in_fp16:
+                linear = linear.half()
+
+            # Simulate the situation where fusion of weight grad calculation and gradient accumulation happens.
+            if gradient_accumulation_fusion:
+                with torch.no_grad():
+                    linear.weight.main_grad = torch.zeros_like(linear.weight)
+
+            orig_input_tensor = torch.randn(input_tensor_shape, device="cuda", requires_grad=True)
+            if accumulation_in_fp16:
+                orig_input_tensor = orig_input_tensor.half()
+            if sequence_parallel_enabled:
+                input_tensor = list(
+                    orig_input_tensor.chunk(tensor_model_parallel_world_size, dim=0)
+                )[parallel_state.get_tensor_model_parallel_rank()]
+            else:
+                input_tensor = orig_input_tensor
+            output, _ = linear(input_tensor)
+            # The order of dimension is expected to be (sequence, batch, hidden)
+            self.assertEqual(output.shape, expected_output_shape, msg=msg)
+
+            orig_loss_weight = torch.randn(input_tensor_shape, device="cuda")
+            if accumulation_in_fp16:
+                orig_loss_weight = orig_loss_weight.half()
+            if sequence_parallel_enabled:
+                loss_weight = orig_loss_weight.chunk(
+                    tensor_model_parallel_world_size, dim=2,
+                )[parallel_state.get_tensor_model_parallel_rank()]
+            else:
+                loss_weight = orig_loss_weight
+            loss = torch.mul(output, loss_weight).sum()
+            loss.backward()
+
+            with torch.no_grad():
+                dldy = orig_loss_weight.clone()
+                x = orig_input_tensor.clone()
+                ref_linear = nn.Linear(
+                    in_features=self.HIDDEN_SIZE,
+                    out_features=self.HIDDEN_SIZE,
+                    bias=False,
+                    device="cuda",
+                )
+                if accumulation_in_fp16:
+                    ref_linear = ref_linear.half()
+                # NOTE(mkozuki): `master_weight` is available because `keep_master_weight_for_test` is set.
+                ref_linear.weight.copy_(linear.master_weight)
+            x.requires_grad_()
+            expected_output = ref_linear(x)
+            if sequence_parallel_enabled:
+                chunk = expected_output.chunk(
+                    tensor_model_parallel_world_size,
+                    dim=2,
+                )[parallel_state.get_tensor_model_parallel_rank()]
+                self.assertEqual(
+                    x=output,
+                    y=chunk,
+                    msg=msg,
+                )
+            else:
+                self.assertEqual(
+                    x=output,
+                    y=expected_output,
+                    msg=msg,
                 )
 
-                input_tensor_shape = self.tensor_shape
-                expected_output_shape = self.tensor_shape
-                # When sequence parallel, `gather_output` is disabled, i.e.,
-                # output of matmul isn't gathered in dimension of feature/hidden (last dim).
-                if sequence_parallel_enabled:
-                    expected_output_shape[-1] //= tensor_model_parallel_world_size
+            expected_loss = torch.mul(expected_output, dldy).sum()
+            expected_loss.backward()
+            grad_attr_name = "main_grad" if gradient_accumulation_fusion else "grad"
+            # NOTE(mkozuki): Numerical errors seems to be enlarged by tensor model parallel.
+            if tensor_model_parallel_world_size == 1:
+                self.assertEqual(
+                    x=getattr(linear.weight, grad_attr_name),
+                    y=ref_linear.weight.grad.chunk(
+                        chunks=tensor_model_parallel_world_size,
+                        dim=0,
+                    )[parallel_state.get_tensor_model_parallel_rank()],
+                    msg=msg,
+                )
 
-                # tensor's shape is [sequence length, batch size, hidden size]
-                set_random_seed(self.SEED)
-                linear = layers.ColumnParallelLinear(
-                    self.HIDDEN_SIZE,
-                    self.HIDDEN_SIZE,
-                    bias=False,
-                    keep_master_weight_for_test=True,
-                    params_dtype=torch.float32,
-                    use_cpu_initialization=True,
-                    gather_output=not sequence_parallel_enabled,
-                    no_async_tensor_model_parallel_allreduce=not async_tensor_model_parallel_allreduce,
-                    gradient_accumulation_fusion=gradient_accumulation_fusion,
-                    accumulation_in_fp16=accumulation_in_fp16,
-                    sequence_parallel_enabled=sequence_parallel_enabled,
-                ).cuda()
-                if accumulation_in_fp16:
-                    linear = linear.half()
-
-                # Simulate the situation where fusion of weight grad calculation and gradient accumulation happens.
-                if gradient_accumulation_fusion:
-                    with torch.no_grad():
-                        linear.weight.main_grad = torch.zeros_like(linear.weight)
-
-                orig_input_tensor = torch.randn(input_tensor_shape, device="cuda", requires_grad=True)
-                if accumulation_in_fp16:
-                    orig_input_tensor = orig_input_tensor.half()
-                if sequence_parallel_enabled:
-                    input_tensor = list(
-                        orig_input_tensor.chunk(tensor_model_parallel_world_size, dim=0)
-                    )[parallel_state.get_tensor_model_parallel_rank()]
-                else:
-                    input_tensor = orig_input_tensor
-                output, _ = linear(input_tensor)
-                # The order of dimension is expected to be (sequence, batch, hidden)
-                self.assertEqual(output.shape, expected_output_shape)
-
-                orig_loss_weight = torch.randn(input_tensor_shape, device="cuda")
-                if accumulation_in_fp16:
-                    orig_loss_weight = orig_loss_weight.half()
-                if sequence_parallel_enabled:
-                    loss_weight = orig_loss_weight.chunk(
-                        tensor_model_parallel_world_size, dim=2,
-                    )[parallel_state.get_tensor_model_parallel_rank()]
-                else:
-                    loss_weight = orig_loss_weight
-                loss = torch.mul(output, loss_weight).sum()
-                loss.backward()
-
-                with torch.no_grad():
-                    dldy = orig_loss_weight.clone()
-                    x = orig_input_tensor.clone()
-                    ref_linear = nn.Linear(
-                        in_features=self.HIDDEN_SIZE,
-                        out_features=self.HIDDEN_SIZE,
-                        bias=False,
-                        device="cuda",
-                    )
-                    if accumulation_in_fp16:
-                        ref_linear = ref_linear.half()
-                    # NOTE(mkozuki): `master_weight` is available because `keep_master_weight_for_test` is set.
-                    ref_linear.weight.copy_(linear.master_weight)
-                x.requires_grad_()
-                expected_output = ref_linear(x)
-                if sequence_parallel_enabled:
-                    chunk = expected_output.chunk(
-                        tensor_model_parallel_world_size,
-                        dim=2,
-                    )[parallel_state.get_tensor_model_parallel_rank()]
-                    self.assertEqual(
-                        x=output,
-                        y=chunk,
-                    )
-                else:
-                    self.assertEqual(
-                        x=output,
-                        y=expected_output,
-                    )
-
-                expected_loss = torch.mul(expected_output, dldy).sum()
-                expected_loss.backward()
-                grad_attr_name = "main_grad" if gradient_accumulation_fusion else "grad"
-                # NOTE(mkozuki): Numerical errors seems to be enlarged by tensor model parallel.
-                if tensor_model_parallel_world_size == 1:
-                    self.assertEqual(
-                        x=getattr(linear.weight, grad_attr_name),
-                        y=ref_linear.weight.grad.chunk(
-                            chunks=tensor_model_parallel_world_size,
-                            dim=0,
-                        )[parallel_state.get_tensor_model_parallel_rank()],
-                    )
-
-                parallel_state.destroy_model_parallel()
+            parallel_state.destroy_model_parallel()
 
 
 class NcclTensorParallelLayerTest(TensorParallelLayerTestBase, NcclDistributedTestBase):

--- a/tests/L0/run_transformer/test_layers.py
+++ b/tests/L0/run_transformer/test_layers.py
@@ -196,7 +196,7 @@ class TensorParallelLayerTestBase:
                 0,
             )[parallel_state.get_tensor_model_parallel_rank()]
             self.assertEqual(
-                splitted_weight_torch, embedding_vocab_parallel.weight.gra, msg=msgd,
+                splitted_weight_torch, embedding_vocab_parallel.weight.grad, msg=msg,
             )
 
             parallel_state.destroy_model_parallel()

--- a/tests/L0/run_transformer/test_mapping.py
+++ b/tests/L0/run_transformer/test_mapping.py
@@ -18,67 +18,65 @@ class MappingTestBase:
         for tensor_model_paralell_world_size in range(1, self.world_size + 1):
             if self.world_size % tensor_model_paralell_world_size > 0:
                 continue
-            with self.subTest(
-                tensor_model_paralell_world_size=tensor_model_paralell_world_size
-            ):
-                parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size_=tensor_model_paralell_world_size
-                )
-                t = torch.full((10, 10, 10, 10), 50, device=f"cuda:{self.rank}")
-                expected = torch.full(
-                    (10, 10, 10, 10),
-                    50 * tensor_model_paralell_world_size,
-                    device=f"cuda:{self.rank}",
-                )
-                self.assertTrue(torch.equal(mappings._reduce(t), expected))
-                parallel_state.destroy_model_parallel()
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size_=tensor_model_paralell_world_size
+            )
+            t = torch.full((10, 10, 10, 10), 50, device=f"cuda:{self.rank}")
+            expected = torch.full(
+                (10, 10, 10, 10),
+                50 * tensor_model_paralell_world_size,
+                device=f"cuda:{self.rank}",
+            )
+            self.assertTrue(
+                torch.equal(mappings._reduce(t), expected),
+                msg=f"tensor_model_paralell_world_size: {tensor_model_paralell_world_size}",
+            )
+            parallel_state.destroy_model_parallel()
 
     def test_split(self):
         for tensor_model_paralell_world_size in range(1, self.world_size + 1):
             if self.world_size % tensor_model_paralell_world_size > 0:
                 continue
-            with self.subTest(
-                tensor_model_paralell_world_size=tensor_model_paralell_world_size
-            ):
-                parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size_=tensor_model_paralell_world_size
-                )
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size_=tensor_model_paralell_world_size
+            )
 
-                tensors = [
-                    torch.randn(10, 1)
-                    for rank in range(tensor_model_paralell_world_size)
-                ]
-                x = torch.cat(tensors, 1)
-                out = mappings._split_along_last_dim(x)
-                self.assertTrue(
-                    torch.equal(
-                        out, tensors[parallel_state.get_tensor_model_parallel_rank()]
-                    )
-                )
-                parallel_state.destroy_model_parallel()
+            tensors = [
+                torch.randn(10, 1)
+                for _ in range(tensor_model_paralell_world_size)
+            ]
+            x = torch.cat(tensors, 1)
+            out = mappings._split_along_last_dim(x)
+            self.assertTrue(
+                torch.equal(
+                    out, tensors[parallel_state.get_tensor_model_parallel_rank()]
+                ),
+                msg=f"tensor_model_paralell_world_size: {tensor_model_paralell_world_size}"
+            )
+            parallel_state.destroy_model_parallel()
 
     def test_gather(self):
         for tensor_model_paralell_world_size in range(1, self.world_size + 1):
             if self.world_size % tensor_model_paralell_world_size > 0:
                 continue
-            with self.subTest(
-                tensor_model_paralell_world_size=tensor_model_paralell_world_size
-            ):
-                parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size_=tensor_model_paralell_world_size
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size_=tensor_model_paralell_world_size
+            )
+            device = f"cuda:{self.rank}"
+            gathered = mappings._gather_along_last_dim(
+                torch.tensor(
+                    [parallel_state.get_tensor_model_parallel_rank()], device=device
                 )
-                device = f"cuda:{self.rank}"
-                gathered = mappings._gather_along_last_dim(
-                    torch.tensor(
-                        [parallel_state.get_tensor_model_parallel_rank()], device=device
-                    )
-                )
-                expected = torch.tensor(
-                    [rank for rank in range(tensor_model_paralell_world_size)],
-                    device=device,
-                )
-                self.assertTrue(torch.equal(gathered, expected))
-                parallel_state.destroy_model_parallel()
+            )
+            expected = torch.tensor(
+                [rank for rank in range(tensor_model_paralell_world_size)],
+                device=device,
+            )
+            self.assertTrue(
+                torch.equal(gathered, expected),
+                msg=f"tensor_model_paralell_world_size: {tensor_model_paralell_world_size}",
+            )
+            parallel_state.destroy_model_parallel()
 
 
 class NcclMappingTest(MappingTestBase, NcclDistributedTestBase): pass

--- a/tests/L0/run_transformer/test_parallel_state.py
+++ b/tests/L0/run_transformer/test_parallel_state.py
@@ -28,42 +28,43 @@ class ParallelStateTestBase:
         self.assertFalse(parallel_state.model_parallel_is_initialized())
 
         for tensor_model_parallel_world_size in range(1, self.world_size + 1):
-            with self.subTest(
-                tensor_model_parallel_world_size=tensor_model_parallel_world_size
-            ):
-                if self.world_size % tensor_model_parallel_world_size:
-                    continue
+            msg = f"tensor_model_parallel_world_siz: {tensor_model_parallel_world_size}"
+            if self.world_size % tensor_model_parallel_world_size:
+                continue
 
-                pipeline_model_parallel_world_size = (
-                    self.world_size // tensor_model_parallel_world_size
-                )
+            pipeline_model_parallel_world_size = (
+                self.world_size // tensor_model_parallel_world_size
+            )
 
-                parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size_=tensor_model_parallel_world_size,
-                    pipeline_model_parallel_size_=pipeline_model_parallel_world_size,
-                )
-                self.assertEqual(
-                    tensor_model_parallel_world_size,
-                    parallel_state.get_tensor_model_parallel_world_size(),
-                )
-                expected_tensor_model_parallel_rank = calc_expected_tensor_model_paralell_rank(
-                    self.rank, tensor_model_parallel_world_size
-                )
-                self.assertEqual(
-                    expected_tensor_model_parallel_rank,
-                    parallel_state.get_tensor_model_parallel_rank(),
-                )
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size_=tensor_model_parallel_world_size,
+                pipeline_model_parallel_size_=pipeline_model_parallel_world_size,
+            )
+            self.assertEqual(
+                tensor_model_parallel_world_size,
+                parallel_state.get_tensor_model_parallel_world_size(),
+                msg=msg,
+            )
+            expected_tensor_model_parallel_rank = calc_expected_tensor_model_paralell_rank(
+                self.rank, tensor_model_parallel_world_size
+            )
+            self.assertEqual(
+                expected_tensor_model_parallel_rank,
+                parallel_state.get_tensor_model_parallel_rank(),
+                msg=msg,
+            )
 
-                expected_tensor_model_parallel_src_rank = (
-                    self.rank // tensor_model_parallel_world_size
-                ) * tensor_model_parallel_world_size
-                self.assertEqual(
-                    expected_tensor_model_parallel_src_rank,
-                    parallel_state.get_tensor_model_parallel_src_rank(),
-                )
+            expected_tensor_model_parallel_src_rank = (
+                self.rank // tensor_model_parallel_world_size
+            ) * tensor_model_parallel_world_size
+            self.assertEqual(
+                expected_tensor_model_parallel_src_rank,
+                parallel_state.get_tensor_model_parallel_src_rank(),
+                msg=msg,
+            )
 
-                parallel_state.destroy_model_parallel()
-                self.assertFalse(parallel_state.model_parallel_is_initialized())
+            parallel_state.destroy_model_parallel()
+            self.assertFalse(parallel_state.model_parallel_is_initialized(), msg=msg)
 
     def test_initialize_model_parallel_with_virtual_and_split(self) -> None:
         if self.world_size < 4:
@@ -138,43 +139,44 @@ class ParallelStateTestBase:
         self.assertFalse(parallel_state.model_parallel_is_initialized())
 
         for tensor_model_parallel_world_size in range(1, self.world_size + 1):
-            with self.subTest(
-                tensor_model_parallel_world_size=tensor_model_parallel_world_size
-            ):
-                if self.world_size % tensor_model_parallel_world_size:
-                    continue
+            msg = f"tensor_model_parallel_world_size: {tensor_model_parallel_world_size}"
+            if self.world_size % tensor_model_parallel_world_size:
+                continue
 
-                pipeline_model_parallel_world_size = (
-                    self.world_size // tensor_model_parallel_world_size
-                )
+            pipeline_model_parallel_world_size = (
+                self.world_size // tensor_model_parallel_world_size
+            )
 
-                parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size_=tensor_model_parallel_world_size,
-                    pipeline_model_parallel_size_=pipeline_model_parallel_world_size,
-                    pipeline_model_parallel_split_rank_=0,
-                )
-                self.assertEqual(
-                    tensor_model_parallel_world_size,
-                    parallel_state.get_tensor_model_parallel_world_size(),
-                )
-                expected_tensor_model_parallel_rank = calc_expected_tensor_model_paralell_rank(
-                    self.rank, tensor_model_parallel_world_size
-                )
-                self.assertEqual(
-                    expected_tensor_model_parallel_rank,
-                    parallel_state.get_tensor_model_parallel_rank(),
-                )
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size_=tensor_model_parallel_world_size,
+                pipeline_model_parallel_size_=pipeline_model_parallel_world_size,
+                pipeline_model_parallel_split_rank_=0,
+            )
+            self.assertEqual(
+                tensor_model_parallel_world_size,
+                parallel_state.get_tensor_model_parallel_world_size(),
+                msg=msg,
+            )
+            expected_tensor_model_parallel_rank = calc_expected_tensor_model_paralell_rank(
+                self.rank, tensor_model_parallel_world_size
+            )
+            self.assertEqual(
+                expected_tensor_model_parallel_rank,
+                parallel_state.get_tensor_model_parallel_rank(),
+                msg=msg,
+            )
 
-                expected_tensor_model_parallel_src_rank = (
-                    self.rank // tensor_model_parallel_world_size
-                ) * tensor_model_parallel_world_size
-                self.assertEqual(
-                    expected_tensor_model_parallel_src_rank,
-                    parallel_state.get_tensor_model_parallel_src_rank(),
-                )
+            expected_tensor_model_parallel_src_rank = (
+                self.rank // tensor_model_parallel_world_size
+            ) * tensor_model_parallel_world_size
+            self.assertEqual(
+                expected_tensor_model_parallel_src_rank,
+                parallel_state.get_tensor_model_parallel_src_rank(),
+                msg=msg,
+            )
 
-                parallel_state.destroy_model_parallel()
-                self.assertFalse(parallel_state.model_parallel_is_initialized())
+            parallel_state.destroy_model_parallel()
+            self.assertFalse(parallel_state.model_parallel_is_initialized(), msg=msg)
 
 
 class NcclParallelStateTest(ParallelStateTestBase, NcclDistributedTestBase): pass

--- a/tests/L0/run_transformer/test_random.py
+++ b/tests/L0/run_transformer/test_random.py
@@ -18,98 +18,95 @@ class TransformerRandomTestBase:
         for tensor_model_parallel_world_size in range(1, self.world_size + 1):
             if self.world_size % tensor_model_parallel_world_size:
                 continue
-            with self.subTest(
-                tensor_model_parallel_world_size=tensor_model_parallel_world_size
-            ):
-                parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size_=tensor_model_parallel_world_size
-                )
+            msg = f"tensor_model_parallel_world_size: {tensor_model_parallel_world_size}"
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size_=tensor_model_parallel_world_size
+            )
 
-                size, seed = 123, 1234
-                torch.cuda.manual_seed(seed)
-                tensor = torch.cuda.FloatTensor(size)
+            size, seed = 123, 1234
+            torch.cuda.manual_seed(seed)
+            tensor = torch.cuda.FloatTensor(size)
 
-                rng_state = torch.cuda.get_rng_state()
-                rng_state_clone = rng_state.clone()
+            rng_state = torch.cuda.get_rng_state()
+            rng_state_clone = rng_state.clone()
 
-                for _ in range(5):
-                    torch.randn(size, out=tensor)
-                result_1 = tensor.clone()
+            for _ in range(5):
+                torch.randn(size, out=tensor)
+            result_1 = tensor.clone()
 
-                self.assertEqual(rng_state.sub(rng_state_clone).max(), 0)
-                self.assertGreater(
-                    torch.cuda.get_rng_state().sub(rng_state_clone).max(), 0
-                )
+            self.assertEqual(rng_state.sub(rng_state_clone).max(), 0, msg=msg)
+            self.assertGreater(
+                torch.cuda.get_rng_state().sub(rng_state_clone).max(), 0
+                msg=msg,
+            )
 
-                new_rng_state = torch.cuda.get_rng_state()
-                self.assertGreater(new_rng_state.sub(rng_state).max(), 0)
+            new_rng_state = torch.cuda.get_rng_state()
+            self.assertGreater(new_rng_state.sub(rng_state).max(), 0, msg=msg)
 
-                tensor_parallel.random._set_cuda_rng_state(rng_state)
-                for _ in range(5):
-                    torch.randn(size, out=tensor)
-                tensor_parallel.random._set_cuda_rng_state(rng_state)
-                for _ in range(5):
-                    torch.randn(size, out=tensor)
-                result_2 = tensor.clone()
+            tensor_parallel.random._set_cuda_rng_state(rng_state)
+            for _ in range(5):
+                torch.randn(size, out=tensor)
+            tensor_parallel.random._set_cuda_rng_state(rng_state)
+            for _ in range(5):
+                torch.randn(size, out=tensor)
+            result_2 = tensor.clone()
 
-                self.assertEqual(result_2, result_1)
+            self.assertEqual(result_2, result_1, msg=msg)
 
-                self.assertEqual(rng_state.sub(rng_state_clone).max(), 0)
+            self.assertEqual(rng_state.sub(rng_state_clone).max(), 0, msg=msg)
 
-                parallel_state.destroy_model_parallel()
+            parallel_state.destroy_model_parallel()
 
     def test_cuda_rng_tracker(self):
         for tensor_model_parallel_world_size in range(1, self.world_size + 1):
             if self.world_size % tensor_model_parallel_world_size:
                 continue
-            with self.subTest(
-                tensor_model_parallel_world_size=tensor_model_parallel_world_size
-            ):
-                parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size_=tensor_model_parallel_world_size
-                )
+            msg = f"tensor_model_parallel_world_size: {tensor_model_parallel_world_size}"
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size_=tensor_model_parallel_world_size
+            )
 
-                seed_1, seed_2, size = 1234, 4321, [12, 21]
-                tensor = torch.cuda.FloatTensor(size)
+            seed_1, seed_2, size = 1234, 4321, [12, 21]
+            tensor = torch.cuda.FloatTensor(size)
 
-                torch.cuda.manual_seed(seed_1)
+            torch.cuda.manual_seed(seed_1)
+            torch.randn(size, out=tensor)
+            target_11 = tensor.clone()
+            torch.randn(size, out=tensor)
+            target_12 = tensor.clone()
+
+            torch.cuda.manual_seed(seed_2)
+            torch.randn(size, out=tensor)
+            targt_21 = tensor.clone()
+            torch.randn(size, out=tensor)
+            target_22 = tensor.clone()
+
+            torch.cuda.manual_seed(seed_1)
+            tensor_parallel.random.get_cuda_rng_tracker().add("test", seed_2)
+
+            torch.randn(size, out=tensor)
+            result_11 = tensor.clone()
+
+            with tensor_parallel.random.get_cuda_rng_tracker().fork("test"):
                 torch.randn(size, out=tensor)
-                target_11 = tensor.clone()
+                result_21 = tensor.clone()
+
+            torch.randn(size, out=tensor)
+            result_12 = tensor.clone()
+
+            with tensor_parallel.random.get_cuda_rng_tracker().fork("test"):
                 torch.randn(size, out=tensor)
-                target_12 = tensor.clone()
+                result_22 = tensor.clone()
 
-                torch.cuda.manual_seed(seed_2)
-                torch.randn(size, out=tensor)
-                targt_21 = tensor.clone()
-                torch.randn(size, out=tensor)
-                target_22 = tensor.clone()
+            self.assertEqual(target_11, result_11, msg=msg)
+            self.assertEqual(target_12, result_12, msg=msg)
+            self.assertEqual(targt_21, result_21, msg=msg)
+            self.assertEqual(target_22, result_22, msg=msg)
+            self.assertNotEqual(result_11, result_21, msg=msg)
+            self.assertNotEqual(result_21, result_22, msg=msg)
 
-                torch.cuda.manual_seed(seed_1)
-                tensor_parallel.random.get_cuda_rng_tracker().add("test", seed_2)
-
-                torch.randn(size, out=tensor)
-                result_11 = tensor.clone()
-
-                with tensor_parallel.random.get_cuda_rng_tracker().fork("test"):
-                    torch.randn(size, out=tensor)
-                    result_21 = tensor.clone()
-
-                torch.randn(size, out=tensor)
-                result_12 = tensor.clone()
-
-                with tensor_parallel.random.get_cuda_rng_tracker().fork("test"):
-                    torch.randn(size, out=tensor)
-                    result_22 = tensor.clone()
-
-                self.assertEqual(target_11, result_11)
-                self.assertEqual(target_12, result_12)
-                self.assertEqual(targt_21, result_21)
-                self.assertEqual(target_22, result_22)
-                self.assertNotEqual(result_11, result_21)
-                self.assertNotEqual(result_21, result_22)
-
-                tensor_parallel.random.get_cuda_rng_tracker().reset()
-                parallel_state.destroy_model_parallel()
+            tensor_parallel.random.get_cuda_rng_tracker().reset()
+            parallel_state.destroy_model_parallel()
 
 
 class NcclTransformerRandomTest(TransformerRandomTestBase, NcclDistributedTestBase): pass

--- a/tests/L0/run_transformer/test_random.py
+++ b/tests/L0/run_transformer/test_random.py
@@ -36,7 +36,7 @@ class TransformerRandomTestBase:
 
             self.assertEqual(rng_state.sub(rng_state_clone).max(), 0, msg=msg)
             self.assertGreater(
-                torch.cuda.get_rng_state().sub(rng_state_clone).max(), 0
+                torch.cuda.get_rng_state().sub(rng_state_clone).max(), 0,
                 msg=msg,
             )
 

--- a/tests/L0/run_transformer/test_transformer_module.py
+++ b/tests/L0/run_transformer/test_transformer_module.py
@@ -31,76 +31,65 @@ def get_launch_option(test_filename) -> Tuple[bool, str]:
     return should_skip, ""
 
 
-def run_transformer_tests():
+def get_test_command(test_file: str) -> str:
+    python_executable_path = sys.executable
+    is_denied = False
+    should_skip, launch_option = get_launch_option(test_file)
+    if should_skip:
+        print(
+            f"### {i} / {len(files)}: {test_file} skipped. Requires multiple GPUs."
+        )
+        return ""
+    test_run_cmd = (
+        f"{python_executable_path} {launch_option} {test_file} "
+        "--micro-batch-size 2 --num-layers 16 --hidden-size 256 --num-attention-heads 8 --max-position-embeddings "
+        "512 --seq-length 512 --global-batch-size 128"
+    )
+    if "bert" in test_file or "gpt" in test_file:
+        import torch
+
+        num_devices = torch.cuda.device_count()
+        if "bert" in test_file:
+            # "bert" uses the interleaving.
+            tensor_model_parallel_size = 2 if num_devices % 2 == 0 and num_devices > 4 else 1
+        if "gpt" in test_file:
+            # "gpt" uses the non-interleaving.
+            tensor_model_parallel_size = 2 if num_devices % 2 == 0 and num_devices >= 4 else 1
+        pipeline_model_parallel_size = num_devices // tensor_model_parallel_size
+        test_run_cmd += f" --pipeline-model-parallel-size {pipeline_model_parallel_size} --tensor-model-parallel-size {tensor_model_parallel_size}"
+
+        if "bert" in test_file:
+            test_run_cmd += f" --bert-no-binary-head"
+    else:
+        test_run_cmd += f" --use-cpu-initialization"
+    return test_run_cmd
+
+
+def _get_test_file(key):
     python_executable_path = sys.executable
     directory = os.path.dirname(__file__)
-    files = [
+    test_file = [
         os.path.join(directory, f)
         for f in os.listdir(directory)
-        if f.startswith("run_") and os.path.isfile(os.path.join(directory, f))
-    ]
-    print("#######################################################")
-    print(f"# Python executable path: {python_executable_path}")
-    print(f"# {len(files)} tests: {files}")
-    print("#######################################################")
-    errors = []
-    for i, test_file in enumerate(files, 1):
-        is_denied = False
-        should_skip, launch_option = get_launch_option(test_file)
-        if should_skip:
-            print(
-                f"### {i} / {len(files)}: {test_file} skipped. Requires multiple GPUs."
-            )
-            continue
-        test_run_cmd = (
-            f"{python_executable_path} {launch_option} {test_file} "
-            "--micro-batch-size 2 --num-layers 16 --hidden-size 256 --num-attention-heads 8 --max-position-embeddings "
-            "512 --seq-length 512 --global-batch-size 128"
-        )
-        if "bert" in test_file or "gpt" in test_file:
-            import torch
-
-            num_devices = torch.cuda.device_count()
-            if "bert" in test_file:
-                # "bert" uses the interleaving.
-                tensor_model_parallel_size = 2 if num_devices % 2 == 0 and num_devices > 4 else 1
-            if "gpt" in test_file:
-                # "gpt" uses the non-interleaving.
-                tensor_model_parallel_size = 2 if num_devices % 2 == 0 and num_devices >= 4 else 1
-            pipeline_model_parallel_size = num_devices // tensor_model_parallel_size
-            test_run_cmd += f" --pipeline-model-parallel-size {pipeline_model_parallel_size} --tensor-model-parallel-size {tensor_model_parallel_size}"
-
-            if "bert" in test_file:
-                test_run_cmd += f" --bert-no-binary-head"
-        else:
-            test_run_cmd += f" --use-cpu-initialization"
-        print(f"### {i} / {len(files)}: cmd: {test_run_cmd}")
-        try:
-            output = (
-                subprocess.check_output(test_run_cmd, shell=True)
-                .decode(sys.stdout.encoding)
-                .strip()
-            )
-        except Exception as e:
-            errors.append((test_file, str(e)))
-        else:
-            if ">> passed the test :-)" not in output:
-                errors.append((test_file, output))
-    else:
-        if not errors:
-            print("### PASSED")
-        else:
-            print("### FAILED")
-            short_msg = f"{len(errors)} out of {len(files)} tests failed"
-            print(short_msg)
-            for (filename, log) in errors:
-                print(f"File: {filename}\nLog: {log}")
-            raise RuntimeError(short_msg)
+        if f.startswith("run_") and os.path.isfile(os.path.join(directory, f)) and key in f
+    ][0]
+    return test_file
 
 
 class TestTransformer(unittest.TestCase):
-    def test_transformer(self):
-        run_transformer_tests()
+    def _test_impl(self, key: str):
+        test_file = _get_test_file(key)
+        command = get_test_command(test_file)
+        if command:
+            subprocess.run(command, shell=True, check=True)
+        else:
+            self.skipTest("Appropriate command is not generated")
+
+    def test_standalone_bert(self):
+        self._test_impl("bert")
+
+    def test_standalone_gpt(self):
+        self._test_impl("gpt")
 
 
 if __name__ == "__main__":

--- a/tests/L0/run_transformer/test_transformer_module.py
+++ b/tests/L0/run_transformer/test_transformer_module.py
@@ -91,6 +91,9 @@ class TestTransformer(unittest.TestCase):
     def test_standalone_gpt(self):
         self._test_impl("gpt")
 
+    def test_dynamic_batch_size(self):
+        self._test_impl("dynamic_batchsize")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/L0/run_transformer/test_transformer_module.py
+++ b/tests/L0/run_transformer/test_transformer_module.py
@@ -36,9 +36,6 @@ def get_test_command(test_file: str) -> str:
     is_denied = False
     should_skip, launch_option = get_launch_option(test_file)
     if should_skip:
-        print(
-            f"### {i} / {len(files)}: {test_file} skipped. Requires multiple GPUs."
-        )
         return ""
     test_run_cmd = (
         f"{python_executable_path} {launch_option} {test_file} "

--- a/tests/L0/run_transformer/test_transformer_utils.py
+++ b/tests/L0/run_transformer/test_transformer_utils.py
@@ -17,23 +17,23 @@ class TransformerUtilsTest(NcclDistributedTestBase):
         for tensor_model_paralell_world_size in range(1, self.world_size + 1):
             if self.world_size % tensor_model_paralell_world_size > 0:
                 continue
-            with self.subTest(
-                tensor_model_paralell_world_size=tensor_model_paralell_world_size
-            ):
-                parallel_state.initialize_model_parallel(
-                    tensor_model_parallel_size_=tensor_model_paralell_world_size
-                )
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size_=tensor_model_paralell_world_size
+            )
 
-                device = "cpu"
-                input_tensor = torch.randn((100, 100, 100), device=device)
-                splits = utils.split_tensor_along_last_dim(input_tensor, 10)
-                last_dim_shapes = torch.tensor(
-                    [int(split.size()[-1]) for split in splits]
-                )
+            device = "cpu"
+            input_tensor = torch.randn((100, 100, 100), device=device)
+            splits = utils.split_tensor_along_last_dim(input_tensor, 10)
+            last_dim_shapes = torch.tensor(
+                [int(split.size()[-1]) for split in splits]
+            )
 
-                self.assertTrue(torch.equal(last_dim_shapes, torch.full((10,), 10),))
+            self.assertTrue(
+                torch.equal(last_dim_shapes, torch.full((10,), 10),),
+                msg=f"tensor_model_paralell_world_size: {tensor_model_paralell_world_size}",
+            )
 
-                parallel_state.destroy_model_parallel()
+            parallel_state.destroy_model_parallel()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Goal
Export junit xml style report only when ~~`xmlrunner` is available and the environment variable of `CI=1`~~ `--xml-report` is passed to `python tests/L0/run_test.py`.

TODO:
- [x] Remove `subTest` because it's not compatible with the current way
of running L0 tests. See the example trace below

```console
======================================================================
Traceback (most recent call last):
  File "/home/mkozuki/ghq/github.com/crcrpar/apex/tests/L0/run_test.py", line 91, in <module>
    main(args)
  File "/home/mkozuki/ghq/github.com/crcrpar/apex/tests/L0/run_test.py", line 78, in main
    result = runner.run(suite)
  File "/home/mkozuki/miniconda3/envs/torchdev/lib/python3.9/site-packages/xmlrunner/xmlrunner.py", line 421, in run
    result.printErrors()
  File "/home/mkozuki/miniconda3/envs/torchdev/lib/python3.9/unittest/runner.py", line 117, in printErrors
    self.printErrorList('FAIL', self.failures)
  File "/home/mkozuki/miniconda3/envs/torchdev/lib/python3.9/site-packages/xmlrunner/xmlrunner.py", line 217, in printErrorList
    '%s [%.3fs]: %s' % (flavour, test_info.elapsed_time,
AttributeError: '_SubTest' object has no attribute 'elapsed_time'
```

Follow-up
- [ ] Use `torch.testing._internal.common_utils.parametrize` and `torch.testing._internal.common_device_type.instantiate_device_type_tests(TestFooBar, globals(), only_for=("cuda",))` for the readability of log

cc @xwang233