### PR TITLE
Update test_fused_layer_norm.py

### DIFF
--- a/apex/normalization/fused_layer_norm.py
+++ b/apex/normalization/fused_layer_norm.py
@@ -24,7 +24,7 @@ def manual_rms_norm(input, normalized_shape, weight, eps):
 
     # convert into half-precision if necessary
     if weight.dtype in [torch.float16, torch.bfloat16]:
-        input = input.to(self.weight.dtype)
+        input = input.to(weight.dtype)
 
     return weight * input
 

--- a/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
+++ b/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
@@ -200,7 +200,6 @@ class TestFusedLayerNorm(common_utils.TestCase):
         self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, 
                                 fwd_thresholds=dict(rtol=1.6e-2, atol=3e-4), bwd_thresholds=dict(rtol=1.6e-2, atol=3e-2))
 
-
     @common_utils.parametrize(
         "dtype, elementwise_affine",
         list(product(autocast_dtypes, (True, False)))
@@ -210,7 +209,6 @@ class TestFusedLayerNorm(common_utils.TestCase):
         bf16_bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
         batch_size = 16
         normalized_shape = [32, 16]
-        # native, fused = _prep_layers(normalized_shape, elementwise_affine, dtype)
         native = torch.nn.LayerNorm(
             normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
         ).to(device="cuda", dtype=dtype)
@@ -236,7 +234,6 @@ class TestFusedLayerNorm(common_utils.TestCase):
         tols = {'rtol': None, 'atol': None} if dtype == torch.half else bf16_bwd_thresholds
         torch.testing.assert_close(native_x.grad, fused_x.grad, **tols, check_dtype=False)
 
-
     @common_utils.parametrize(
         "dtype, elementwise_affine",
         list(product(autocast_dtypes, (True, False)))
@@ -246,10 +243,9 @@ class TestFusedLayerNorm(common_utils.TestCase):
         bf16_bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
         batch_size = 16
         normalized_shape = [32, 16]
-        # native, fused = _prep_rms_layers(normalized_shape, elementwise_affine, dtype)
         native = FusedRMSNorm(
             normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
-        )
+        ).to(dtype=dtype)
         fused = FusedRMSNorm(
             normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
         ).cuda()

--- a/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
+++ b/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
@@ -8,198 +8,11 @@ from apex.normalization import FusedRMSNorm
 from apex.normalization import MixedFusedLayerNorm
 from apex.normalization import MixedFusedRMSNorm
 
+from torch.testing._internal import common_utils
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import onlyCUDA
 
-class TestFusedLayerNorm(unittest.TestCase):
-    dtype = torch.float
-    elementwise_affine = False
-    normalized_shape = [32, 16]
-    rtol, atol = None, None
-    fwd_thresholds = dict(rtol=None, atol=None)
-    bwd_thresholds = dict(rtol=None, atol=None)
-    mixed_fused = False
-
-    def setUp(self):
-        # bias and weight are set to 0 and 1 respectively, so no need to copy parameters from cpu module to the gpu one
-        if not self.mixed_fused:
-            self.module_cpu_ = FusedLayerNorm(
-                normalized_shape=self.normalized_shape, elementwise_affine=self.elementwise_affine).cpu()
-            self.module_cuda_ = FusedLayerNorm(
-                normalized_shape=self.normalized_shape, elementwise_affine=self.elementwise_affine).to(device="cuda", dtype=self.dtype)
-        else:
-            assert self.elementwise_affine
-            self.module_cpu_ = MixedFusedLayerNorm(
-                normalized_shape=self.normalized_shape).cpu()
-            self.module_cuda_ = MixedFusedLayerNorm(
-                normalized_shape=self.normalized_shape).to(device="cuda", dtype=self.dtype)
-
-
-    def _check_same_output(self, batch_size, contiguous):
-        torch.cuda.manual_seed(42)
-        if contiguous:
-            input_shape = [batch_size] + self.normalized_shape
-            input_ = torch.randn(input_shape, device="cpu").requires_grad_(True)
-            input_cuda_ = input_.to(device="cuda", dtype=self.dtype).detach().requires_grad_(True)
-            self.assertTrue(input_.is_contiguous())
-            self.assertTrue(input_cuda_.is_contiguous())
-        else:
-            input_shape = [batch_size] + self.normalized_shape
-            input_shape = [batch_size * 3] + [self.normalized_shape[0] * 5, self.normalized_shape[1] * 3]
-            input_src_ = torch.randn(input_shape, device="cpu")
-            input_ = input_src_[::3, ::5, ::3].detach().requires_grad_(True)
-            input_cuda_ = input_src_.to(device="cuda", dtype=self.dtype)[::3, ::5, ::3].detach().requires_grad_(True)
-            # make sure that tensors are NOT contiguous.
-            self.assertFalse(input_.is_contiguous())
-            self.assertFalse(input_cuda_.is_contiguous())
-        out_cpu_ = self.module_cpu_(input_)
-        gO = torch.rand_like(out_cpu_)
-        out_cpu_.backward(gO)
-        out_cuda_ = self.module_cuda_(input_cuda_)
-        gO = gO.to(device="cuda", dtype=self.dtype)
-        out_cuda_.backward(gO)
-        self.assertFalse(out_cpu_.is_cuda)
-        self.assertTrue(out_cuda_.is_cuda)
-        # TODO (mkozuki): `torch.testing.assert_allclose` is deprecated.
-        # Use `torch.testing.assert_close`.
-        # See https://github.com/pytorch/pytorch/issues/61844
-        torch.testing.assert_allclose(
-            out_cpu_.to(device="cuda", dtype=self.dtype), out_cuda_, **self.fwd_thresholds)
-        torch.testing.assert_allclose(
-            input_.grad.to(device="cuda", dtype=self.dtype), input_cuda_.grad, **self.bwd_thresholds)
-
-    def _test_same_output(self, batch_size):
-        for contiguous in (True, False):
-            self._check_same_output(batch_size, contiguous)
-
-    def test_layer_norm(self):
-        self._test_same_output(16)
-
-    def test_large_batch(self):
-        self._test_same_output(65536)
-
-
-class TestFusedRMSNorm(unittest.TestCase):
-    dtype = torch.float
-    elementwise_affine = False
-    normalized_shape = [32, 16]
-    rtol, atol = None, None
-    fwd_thresholds = dict(rtol=None, atol=None)
-    bwd_thresholds = dict(rtol=None, atol=None)
-    mixed_fused = False
-
-    def setUp(self):
-        # bias and weight are set to 0 and 1 respectively, so no need to copy parameters from cpu module to the gpu one
-        if not self.mixed_fused:
-            self.module_cpu_ = FusedRMSNorm(
-                normalized_shape=self.normalized_shape, elementwise_affine=self.elementwise_affine).cpu()
-            self.module_cuda_ = FusedRMSNorm(
-                normalized_shape=self.normalized_shape, elementwise_affine=self.elementwise_affine).to(device="cuda", dtype=self.dtype)
-        else:
-            assert self.elementwise_affine
-            self.module_cpu_ = MixedFusedRMSNorm(
-                normalized_shape=self.normalized_shape).cpu()
-            self.module_cuda_ = MixedFusedRMSNorm(
-                normalized_shape=self.normalized_shape).to(device="cuda", dtype=self.dtype)
-
-    def _check_same_output(self, batch_size, contiguous):
-        torch.cuda.manual_seed(42)
-        if contiguous:
-            input_shape = [batch_size] + self.normalized_shape
-            input_ = torch.randn(input_shape, device="cpu").requires_grad_(True)
-            input_cuda_ = input_.to(device="cuda", dtype=self.dtype).detach().requires_grad_(True)
-            self.assertTrue(input_.is_contiguous())
-            self.assertTrue(input_cuda_.is_contiguous())
-        else:
-            input_shape = [batch_size] + self.normalized_shape
-            input_shape = [batch_size * 3] + [self.normalized_shape[0] * 5, self.normalized_shape[1] * 3]
-            input_src_ = torch.randn(input_shape, device="cpu")
-            input_ = input_src_[::3, ::5, ::3].detach().requires_grad_(True)
-            input_cuda_ = input_src_.to(device="cuda", dtype=self.dtype)[::3, ::5, ::3].detach().requires_grad_(True)
-            # make sure that tensors are NOT contiguous.
-            self.assertFalse(input_.is_contiguous())
-            self.assertFalse(input_cuda_.is_contiguous())
-        out_cpu_ = self.module_cpu_(input_)
-        gO = torch.rand_like(out_cpu_)
-        out_cpu_.backward(gO)
-        out_cuda_ = self.module_cuda_(input_cuda_)
-        # TODO (mkozuki): `torch.testing.assert_allclose` is deprecated.
-        # Use `torch.testing.assert_close`.
-        # See https://github.com/pytorch/pytorch/issues/61844
-        torch.testing.assert_allclose(
-            out_cpu_.to(device="cuda", dtype=self.dtype), out_cuda_.clone().detach(), **self.fwd_thresholds)
-        gO = gO.to(device="cuda", dtype=self.dtype)
-        out_cuda_.backward(gO)
-        self.assertFalse(out_cpu_.is_cuda)
-        self.assertTrue(out_cuda_.is_cuda)
-        torch.testing.assert_allclose(
-            input_.grad.to(device="cuda", dtype=self.dtype), input_cuda_.grad, **self.bwd_thresholds)
-        if self.elementwise_affine:
-            torch.testing.assert_allclose(self.module_cpu_.weight.grad.to(device="cuda", dtype=self.dtype),
-                                          self.module_cuda_.weight.grad, **self.bwd_thresholds)
-
-    def _test_same_output(self, batch_size):
-        for contiguous in (True, False):
-            self._check_same_output(batch_size, contiguous)
-
-    def test_layer_norm(self):
-        self._test_same_output(16)
-
-    def test_large_batch(self):
-        self._test_same_output(65536)
-
-
-class TestFusedLayerNormElemWise(TestFusedLayerNorm):
-    elementwise_affine = True
-
-class TestMixedFusedLayerNormElemWise(TestFusedLayerNorm):
-    elementwise_affine = True
-    mixed_fused = True
-
-class TestFusedLayerNormElemWiseHalf(TestFusedLayerNormElemWise):
-    dtype = torch.half
-
-    def test_large_batch(self):
-        self.skipTest("Skip to save time")
-
-class TestFusedLayerNormElemWiseBFloat16(TestFusedLayerNormElemWise):
-    dtype = torch.bfloat16
-    # NOTE (mkozuki): [BFloat16 Layer Norm flakiness]
-    # Use thresholds larger than those used in pytorch, see
-    # https://github.com/pytorch/pytorch/blob/72274e2a2fd55019ec860e1743dbdc5b0c5a5624/torch/testing/_asserts.py#L26
-    fwd_thresholds = dict(rtol=1.6e-2, atol=3e-4)
-    bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
-
-    def test_large_batch(self):
-        self.skipTest("Skip to save time")
-
-
-class TestFusedRMSNormElemWise(TestFusedRMSNorm):
-    bwd_thresholds = dict(rtol=2e-3, atol=2e-4)
-    elementwise_affine = True
-
-class TestMixedFusedRMSNormElemWise(TestFusedRMSNorm):
-    bwd_thresholds = dict(rtol=2e-3, atol=2e-4)
-    elementwise_affine = True
-    mixed_fused = True
-
-class TestFusedRMSNormElemWiseHalf(TestFusedRMSNormElemWise):
-    dtype = torch.half
-    bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
-
-    def test_large_batch(self):
-        self.skipTest("Skip to save time")
-
-
-class TestFusedLayerNormElemWiseBFloat16(TestFusedLayerNormElemWise):
-    dtype = torch.bfloat16
-    # NOTE (mkozuki): [BFloat16 Layer Norm flakiness]
-    # Use thresholds larger than those used in pytorch, see
-    # https://github.com/pytorch/pytorch/blob/72274e2a2fd55019ec860e1743dbdc5b0c5a5624/torch/testing/_asserts.py#L26
-    fwd_thresholds = dict(rtol=1.6e-2, atol=3e-4)
-    bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
-
-    def test_large_batch(self):
-        self.skipTest("Skip to save time")
-
+from itertools import product
 
 def _prep_layers(normalized_shape, elementwise_affine, dtype):
     native = torch.nn.LayerNorm(
@@ -228,26 +41,209 @@ def _prep_inputs(batch_size, normalized_shape, dtype):
         native = fused.clone().to(dtype).requires_grad_(True)
     return native, fused
 
-
 autocast_dtypes = (torch.half, torch.bfloat16) if torch.cuda.is_bf16_supported() else (torch.half,)
 
-class TestAutocastFusedLayerNorm(unittest.TestCase):
-    bf16_fwd_thresholds = dict(rtol=1.6e-2, atol=3e-4)
-    bf16_bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
+class TestFusedLayerNorm(common_utils.TestCase):
 
-    def setUp(self):
-        self.batch_size = 16
-        self.normalized_shape = [32, 16]
+    def _test_fused_layer_norm(
+        self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype,
+        fwd_thresholds=dict(rtol=None, atol=None), bwd_thresholds=dict(rtol=None, atol=None)
+        ):
 
-    def _run_test(self, dtype, elementwise_affine):
-        native, fused = _prep_layers(self.normalized_shape, elementwise_affine, dtype)
-        native_x, fused_x = _prep_inputs(self.batch_size, self.normalized_shape, dtype)
+        normalized_shape = [32, 16]
+
+        if not mixed_fused:
+            module_cpu_ = FusedLayerNorm(
+                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine).cpu()
+            module_cuda_ = FusedLayerNorm(
+                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine).to(device="cuda", dtype=dtype)
+        else:
+            assert elementwise_affine
+            module_cpu_ = MixedFusedLayerNorm(
+                normalized_shape=normalized_shape).cpu()
+            module_cuda_ = MixedFusedLayerNorm(
+                normalized_shape=normalized_shape).to(device="cuda", dtype=dtype)
+
+        torch.cuda.manual_seed(42)
+        if contiguous:
+            input_shape = [batch_size] + normalized_shape
+            input_ = torch.randn(input_shape, device="cpu").requires_grad_(True)
+            input_cuda_ = input_.to(device="cuda", dtype=dtype).detach().requires_grad_(True)
+            self.assertTrue(input_.is_contiguous())
+            self.assertTrue(input_cuda_.is_contiguous())
+        else:
+            input_shape = [batch_size] + normalized_shape
+            input_shape = [batch_size * 3] + [normalized_shape[0] * 5, normalized_shape[1] * 3]
+            input_src_ = torch.randn(input_shape, device="cpu")
+            input_ = input_src_[::3, ::5, ::3].detach().requires_grad_(True)
+            input_cuda_ = input_src_.to(device="cuda", dtype=dtype)[::3, ::5, ::3].detach().requires_grad_(True)
+            # make sure that tensors are NOT contiguous.
+            self.assertFalse(input_.is_contiguous())
+            self.assertFalse(input_cuda_.is_contiguous())
+        out_cpu_ = module_cpu_(input_)
+        gO = torch.rand_like(out_cpu_)
+        out_cpu_.backward(gO)
+        out_cuda_ = module_cuda_(input_cuda_)
+
+        gO = gO.to(device="cuda", dtype=dtype)
+        out_cuda_.backward(gO)
+        self.assertFalse(out_cpu_.is_cuda)
+        self.assertTrue(out_cuda_.is_cuda)
+        torch.testing.assert_close(
+            out_cpu_.to(device="cuda", dtype=dtype), out_cuda_, **fwd_thresholds)
+        torch.testing.assert_close(
+            input_.grad.to(device="cuda", dtype=dtype), input_cuda_.grad, **bwd_thresholds)
+
+    def _test_fused_rms_norm(
+        self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype,
+        fwd_thresholds=dict(rtol=None, atol=None), bwd_thresholds=dict(rtol=None, atol=None)
+        ):
+
+        normalized_shape = [32, 16]
+
+        if not mixed_fused:
+            module_cpu_ = FusedRMSNorm(
+                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine).cpu()
+            module_cuda_ = FusedRMSNorm(
+                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine).to(device="cuda", dtype=dtype)
+        else:
+            assert elementwise_affine
+            module_cpu_ = MixedFusedRMSNorm(
+                normalized_shape=normalized_shape).cpu()
+            module_cuda_ = MixedFusedRMSNorm(
+                normalized_shape=normalized_shape).to(device="cuda", dtype=dtype)
+
+        torch.cuda.manual_seed(42)
+        if contiguous:
+            input_shape = [batch_size] + normalized_shape
+            input_ = torch.randn(input_shape, device="cpu").requires_grad_(True)
+            input_cuda_ = input_.to(device="cuda", dtype=dtype).detach().requires_grad_(True)
+            self.assertTrue(input_.is_contiguous())
+            self.assertTrue(input_cuda_.is_contiguous())
+        else:
+            input_shape = [batch_size] + normalized_shape
+            input_shape = [batch_size * 3] + [normalized_shape[0] * 5, normalized_shape[1] * 3]
+            input_src_ = torch.randn(input_shape, device="cpu")
+            input_ = input_src_[::3, ::5, ::3].detach().requires_grad_(True)
+            input_cuda_ = input_src_.to(device="cuda", dtype=dtype)[::3, ::5, ::3].detach().requires_grad_(True)
+            # make sure that tensors are NOT contiguous.
+            self.assertFalse(input_.is_contiguous())
+            self.assertFalse(input_cuda_.is_contiguous())
+        out_cpu_ = module_cpu_(input_)
+        gO = torch.rand_like(out_cpu_)
+        out_cpu_.backward(gO)
+        out_cuda_ = module_cuda_(input_cuda_)
+
+        torch.testing.assert_close(
+            out_cpu_.to(device="cuda", dtype=dtype), out_cuda_.clone().detach(), **fwd_thresholds)
+        gO = gO.to(device="cuda", dtype=dtype)
+        out_cuda_.backward(gO)
+        self.assertFalse(out_cpu_.is_cuda)
+        self.assertTrue(out_cuda_.is_cuda)
+        torch.testing.assert_close(
+            input_.grad.to(device="cuda", dtype=dtype), input_cuda_.grad, **bwd_thresholds)
+        if elementwise_affine:
+            torch.testing.assert_close(module_cpu_.weight.grad.to(device="cuda", dtype=dtype),
+                                          module_cuda_.weight.grad, **bwd_thresholds)
+
+    # layer norm tests
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
+        list(product((16, 65536), (True, False), (False,), (False,), (torch.float,)))
+    )
+    def test_layer_norm_regular(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype)
+    
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
+        list(product((16, 65536), (True, False), (True,), (False,), (torch.float,)))
+    )
+    def test_layer_norm_elemwise(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype)
+
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
+        list(product((16, 65536), (True, False), (True,), (True,), (torch.float,)))
+    )
+    def test_layer_norm_mixed(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype)
+    
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
+        list(product((16,), (True, False), (True,), (False,), (torch.half,)))
+    )
+    def test_layer_norm_half(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype,
+                                fwd_thresholds=dict(rtol=1e-3, atol=1e-3), bwd_thresholds=dict(rtol=1e-3, atol=1e-3))
+    
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
+        list(product((16,), (True, False), (True,), (False,), (torch.bfloat16,)))
+    )
+    def test_layer_norm_bfloat16(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, 
+                                fwd_thresholds=dict(rtol=1.6e-2, atol=3e-4), bwd_thresholds=dict(rtol=1.6e-2, atol=3e-3))
+
+    # rms norm tests
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
+        list(product((16, 65536), (True, False), (False,), (False,), (torch.float,)))
+    )
+    def test_rms_norm_regular(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype)
+
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
+        list(product((16, 65536), (True, False), (True,), (False,), (torch.float,)))
+    )
+    def test_rms_norm_elemwise(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype,
+                                bwd_thresholds=dict(rtol=2e-3, atol=2e-4))
+
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
+        list(product((16, 65536), (True, False), (True,), (True,), (torch.float,)))
+    )
+    def test_rms_norm_mixed(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype,
+                                bwd_thresholds=dict(rtol=2e-3, atol=2e-4))
+    
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
+        list(product((16,), (True, False), (True,), (False,), (torch.half,)))
+    )
+    def test_rms_norm_half(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype,
+                                bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3))
+    
+    @common_utils.parametrize(
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
+        list(product((16,), (True, False), (True,), (False,), (torch.bfloat16,)))
+    )
+    def test_rms_norm_bfloat16(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, 
+                                fwd_thresholds=dict(rtol=1.6e-2, atol=3e-4), bwd_thresholds=dict(rtol=1.6e-2, atol=3e-2))
+
+
+    @common_utils.parametrize(
+        "dtype, elementwise_affine",
+        list(product(autocast_dtypes, (True, False)))
+    )
+    def test_autocast_fused_layer_norm(self, dtype, elementwise_affine):
+        bf16_fwd_thresholds = dict(rtol=1.6e-2, atol=3e-4)
+        bf16_bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
+        batch_size = 16
+        normalized_shape = [32, 16]
+        native, fused = _prep_layers(normalized_shape, elementwise_affine, dtype)
+        native_x, fused_x = _prep_inputs(batch_size, normalized_shape, dtype)
 
         expected = native(native_x)
         with torch.cuda.amp.autocast(dtype=dtype):
             actual = fused(fused_x)
