### PR TITLE
Support overlapped grad sync with Megatron pipeline parallelism

### DIFF
--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -933,6 +933,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                     self._grad_copy(param)
                     self._try_start_bucket_grad_sync(
                         params=[param],
+                        ignore_last_bucket=False,
                     )
         self._force_bucket_grad_sync()
 

--- a/apex/transformer/pipeline_parallel/schedules/common.py
+++ b/apex/transformer/pipeline_parallel/schedules/common.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Tuple, Union, Optional, Sequence
 
 import torch
@@ -397,11 +396,3 @@ def backward_step(
 
     # timers("backward-compute").stop()
     return input_tensor_grad[0] if unwrap_input_tensor_grad else input_tensor_grad
-
-
-@contextmanager
-def placeholder_handler():
-    try:
-        yield
-    finally:
-        pass

--- a/apex/transformer/pipeline_parallel/schedules/common.py
+++ b/apex/transformer/pipeline_parallel/schedules/common.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Tuple, Union, Optional, Sequence
 
 import torch
@@ -396,3 +397,11 @@ def backward_step(
 
     # timers("backward-compute").stop()
     return input_tensor_grad[0] if unwrap_input_tensor_grad else input_tensor_grad
+
+
+@contextmanager
+def placeholder_handler():
+    try:
+        yield
+    finally:
+        pass

--- a/apex/transformer/pipeline_parallel/schedules/fwd_bwd_no_pipelining.py
+++ b/apex/transformer/pipeline_parallel/schedules/fwd_bwd_no_pipelining.py
@@ -1,3 +1,4 @@
+import contextlib
 from typing import List, Union, Optional
 
 import torch
@@ -10,7 +11,6 @@ from apex.transformer.pipeline_parallel.schedules.common import Batch
 from apex.transformer.pipeline_parallel.schedules.common import FwdStepFunc
 from apex.transformer.pipeline_parallel.schedules.common import forward_step
 from apex.transformer.pipeline_parallel.schedules.common import backward_step
-from apex.transformer.pipeline_parallel.schedules.common import placeholder_handler
 from apex.transformer.log_util import get_transformer_logger
 
 
@@ -69,7 +69,7 @@ def forward_backward_no_pipelining(
     elif isinstance(model, torch.nn.parallel.distributed.DistributedDataParallel):
         context_handler = model.no_sync
     else:
-        context_handler = placeholder_handler
+        context_handler = contextlib.nullcontext
 
     losses_reduced = []
     input_tensor, output_tensor_grad = None, None

--- a/apex/transformer/pipeline_parallel/schedules/fwd_bwd_no_pipelining.py
+++ b/apex/transformer/pipeline_parallel/schedules/fwd_bwd_no_pipelining.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from typing import List, Union, Optional
 
 import torch
@@ -11,6 +10,7 @@ from apex.transformer.pipeline_parallel.schedules.common import Batch
 from apex.transformer.pipeline_parallel.schedules.common import FwdStepFunc
 from apex.transformer.pipeline_parallel.schedules.common import forward_step
 from apex.transformer.pipeline_parallel.schedules.common import backward_step
+from apex.transformer.pipeline_parallel.schedules.common import placeholder_handler
 from apex.transformer.log_util import get_transformer_logger
 
 
@@ -18,14 +18,6 @@ _all__ = ["forward_backward_no_pipelining"]
 
 
 _logger = get_transformer_logger(__name__)
-
-
-@contextmanager
-def placeholder_handler():
-    try:
-        yield
-    finally:
-        pass
 
 
 def forward_backward_no_pipelining(
@@ -59,7 +51,7 @@ def forward_backward_no_pipelining(
         disable_autocast: Turn off `enabled` flag of `torch.cuda.amp.autocast` if :obj:`True`.
             Should be used when your forward and loss computation is in the autocast context to
             avoid unnecesarily nest autocast context.
-        custom_sync_context_handler:
+        custom_sync_context_handler: Context manager to disable asynchronous gradient reductions.
         **kwargs: Added to handle `tensor_shape` which has no effect on this function.
 
     Returns:

--- a/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_without_interleaving.py
+++ b/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_without_interleaving.py
@@ -16,6 +16,7 @@ from apex.transformer.pipeline_parallel.schedules.common import FwdStepFunc
 from apex.transformer.pipeline_parallel.schedules.common import backward_step
 from apex.transformer.pipeline_parallel.schedules.common import forward_step
 from apex.transformer.pipeline_parallel.schedules.common import free_output_tensor
+from apex.transformer.pipeline_parallel.schedules.common import placeholder_handler
 from apex.transformer.log_util import get_transformer_logger
 
 
@@ -239,6 +240,7 @@ def forward_backward_pipelining_without_interleaving(
     deallocate_pipeline_outputs: bool = False,
     async_comm: bool = False,
     sequence_parallel_enabled: bool = False,
+    custom_sync_context_handler = None,
     **kwargs,
 ) -> List[Union[torch.Tensor, Sequence[torch.Tensor]]]:
     """Run non-interleaved 1F1B schedule, with communication between pipeline stages.
@@ -269,9 +271,18 @@ def forward_backward_pipelining_without_interleaving(
         sequence_parallel_enabled: Set to :obj:`True` for this function to handle sequence length.
             When :obj:`True`, the sequence length on each tensor model parallel rank is updated
             to :math:`original\_sequence\_length / tensor\_model\_parallel\_world\_size`.
+        custom_sync_context_handler: Context manager to disable
+            asynchronous gradient reductions. In the first pipeline
+            stage, asynchronous gradient reductions are enabled in the
+            backward pass of the last microbatch. In other pipeline
+            stages, asynchronous gradient reductions are disabled and
+            gradients must be manually synchronized by the caller (in
+            practice the runtime is covered up by the bubble
+            overhead).
 
     Returns:
         a list of loss `torch.Tensor`s if the last stage, empty list otherwise.
+
     """
     # timers = get_timers()
 
@@ -286,6 +297,14 @@ def forward_backward_pipelining_without_interleaving(
         msg = f"`model` is expected be a `nn.Module`, but {type(model)}"
         raise RuntimeError(msg)
     model: torch.nn.Module = model[0]
+
+    # Disable async grad reductions
+    if custom_sync_context_handler is not None:
+        context_handler = custom_sync_context_handler
+    else:
+        context_handler = placeholder_handler
+    context = context_handler()
+    context.__enter__()
 
     # Compute number of warmup microbatches.
     num_microbatches: int = get_num_microbatches()
@@ -456,6 +475,9 @@ def forward_backward_pipelining_without_interleaving(
     _logger.info("Cooldown phase")
     if not forward_only:
         for i in range(num_warmup_microbatches):
+            if i == num_warmup_microbatches-1 and rank == 0:
+                context.__exit__(None, None, None)
+                context = None
             _logger.debug(f"cooldown iter: {i} / {num_warmup_microbatches}")
             input_tensor = input_tensors.pop(0)
             output_tensor = output_tensors.pop(0)
@@ -485,5 +507,10 @@ def forward_backward_pipelining_without_interleaving(
                 async_comm=async_comm,
                 sequence_parallel_enabled=sequence_parallel_enabled,
             )
+
+    # Make sure to exit context handler for async grad reductions
+    if context is not None:
+        context.__exit__(None, None, None)
+        context = None
 
     return losses_reduced

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -536,12 +536,15 @@ class NcclPipelineParallelWithCustomSyncContextHandler(NcclDistributedTestBase):
         torch.cuda.synchronize()
 
         # Check context behavior
-        assert has_entered_context, 'Has not entered custom sync context'
-        assert has_exited_context, 'Has not exited custom sync context'
-        assert no_grad_at_context_exit == parallel_state.is_pipeline_first_stage(), \
-            'Expected to exit custom sync context '\
-            'before backward pass in first pipeline stage ' \
+        self.assertTrue(has_entered_context, 'Has not entered custom sync context')
+        self.assertTrue(has_exited_context, 'Has not exited custom sync context')
+        self.assertEqual(
+            no_grad_at_context_exit,
+            parallel_state.is_pipeline_first_stage(),
+            'Expected to exit custom sync context '
+            'before backward pass in first pipeline stage '
             'and after backward pass in other pipeline stages'
+        )
 
         # Clean up
         parallel_state.destroy_model_parallel()


### PR DESCRIPTION
This PR adds functionality so that the distributed Adam optimizer can overlap grad reduce-scatters with backward compute in the first pipeline stage. Async grad reductions are disabled in the other pipeline stages since it slows down the backward pass, so the reduction should be done externally while waiting for the first stage to finish. Note that this is not compatible with `DistributedDataParallel` since I am not aware of an option to manually trigger a reduction after using `no_sync`.

I've also done some refactoring of distributed Adam to support NeMo-Megatron integration, mostly so that I can selectively disable async grad reductions for model-parallel operations:

- Each bucket independently keeps track of which grads it has received
- Exposed function that creates callback functions for launching async grad reductions, which I override in NeMo
- Perform collective communication for checkpointing in main stream in order to reduce memory pool overheads
- Change default value for grad norm function from `[]` to `None`. This allows us to pass in empty iterators