### PR TITLE
Update `apex.mlp` to use fp16 in `autocast`

### DIFF
--- a/apex/_autocast_utils.py
+++ b/apex/_autocast_utils.py
@@ -3,6 +3,9 @@ from typing import Optional, Sequence
 import torch
 
 
+__all__ = ["_cast_if_autocast_enabled"]
+
+
 def _get_autocast_dtypes() -> Sequence[torch.dtype]:
     if torch.cuda.is_bf16_supported():
         return [torch.half, torch.bfloat16]

--- a/apex/mlp/mlp.py
+++ b/apex/mlp/mlp.py
@@ -1,9 +1,12 @@
 from copy import copy
 import math
+
 import torch
 from torch import nn
+
+from apex._autocast_utils import _cast_if_autocast_enabled
 import mlp_cuda
-from .. import amp
+
 
 class MlpFunction(torch.autograd.Function):
     @staticmethod
@@ -21,8 +24,11 @@ class MlpFunction(torch.autograd.Function):
         del ctx.outputs
         return (None, None, *grads)
 
-# TODO(crcrpar): Should make this compatible with torch.cuda.amp
-mlp_function = amp.half_function(MlpFunction.apply)
+
+def mlp_function(bias, activation, *args):
+    autocast_args = _cast_if_autocast_enabled(bias, activation, *args)
+    return MlpFunction.apply(*autocast_args)
+
 
 class MLP(torch.nn.Module):
     """Launch MLP in C++
@@ -33,16 +39,16 @@ class MLP(torch.nn.Module):
         relu (bool): Default True
     """
     def __init__(self, mlp_sizes, bias=True, activation='relu'):
-        super(MLP, self).__init__()
+        super().__init__()
         self.num_layers = len(mlp_sizes) - 1
         self.mlp_sizes = copy(mlp_sizes)
         self.bias = 1 if bias else 0
 
-        if activation is 'none':
+        if activation == 'none':
             self.activation = 0
-        elif activation is 'relu':
+        elif activation == 'relu':
             self.activation = 1
-        elif activation is 'sigmoid':
+        elif activation == 'sigmoid':
             self.activation = 2
         else:
             raise TypeError("activation must be relu or none.")


### PR DESCRIPTION
- Deify PyTorch autocast context and casts tensors
- add test cases with and without autocast enabled (currently only fp16)