### PR TITLE
Optimize distributed Adam kernels and implementation

### DIFF
--- a/apex/contrib/csrc/optimizers/multi_tensor_distopt_adam.cpp
+++ b/apex/contrib/csrc/optimizers/multi_tensor_distopt_adam.cpp
@@ -4,17 +4,37 @@ void multi_tensor_fused_adam_cuda(
   int chunk_size,
   at::Tensor noop_flag,
   std::vector<std::vector<at::Tensor>> tensor_lists,
-  at::Tensor per_tensor_beta1,
-  at::Tensor per_tensor_beta2,
-  at::Tensor per_tensor_bias_correction,
-  at::Tensor per_tensor_eps,
-  at::Tensor per_tensor_weight_decay,
+  at::Tensor grad_scale,
   float lr,
-  float grad_scale,
+  float beta1,
+  float beta2,
+  float eps,
   int step,
-  int mode);
+  int mode,
+  int bias_correction,
+  float weight_decay);
+
+void multi_tensor_fused_adam_with_param_remainders_cuda(
+  int chunk_size,
+  at::Tensor noop_flag,
+  std::vector<std::vector<at::Tensor>> tensor_lists,
+  at::Tensor grad_scale,
+  float lr,
+  float beta1,
+  float beta2,
+  float eps,
+  int step,
+  int mode,
+  int bias_correction,
+  float weight_decay);
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-  m.def("multi_tensor_fused_adam", &multi_tensor_fused_adam_cuda,
-        "Multi tensor Adam optimized CUDA implementation.");
+  m.def("multi_tensor_fused_adam",
+        &multi_tensor_fused_adam_cuda,
+        "CUDA kernels for multi-tensor Adam, "
+        "with param copy");
+  m.def("multi_tensor_fused_adam_with_param_remainders",
+        &multi_tensor_fused_adam_with_param_remainders_cuda,
+        "CUDA kernel for multi-tensor Adam, "
+        "with stored param remainders and param copy");
 }

--- a/apex/contrib/csrc/optimizers/multi_tensor_distopt_adam_kernel.cu
+++ b/apex/contrib/csrc/optimizers/multi_tensor_distopt_adam_kernel.cu
@@ -14,151 +14,305 @@
 #define ILP 4
 
 template<typename T>