-        tols = {'rtol': None, 'atol': None} if dtype == torch.half else TestAutocastFusedLayerNorm.bf16_fwd_thresholds
-        torch.testing.assert_allclose(actual, expected, **tols)
+        tols = {'rtol': None, 'atol': None} if dtype == torch.half else bf16_fwd_thresholds
+        # original tests used torch.testing.assert_allclose, which disables dtype checking by default. 
+        # link to issue here: https://github.com/pytorch/pytorch/issues/61844
+        torch.testing.assert_close(actual, expected, **tols, check_dtype=False) 
 
         g_native = torch.rand_like(expected)
         with torch.no_grad():
@@ -255,30 +251,27 @@ class TestAutocastFusedLayerNorm(unittest.TestCase):
         expected.backward(g_native)
         actual.backward(g_fused)
 
-        tols = {'rtol': None, 'atol': None} if dtype == torch.half else TestAutocastFusedLayerNorm.bf16_bwd_thresholds
-        torch.testing.assert_allclose(native_x.grad, fused_x.grad, **tols)
+        tols = {'rtol': None, 'atol': None} if dtype == torch.half else bf16_bwd_thresholds
+        torch.testing.assert_close(native_x.grad, fused_x.grad, **tols, check_dtype=False)
 
-    def test_autocast(self):
-        for (dtype, elementwise_affine) in itertools.product(autocast_dtypes, (True, False)):
-            self._run_test(dtype, elementwise_affine)
 