-__device__ __forceinline__ bool is_aligned(T* p){
+__device__ __forceinline__ bool is_aligned(const T* p){
   return ((uint64_t)p) % (ILP*sizeof(T)) == 0;
 }
 
 template<typename T>
-__device__ __forceinline__ void load_store(T* dst, T* src, int dst_offset, int src_offset){
+__device__ __forceinline__ void load_store(
+  T* dst,
+  const T* src,
+  int dst_offset = 0,
+  int src_offset = 0){
   typedef typename std::aligned_storage<ILP*sizeof(T), ILP*alignof(T)>::type LT;
-  ((LT*)dst)[dst_offset] = ((LT*)src)[src_offset];
+  ((LT*)dst)[dst_offset] = ((const LT*)src)[src_offset];
 }
 
 typedef enum{
-  ADAM_MODE_0   =0, // eps under square root
-  ADAM_MODE_1   =1  // eps outside square root
+  ADAM_MODE_0   =0, // L2 regularization mode
+  ADAM_MODE_1   =1  // Decoupled weight decay mode(AdamW)
 } adamMode_t;
 
-template <int DEPTH, typename T, typename GRAD_T>
+/* Multi-tensor Adam
+ *
+ * Updates params in-place and outputs a copy with a desired datatype.
+ */
+template <typename T, typename GRAD_T, typename PARAM_OUT_T>
 struct DistAdamFunctor
 {
+  // Vectorized local compute
+  __device__ __forceinline__ static void local_step(
+    T p[ILP],
+    T m[ILP],
+    T v[ILP],
+    const GRAD_T g[ILP],
+    const T grad_scale,
+    const float beta1,
+    const float beta2,
+    const float beta1_correction,
+    const float beta2_correction,
+    const float eps,
+    const float lr,
+    adamMode_t mode,
+    const float weight_decay) {
+    if (mode == ADAM_MODE_0) { // L2
+#pragma unroll
+      for (int ii = 0; ii < ILP; ii++) {
+        T scaled_grad = (g[ii] * grad_scale) + (weight_decay * p[ii]);
+        m[ii] = beta1*m[ii] + (1-beta1)*scaled_grad;
+        v[ii] = beta2*v[ii] + (1-beta2)*scaled_grad*scaled_grad;
+        T next_m_unbiased = m[ii] / beta1_correction;
+        T next_v_unbiased = v[ii] / beta2_correction;
+        T denom = sqrtf(next_v_unbiased) + eps;
+        T update = next_m_unbiased / denom;
+        p[ii] -= lr * update;
+      }
+    } else { // weight decay
+#pragma unroll
+      for (int ii = 0; ii < ILP; ii++) {
+        T scaled_grad = g[ii] * grad_scale;
+        m[ii] = beta1*m[ii] + (1-beta1)*scaled_grad;
+        v[ii] = beta2*v[ii] + (1-beta2)*scaled_grad*scaled_grad;
+        T next_m_unbiased = m[ii] / beta1_correction;
+        T next_v_unbiased = v[ii] / beta2_correction;
+        T denom = sqrtf(next_v_unbiased) + eps;
+        T update = (next_m_unbiased / denom) + (weight_decay * p[ii]);
+        p[ii] -= lr * update;
+      }
+    }
+  }
+
   __device__ __forceinline__ void operator()(
     int chunk_size,
     volatile int* noop_gmem,
-    TensorListMetadata<DEPTH>& tl,
-    const float* per_tensor_beta1,
-    const float* per_tensor_beta2,
-    const int* per_tensor_bias_correction,
-    const float* per_tensor_eps,
-    const float* per_tensor_weight_decay,
+    TensorListMetadata<5>& tl,
+    const float* grad_scale_ptr,
+    const float beta1,
+    const float beta2,
+    const float beta1_correction,
+    const float beta2_correction,
+    const float eps,
     const float lr,
-    const float grad_scale,
-    const int step,
-    adamMode_t mode)
+    adamMode_t mode,
+    const float weight_decay) const
   {
     int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int tensor_num = tl.start_tensor_this_launch + tensor_loc;
     int chunk_idx = tl.block_to_chunk[blockIdx.x];
     int n = tl.sizes[tensor_loc];
 
-    float b1 = per_tensor_beta1[tensor_num];
-    float b2 = per_tensor_beta2[tensor_num];
-    float eps = per_tensor_eps[tensor_num];
-    float decay = per_tensor_weight_decay[tensor_num];
+    const T grad_scale = *grad_scale_ptr;
 
-    float beta1_correction = 1.0f, beta2_correction = 1.0f;
-    if (per_tensor_bias_correction[tensor_num] == 1) {
-      beta1_correction = 1 - std::pow(b1, step);
-      beta2_correction = 1 - std::pow(b2, step);
-    }
-
-    T* p = (T *)tl.addresses[0][tensor_loc];
-    p += chunk_idx*chunk_size;
+    T* p_in = (T *)tl.addresses[0][tensor_loc];
+    p_in += chunk_idx*chunk_size;
     T* m = (T *)tl.addresses[1][tensor_loc];
     m += chunk_idx*chunk_size;
     T* v = (T *)tl.addresses[2][tensor_loc];
     v += chunk_idx*chunk_size;
-    GRAD_T* g = (GRAD_T *)tl.addresses[3][tensor_loc];
+    const GRAD_T* g = (GRAD_T *)tl.addresses[3][tensor_loc];
     g += chunk_idx*chunk_size;
-    GRAD_T* p_copy = NULL;
-    if (DEPTH == 5) {
-      p_copy = (GRAD_T *)tl.addresses[4][tensor_loc];
-      p_copy += chunk_idx*chunk_size;
-    }
+    PARAM_OUT_T* p_out = (PARAM_OUT_T *)tl.addresses[4][tensor_loc];
+    p_out += chunk_idx*chunk_size;
 
     n -= chunk_idx*chunk_size;
-    
-    T incoming_p[ILP];
-    T incoming_m[ILP];
-    T incoming_v[ILP];
-    T incoming_g[ILP];
+    n = chunk_size < n ? chunk_size : n;
 
-    // to make things simple, we put aligned case in a different code path
-    if (n % ILP == 0 &&
-      chunk_size % ILP == 0 &&
-      is_aligned(p) &&
-      is_aligned(m) &&
-      is_aligned(v) &&
-      is_aligned(g) &&
-      is_aligned(p_copy)) {
-      for (int i_start = threadIdx.x; i_start*ILP < n && i_start*ILP < chunk_size; i_start += blockDim.x) {
-        // load
-        GRAD_T tmp_g[ILP];
-        load_store(incoming_p, p, 0, i_start);
-        load_store(incoming_m, m, 0, i_start);
-        load_store(incoming_v, v, 0, i_start);
-        load_store(tmp_g, g, 0, i_start);
+    const bool aligned = (n % ILP == 0 &&
+                          is_aligned(p_in) &&
+                          is_aligned(m) &&
+                          is_aligned(v) &&
+                          is_aligned(g) &&
+                          is_aligned(p_out));
+
+    for (int i_start = threadIdx.x*ILP; i_start < n; i_start += blockDim.x*ILP) {
+      T local_p[ILP];
+      T local_m[ILP];
+      T local_v[ILP];
+      GRAD_T local_g[ILP];
+      PARAM_OUT_T local_p_out[ILP];
+
+      // Load
+      if (aligned) {
+        load_store(local_p, p_in + i_start);
+        load_store(local_m, m + i_start);
+        load_store(local_v, v + i_start);
+        load_store(local_g, g + i_start);
+      } else {
 #pragma unroll
-        for (int ii = 0; ii < ILP; ii++) {
-          incoming_g[ii] = static_cast<T>(tmp_g[ii]);
-          T scaled_grad = incoming_g[ii]/grad_scale;
-          incoming_m[ii] = b1*incoming_m[ii] + (1-b1)*scaled_grad;
-          incoming_v[ii] = b2*incoming_v[ii] + (1-b2)*scaled_grad*scaled_grad;
-          T next_m_unbiased = incoming_m[ii] / beta1_correction;
-	  T next_v_unbiased = incoming_v[ii] / beta2_correction;
-	  float denom;
-          if (mode == ADAM_MODE_0)
-            denom = sqrtf(next_v_unbiased + eps);
-          else // Mode 1
-            denom = sqrtf(next_v_unbiased) + eps;
-          float update = (next_m_unbiased / denom) + (decay * incoming_p[ii]);
-          incoming_p[ii] = incoming_p[ii] - (lr * update);
-	  if (DEPTH == 5)  tmp_g[ii] = static_cast<GRAD_T>(incoming_p[ii]);
-        }
-        load_store(p, incoming_p, i_start, 0);
-        load_store(m, incoming_m, i_start, 0);
-        load_store(v, incoming_v, i_start, 0);
-        if (DEPTH == 5) load_store(p_copy, tmp_g, i_start, 0);
-      }
-    } else {
-      for (int i_start = 0;
-          i_start < n && i_start < chunk_size;
-          i_start += blockDim.x*ILP) {
-
-#pragma unroll
-        for (int ii = 0; ii < ILP; ii++) {
-          incoming_p[ii] = 0;
-          incoming_m[ii] = 0;
-          incoming_v[ii] = 0;
-          incoming_g[ii] = 0;
-
-          int i = i_start + threadIdx.x + ii*blockDim.x;
-          if (i < n && i < chunk_size) {
-            incoming_p[ii] = p[i];
-            incoming_m[ii] = m[i];
-            incoming_v[ii] = v[i];
-            incoming_g[ii] = static_cast<T>(g[i]);
+        for (int ii = 0, i = i_start; ii < ILP; ii++, i++) {
+          if (i < n) {
+            local_p[ii] = p_in[i];
+            local_m[ii] = m[i];
+            local_v[ii] = v[i];
+            local_g[ii] = g[i];
+          } else {
+            local_p[ii] = 0;
+            local_m[ii] = 0;
+            local_v[ii] = 0;
+            local_g[ii] = 0;
           }
         }
+      }
 
+      // Local compute
+      local_step(
+        local_p, local_m, local_v, local_g, grad_scale,
+        beta1, beta2, beta1_correction, beta2_correction,
+        eps, lr, mode, weight_decay);
 #pragma unroll
-        for (int ii = 0; ii < ILP; ii++) {
-          int j = i_start + threadIdx.x + ii*blockDim.x;
+      for (int ii = 0; ii < ILP; ii++) {
+        local_p_out[ii] = static_cast<PARAM_OUT_T>(local_p[ii]);
+      }
 
-          if (j < n && j < chunk_size) {
-            T scaled_grad = incoming_g[ii]/grad_scale;
-            m[j] = b1*incoming_m[ii] + (1-b1)*scaled_grad;
-            v[j] = b2*incoming_v[ii] + (1-b2)*scaled_grad*scaled_grad;
-            T next_m_unbiased = m[j] / beta1_correction;
-            T next_v_unbiased = v[j] / beta2_correction;
-	    float denom;
-            if (mode == ADAM_MODE_0)
-              denom = sqrtf(next_v_unbiased + eps);
-            else // Mode 1
-              denom = sqrtf(next_v_unbiased) + eps;
-            float update = (next_m_unbiased / denom) + (decay * incoming_p[ii]);
-            p[j] = incoming_p[ii] - (lr * update);
-	    if (DEPTH == 5)  p_copy[j] = (GRAD_T) p[j];
+      // Store
+      if (aligned) {
+        load_store(p_in + i_start, local_p);
+        load_store(m + i_start, local_m);
+        load_store(v + i_start, local_v);
+        load_store(p_out + i_start, local_p_out);
+      } else {
+#pragma unroll
+        for (int ii = 0, i = i_start; ii < ILP; ii++, i++) {
+          if (i < n) {
+            p_in[i] = local_p[ii];
+            m[i] = local_m[ii];
+            v[i] = local_v[ii];
+	    p_out[i] = local_p_out[ii];
+          }
+        }
+      }
+    }
+  }
+};
+
+/* Functor for multi-tensor Adam with implicit main params
+ *
+ * If params are BF16 and optimizer state is FP32, it is not necessary
+ * to store FP32 main params. Instead, store 16-bit param remainder
+ * and combine with BF16 param to reconstruct the FP32 main param.
+ */
+struct DistAdamWithParamRemaindersFunctor
+{
+  __device__ __forceinline__ void operator()(
+    int chunk_size,
+    volatile int* noop_gmem,
+    TensorListMetadata<6>& tl,
+    const float* grad_scale_ptr,
+    const float beta1,
+    const float beta2,
+    const float beta1_correction,
+    const float beta2_correction,
+    const float eps,
+    const float lr,
+    adamMode_t mode,
+    const float weight_decay) const
+  {
+    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    int chunk_idx = tl.block_to_chunk[blockIdx.x];
+    int n = tl.sizes[tensor_loc];
+
+    const float grad_scale = *grad_scale_ptr;
+
+    int16_t* p_in = (int16_t *)tl.addresses[0][tensor_loc];
+    p_in += chunk_idx*chunk_size;
+    int16_t* p_rem = (int16_t *)tl.addresses[1][tensor_loc];
+    p_rem += chunk_idx*chunk_size;
+    float* m = (float *)tl.addresses[2][tensor_loc];
+    m += chunk_idx*chunk_size;
+    float* v = (float *)tl.addresses[3][tensor_loc];
+    v += chunk_idx*chunk_size;
+    float* g = (float *)tl.addresses[4][tensor_loc];
+    g += chunk_idx*chunk_size;
+    int16_t* p_out = (int16_t *)tl.addresses[5][tensor_loc];
+    p_out += chunk_idx*chunk_size;
+
+    n -= chunk_idx*chunk_size;
+    n = chunk_size < n ? chunk_size : n;
+
+    const bool aligned = (n % ILP == 0 &&
+                          is_aligned(p_in) &&
+                          is_aligned(p_rem) &&
+                          is_aligned(m) &&
+                          is_aligned(v) &&
+                          is_aligned(g) &&
+                          is_aligned(p_out));
+
+    for (int i_start = threadIdx.x*ILP; i_start < n; i_start += blockDim.x*ILP) {
+      union fp32_or_int162 {
+        float fp32;
+        int16_t int16[2];
+      };
+      fp32_or_int162 local_p[ILP];
+      int16_t local_p_bf16[ILP];
+      int16_t local_p_rem[ILP];
+      float local_m[ILP];
+      float local_v[ILP];
+      float local_g[ILP];
+
+      // Load
+      if (aligned) {
+        load_store(local_p_bf16, p_in + i_start);
+        load_store(local_p_rem, p_rem + i_start);
+        load_store(local_m, m + i_start);
+        load_store(local_v, v + i_start);
+        load_store(local_g, g + i_start);
+      } else {
+#pragma unroll
+        for (int ii = 0, i = i_start; ii < ILP; ii++, i++) {
+          if (i < n) {
+            local_p_bf16[ii] = p_in[i];
+            local_p_rem[ii] = p_rem[i];
+            local_m[ii] = m[i];
+            local_v[ii] = v[i];
+            local_g[ii] = g[i];
+          } else {
+            local_p_bf16[ii] = 0;
+            local_p_rem[ii] = 0;
+            local_m[ii] = 0;
+            local_v[ii] = 0;
+            local_g[ii] = 0;
+          }
+        }
+      }
+
+      // Reconstruct FP32 params
+#pragma unroll
+      for (int ii = 0; ii < ILP; ii++) {
+        if (local_p_rem[ii] < 0)
+          local_p_bf16[ii]--; // Undo rounding
+        local_p[ii].int16[1] = local_p_bf16[ii];
+        local_p[ii].int16[0] = local_p_rem[ii];
+      }
+
+      // Local compute
+      using LocalFunctor = DistAdamFunctor<float, float, void>;
+      LocalFunctor::local_step(
+        reinterpret_cast<float *>(local_p), local_m, local_v, local_g, grad_scale,
+        beta1, beta2, beta1_correction, beta2_correction,
+        eps, lr, mode, weight_decay);
+
+      // Split into BF16 params (rounded-to-nearest) and remainders
+#pragma unroll
+      for (int ii = 0; ii < ILP; ii++) {
+        local_p_bf16[ii] = local_p[ii].int16[1];
+        local_p_rem[ii] = local_p[ii].int16[0];
+        if (local_p_rem[ii] < 0)
+          local_p_bf16[ii]++; // Round up
+      }
+
+      // Store
+      if (aligned) {
+        load_store(p_rem + i_start, local_p_rem);
+        load_store(m + i_start, local_m);
+        load_store(v + i_start, local_v);
+        load_store(p_out + i_start, local_p_bf16);
+      } else {
+#pragma unroll
+        for (int ii = 0, i = i_start; ii < ILP; ii++, i++) {
+          if (i < n) {
+            p_rem[i] = local_p_rem[ii];
+            m[i] = local_m[ii];
+            v[i] = local_v[ii];
+	    p_out[i] = local_p_bf16[ii];
           }
         }
       }
@@ -169,60 +323,96 @@ struct DistAdamFunctor
 void multi_tensor_fused_adam_cuda(
   int chunk_size,
   at::Tensor noop_flag,
-  std::vector<std::vector<at::Tensor>> tensor_lists,  // p, m, v, g, p_copy
-  at::Tensor per_tensor_beta1,
-  at::Tensor per_tensor_beta2,
-  at::Tensor per_tensor_bias_correction,
-  at::Tensor per_tensor_eps,
-  at::Tensor per_tensor_weight_decay,
+  std::vector<std::vector<at::Tensor>> tensor_lists,  // p_in, m, v, g, p_out
+  at::Tensor grad_scale,
   float lr,
-  float grad_scale,
+  float beta1,
+  float beta2,
+  float eps,
   int step,
-  int mode)
+  int mode,
+  int bias_correction,
+  float weight_decay)
 {
   using namespace at;
 
+  // Expect p_in, m, v, g, p_out
   size_t tl_sz = tensor_lists.size();
-  AT_ASSERTM(tl_sz == 4 || tl_sz == 5, "expected tensor lists of size 4 or 5");
+  AT_ASSERTM(tl_sz == 5, "expected tensor lists of size 5");
 
-  if (tl_sz == 5) {
-    DISPATCH_FLOAT_AND_HALF(tensor_lists[3][0].scalar_type(), 0, "dist_adam_cuda_kernel",  // g
-      using accscalar_t = at::acc_type<scalar_t_0, true>;
+  // Assume p_in and g have same type
+  auto p_in_type = tensor_lists[0][0].scalar_type();
+  auto g_type = tensor_lists[3][0].scalar_type();
+  auto p_out_type = tensor_lists[4][0].scalar_type();
+  AT_ASSERTM(p_in_type == g_type, "expected main params and grads to have same type");
+
+  float beta1_correction = 1.0f, beta2_correction = 1.0f;
+  if (bias_correction == 1) {
+    beta1_correction = 1 - std::pow(beta1, step);
+    beta2_correction = 1 - std::pow(beta2, step);
+  }
+
+  DISPATCH_FLOAT_HALF_AND_BFLOAT(p_in_type, 0, "dist_adam_cuda_kernel",
+    DISPATCH_FLOAT_HALF_AND_BFLOAT(p_out_type, 1, "dist_adam_cuda_kernel",
       multi_tensor_apply<5>(
         BLOCK_SIZE,
         chunk_size,
         noop_flag,
         tensor_lists,
-        DistAdamFunctor<5, accscalar_t, scalar_t_0>(),
-        per_tensor_beta1.DATA_PTR<float>(),
-        per_tensor_beta2.DATA_PTR<float>(),
-        per_tensor_bias_correction.DATA_PTR<int>(),
-        per_tensor_eps.DATA_PTR<float>(),
-        per_tensor_weight_decay.DATA_PTR<float>(),
+        DistAdamFunctor<scalar_t_0, scalar_t_0, scalar_t_1>(),
+        grad_scale.DATA_PTR<float>(),
+        beta1,
+        beta2,
+        beta1_correction,
+        beta2_correction,
+        eps,
         lr,
-        grad_scale,
-        step,
-        (adamMode_t) mode);
-    );
-  } else {
-    DISPATCH_FLOAT_AND_HALF(tensor_lists[3][0].scalar_type(), 0, "dist_adam_cuda_kernel",  // g
-      using accscalar_t = at::acc_type<scalar_t_0, true>;
-      multi_tensor_apply<4>(
-        BLOCK_SIZE,
-        chunk_size,
-        noop_flag,
-        tensor_lists,
-        DistAdamFunctor<4, accscalar_t, scalar_t_0>(),
-        per_tensor_beta1.DATA_PTR<float>(),
-        per_tensor_beta2.DATA_PTR<float>(),
-        per_tensor_bias_correction.DATA_PTR<int>(),
-        per_tensor_eps.DATA_PTR<float>(),
-        per_tensor_weight_decay.DATA_PTR<float>(),
-        lr,
-        grad_scale,
-        step,
-        (adamMode_t) mode);
-    );
+        (adamMode_t) mode,
+        weight_decay);
+  ));
+  C10_CUDA_CHECK(cudaGetLastError());
+}
+
+void multi_tensor_fused_adam_with_param_remainders_cuda(
+  int chunk_size,
+  at::Tensor noop_flag,
+  std::vector<std::vector<at::Tensor>> tensor_lists,  // p_in, p_rem, m, v, g, p_out
+  at::Tensor grad_scale,
+  float lr,
+  float beta1,
+  float beta2,
+  float eps,
+  int step,
+  int mode,
+  int bias_correction,
+  float weight_decay)
+{
+  using namespace at;
+
+  // Expect p_in, p_rem, m, v, g, p_out
+  size_t tl_sz = tensor_lists.size();
+  AT_ASSERTM(tl_sz == 6, "expected tensor lists of size 6");
+
+  float beta1_correction = 1.0f, beta2_correction = 1.0f;
+  if (bias_correction == 1) {
+    beta1_correction = 1 - std::pow(beta1, step);
+    beta2_correction = 1 - std::pow(beta2, step);
   }
+
+  multi_tensor_apply<6>(
+    BLOCK_SIZE,
+    chunk_size,
+    noop_flag,
+    tensor_lists,
+    DistAdamWithParamRemaindersFunctor(),
+    grad_scale.DATA_PTR<float>(),
+    beta1,
+    beta2,
+    beta1_correction,
+    beta2_correction,
+    eps,
+    lr,
+    (adamMode_t) mode,
+    weight_decay);
   C10_CUDA_CHECK(cudaGetLastError());
 }

--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -20,10 +20,9 @@ except ImportError:
     import warnings
     warnings.warn(
         'Could not find recommended CUDA kernels when importing '
-        'apex.contrib.optimizers.distributed_fused_adam. '
-        'Apex should be installed with the following options: '
-        '`--cpp_exp`, `--cuda_ext`, '
-        '`--distributed_adam`, `--deprecated_fused_adam`.'
+        '`DistributedFusedAdam`. '
+        'For best performance, Apex should be installed with '
+        '`--deprecated_fused_adam`.'
     )
 
 def _round_to_multiple(number, multiple, round_up=True):

--- a/apex/contrib/test/optimizers/test_dist_adam.py
+++ b/apex/contrib/test/optimizers/test_dist_adam.py
@@ -8,32 +8,34 @@ from apex.contrib.optimizers.distributed_fused_adam import DistributedFusedAdam
 from apex.transformer.testing.distributed_test_base import NcclDistributedTestBase
 
 class SimpleModel(torch.nn.Module):
-
     def __init__(self, num_layers, size):
         super().__init__()
-        self.layers = torch.nn.ModuleList([
-            torch.nn.Linear(size, size, bias=(i%3==0))
-            for i in range(num_layers)
+        self.params = torch.nn.ParameterList([
+            torch.nn.Parameter(torch.rand(1, size) + 1)
+            for _ in range(num_layers)
         ])
-
     def forward(self, x):
         y = 0
-        for i, l in enumerate(self.layers):
-            y += (i+1) * l(x)
+        for i, param in enumerate(self.params):
+            y += (i+1) * param * x
         return y
 
 def make_models(
         num_layers,
         size,
-        dtype=torch.float32,
+        adam_w_mode=True,
+        model_dtype=torch.float32,
+        optim_dtype=None,
         param_sync_dtype=None,
         device='cuda',
         overlap_communication=True,
+        store_params=False,
+        store_param_remainders=False,
 ):
 
     # Construct models with same parameters
-    ref_model = SimpleModel(num_layers, size).to(dtype=dtype, device=device)
-    dist_model = SimpleModel(num_layers, size).to(dtype=dtype, device=device)
+    ref_model = SimpleModel(num_layers, size).to(dtype=model_dtype, device=device)
+    dist_model = SimpleModel(num_layers, size).to(dtype=model_dtype, device=device)
     with torch.no_grad():
         for ref_param, dist_param in zip(dist_model.parameters(),
                                          ref_model.parameters()):
@@ -48,8 +50,11 @@ def make_models(
     )
 
     # Construct optimizers with same hyperparameters
+    if optim_dtype is None:
+        optim_dtype = model_dtype
     optim_args = dict(lr=0.1, betas=(0.1,0.2), eps=0.25, weight_decay=0.1)
-    ref_optim = torch.optim.AdamW(
+    ref_optim_class = torch.optim.AdamW if adam_w_mode else torch.optim.Adam
+    ref_optim = ref_optim_class(
         [
             {'params': list(ref_model.parameters())[1::2], 'lr': 0.2},
             {'params': list(ref_model.parameters())[0::2]},
@@ -61,10 +66,13 @@ def make_models(
             {'params': list(dist_model.parameters())[1::2], 'lr': 0.2},
             {'params': list(dist_model.parameters())[0::2]},
         ],
+        adam_w_mode=adam_w_mode,
         overlap_grad_sync=overlap_communication,
         bucket_cap_mb=71/(4*1024*1024),
-        dtype=torch.float32,
+        dtype=optim_dtype,
         param_sync_dtype=param_sync_dtype,
+        store_params=store_params,
+        store_param_remainders=store_param_remainders,
         **optim_args,
     )
 
@@ -83,18 +91,22 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
 
     def test_matches_pytorch(
             self,
+            rtol=None,
+            atol=None,
             num_layers=11,
             layer_size=7,
             batch_size=3,
             num_steps=3,
             micro_batch_steps=3,
+            adam_w_mode=True,
             overlap_communication=True,
             use_nosync=True,
-            dtype=torch.float32,
+            model_dtype=torch.float32,
+            optim_dtype=None,
             param_sync_dtype=None,
             device='cuda',
-            rtol=None,
-            atol=None,
+            store_params=False,
+            store_param_remainders=False,
     ):
 
         torch.manual_seed(self.seed + self.rank)
@@ -103,10 +115,14 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
         ref_model, ref_optim, dist_model, dist_optim = make_models(
             num_layers,
             layer_size,
-            dtype=dtype,
+            adam_w_mode=adam_w_mode,
+            model_dtype=model_dtype,
+            optim_dtype=optim_dtype,
             param_sync_dtype=param_sync_dtype,
             device=device,
             overlap_communication=overlap_communication,
+            store_params=store_params,
+            store_param_remainders=store_param_remainders,
         )
 
         # Training loop
@@ -122,8 +138,8 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
                 # Synthetic data
                 x = torch.rand(batch_size, layer_size) - 0.5
                 dy = torch.rand_like(x) - 0.5
-                x = x.to(dtype=dtype, device=device)
-                dy = dy.to(dtype=dtype, device=device)
+                x = x.to(dtype=model_dtype, device=device)
+                dy = dy.to(dtype=model_dtype, device=device)
 
                 # Reference implementation
                 x_ref = x.detach().clone().requires_grad_(True)
@@ -155,6 +171,11 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
                 torch.testing.assert_close(
                     dist_param, ref_param, rtol=rtol, atol=atol)
 
+    def test_matches_pytorch_l2_reg(self):
+        self.test_matches_pytorch(
+            adam_w_mode=False,
+        )
+
     def test_matches_pytorch_no_overlap(self):
         self.test_matches_pytorch(
             overlap_communication=False,
@@ -166,24 +187,47 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
 
     def test_matches_pytorch_fp64(self):
         self.test_matches_pytorch(
-            dtype=torch.float64,
             rtol=1.3e-6,
             atol=1e-5,
+            model_dtype=torch.float64,
+            optim_dtype=torch.float32,
         )
 
     def test_matches_pytorch_fp16(self):
         self.test_matches_pytorch(
-            dtype=torch.float16,
-            rtol=1e-2,
-            atol=1e-2,
+            rtol=5e-3,
+            atol=1e-5,
+            micro_batch_steps=1,
+            model_dtype=torch.float16,
+            optim_dtype=torch.float16,
         )
 
-    def test_matches_pytorch_allgather_fp16(self):
+    def test_matches_pytorch_bf16(self):
         self.test_matches_pytorch(
-            dtype=torch.float32,
+            micro_batch_steps=1,
+            model_dtype=torch.bfloat16,
+            optim_dtype=torch.bfloat16,
+        )
+
+    def test_matches_pytorch_fp16_params(self):
+        self.test_matches_pytorch(
+            rtol=5e-3,
+            atol=1e-5,
+            micro_batch_steps=1,
+            model_dtype=torch.float16,
+            optim_dtype=torch.float32,
             param_sync_dtype=torch.float16,
-            rtol=1e-2,
-            atol=1e-2,
+            store_params=True,
+        )
+
+    def test_matches_pytorch_bf16_param_remainders(self):
+        self.test_matches_pytorch(
+            micro_batch_steps=1,
+            model_dtype=torch.bfloat16,
+            optim_dtype=torch.float32,
+            param_sync_dtype=torch.bfloat16,
+            store_params=False,
+            store_param_remainders=True,
         )
 
     def test_raises_on_mismatch(self):
@@ -200,9 +244,9 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
 
         # Only perform training step with distributed model
         dist_optim.zero_grad()
-        x = torch.rand(3, layer_size) + 0.5
+        x = torch.rand(3, layer_size) - 0.5
         x = x.to(dtype=torch.float32, device='cuda')
-        dy = torch.rand_like(x) + 0.5
+        dy = torch.rand_like(x) - 0.5
         y = dist_model(x)
         y.backward(dy)
         dist_optim.step()
@@ -227,8 +271,8 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
         xs = [3, 1, 4, 1, 5, 9]
         dys = [1, -1, 1, -1, 1, -1]
         for x, dy in zip(xs, dys):
-            x = torch.tensor([x], dtype=torch.float32, device='cuda')
-            dy = torch.tensor([dy], dtype=torch.float32, device='cuda')
+            x = torch.tensor([[x]], dtype=torch.float32, device='cuda')
+            dy = torch.tensor([[dy]], dtype=torch.float32, device='cuda')
 
             # Reference implementation
             ref_optim.zero_grad()
@@ -269,8 +313,8 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
         xs = [3, 1, 4, 1, 5, 9]
         dys = [1, float('inf'), 1, 1, float('nan'), -1]
         for x, dy in zip(xs, dys):
-            x = torch.tensor([x], dtype=torch.float32, device='cuda')
-            dy = torch.tensor([dy], dtype=torch.float32, device='cuda')
+            x = torch.tensor([[x]], dtype=torch.float32, device='cuda')
+            dy = torch.tensor([[dy]], dtype=torch.float32, device='cuda')
 
             # Reference implementation
             ref_optim.zero_grad()

--- a/apex/contrib/test/optimizers/test_dist_adam.py
+++ b/apex/contrib/test/optimizers/test_dist_adam.py
@@ -204,6 +204,8 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
 
     def test_matches_pytorch_bf16(self):
         self.test_matches_pytorch(
+            rtol=5e-2,
+            atol=1e-5,
             micro_batch_steps=1,
             model_dtype=torch.bfloat16,
             optim_dtype=torch.bfloat16,
@@ -222,6 +224,8 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
 
     def test_matches_pytorch_bf16_param_remainders(self):
         self.test_matches_pytorch(
+            rtol=5e-2,
+            atol=1e-5,
             micro_batch_steps=1,
             model_dtype=torch.bfloat16,
             optim_dtype=torch.float32,

--- a/csrc/multi_tensor_apply.cuh
+++ b/csrc/multi_tensor_apply.cuh
@@ -13,8 +13,8 @@
 
 
 // TODO:  Kernel arg size limit may be <4KB for some other cards (ie Jetson)
-constexpr int depth_to_max_tensors[5] = {110, 64, 48, 36, 30};
-constexpr int depth_to_max_blocks[5] = {320, 320, 320, 320, 320};
+constexpr int depth_to_max_tensors[6] = {110, 64, 48, 36, 30, 24};
+constexpr int depth_to_max_blocks[6] = {320, 320, 320, 320, 320, 320};
 
 template<int n> struct TensorListMetadata
 {


### PR DESCRIPTION
While mucking around with the kernels for `DistributedFusedAdam`, I've taken the opportunity to make internal improvements and add new features:

- Refactor kernels so they do not require GPU synchronization.
- Add option to directly use values from params instead of storing a copy of params as optimizer state. I've disabled this by default since NeMo Megatron expects that the optimizer operates on FP32 main params instead of BF16 model params. However, I'd like to enable this option by default in the future since a typical user will use the same dtype for their model and optimizer, so it's an easy memory saving.
- If optimizer is FP32 and params are BF16, add option to just store 16-bit param remainders and reconstruct FP32 params out of BF16 params. This is intended to reduce memory usage in NeMo Megatron.
- Add option to choose between Adam and AdamW, matching the behavior of `FusedAdam`.
- Avoid calling collectives in side streams. I noticed significant memory overheads when running with the 22.08 PyTorch container, and I think it's because PyTorch's NCCL collectives allocate some memory internally.

Running GPT-3 5B on a Selene node (4-way data parallelism, 2-way pipeline parallelism, local batch size 2, no micro-batching):

   | Optimizer                | Data types |Step time | Loss at step 50 | Allocated memory | Reserved memory |
   |-----------------------|---|--------|-----------------|--------------|-----------------|
   |  `FusedAdam`         | BF16 params, FP32 main params | 1.44 sec  |            6.53 | 60.4 GB     | 60.9 GB        |
   | `DistributedFusedAdam` | BF16 params, FP32 main params      | 1.37 sec  |            6.54 | 38.2 GB     | 39.8 GB        |
   | `DistributedFusedAdam` | BF16 params, 16-bit param remainders | 1.36 sec  |            6.53 | 36.8 GB     | 37.4 GB        |