-class TestAutocastFusedRMSNorm(unittest.TestCase):
-    bf16_fwd_thresholds = dict(rtol=1.6e-2, atol=3e-4)
-    bf16_bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
-
-    def setUp(self):
-        self.batch_size = 16
-        self.normalized_shape = [32, 16]
-
-    def _run_test(self, dtype, elementwise_affine):
-        native, fused = _prep_rms_layers(self.normalized_shape, elementwise_affine, dtype)
-        native_x, fused_x = _prep_inputs(self.batch_size, self.normalized_shape, dtype)
+    @common_utils.parametrize(
+        "dtype, elementwise_affine",
+        list(product(autocast_dtypes, (True, False)))
+    )
+    def test_autocast_fused_rms_norm(self, dtype, elementwise_affine):
+        bf16_fwd_thresholds = dict(rtol=1.6e-2, atol=3e-4)
+        bf16_bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
+        batch_size = 16
+        normalized_shape = [32, 16]
+        native, fused = _prep_rms_layers(normalized_shape, elementwise_affine, dtype)
+        native_x, fused_x = _prep_inputs(batch_size, normalized_shape, dtype)
 
         expected = native(native_x.cpu())
         with torch.cuda.amp.autocast(dtype=dtype):
             actual = fused(fused_x)
-        tols = {'rtol': None, 'atol': None} if dtype == torch.half else TestAutocastFusedRMSNorm.bf16_fwd_thresholds
-        torch.testing.assert_allclose(actual, expected.detach().clone().cuda(), **tols)
+        tols = {'rtol': None, 'atol': None} if dtype == torch.half else bf16_fwd_thresholds
+        torch.testing.assert_close(actual, expected.detach().clone().cuda(), **tols, check_dtype=False)
 
         g_native = torch.rand_like(expected)
         with torch.no_grad():
@@ -286,13 +279,11 @@ class TestAutocastFusedRMSNorm(unittest.TestCase):
         expected.backward(g_native)
         actual.backward(g_fused)
 
-        tols = {'rtol': None, 'atol': None} if dtype == torch.half else TestAutocastFusedRMSNorm.bf16_bwd_thresholds
-        torch.testing.assert_allclose(native_x.grad.cuda(), fused_x.grad, **tols)
+        tols = {'rtol': 1e-3, 'atol': 1e-3} if dtype == torch.half else bf16_bwd_thresholds
+        torch.testing.assert_close(native_x.grad.cuda(), fused_x.grad, **tols, check_dtype=False)
 
-    def test_autocast(self):
-        for (dtype, elementwise_affine) in itertools.product(autocast_dtypes, (True, False)):
-            self._run_test(dtype, elementwise_affine)
 
+instantiate_device_type_tests(TestFusedLayerNorm, globals(), only_for=("cuda",))
 
 if __name__ == "__main__":
-    unittest.main()
+    common_utils.run_tests()


### PR DESCRIPTION
Use parametrize and instantiate_device_type_tests to make tests cleaner.
Update torch.testing.assert_allclose to torch.testing.assert_close according to https://github.com/pytorch/pytorch/issues/61844. 