### PR TITLE
update fused_dense to use torch.autocast instead of apex amp

### DIFF
--- a/apex/contrib/test/fused_dense/test_fused_dense.py
+++ b/apex/contrib/test/fused_dense/test_fused_dense.py
@@ -1,6 +1,7 @@
 import unittest
-import torch
 import os
+
+import torch
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
@@ -24,7 +25,7 @@ class FusedDenseTest(common_utils.TestCase):
         hidden_dim = 1024
 
         ref_inputs = torch.randn(sequences*seq_length, hidden_dim,
-                                 dtype=dtype, device=torch.device("cuda")).int().to(dtype=dtype).requires_grad_(True)
+                                 dtype=dtype, device=torch.device("cuda")).requires_grad_(True)
 
         tst_inputs = ref_inputs.clone().detach().requires_grad_(True)
         dense = fused_dense.FusedDense(1024, 3072)

--- a/apex/contrib/test/fused_dense/test_fused_dense.py
+++ b/apex/contrib/test/fused_dense/test_fused_dense.py
@@ -1,6 +1,8 @@
 import unittest
-
 import torch
+import os
+from torch.testing._internal import common_utils
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
 SKIP_TEST = None
 try:
@@ -10,39 +12,50 @@ except ImportError as e:
 
 
 @unittest.skipIf(SKIP_TEST, f"{SKIP_TEST}")
-class FusedDenseTest(unittest.TestCase):
-    def setUp(self, seed=0):
+class FusedDenseTest(common_utils.TestCase):
+
+    def _test_fused_dense(self, dtype, seed=0):
+
+        os.environ["TORCH_ALLOW_TF32_CUBLAS_OVERRIDE"] = "0"
         torch.manual_seed(seed)
 
-        self.seq_length   = 512
-        self.sequences    = 3
-        self.hidden_dim   = 1024
+        seq_length = 512
+        sequences = 3
+        hidden_dim = 1024
 
-        self.ref_inputs = torch.randn(self.sequences*self.seq_length, self.hidden_dim,
-                                      dtype=torch.float16, device=torch.device("cuda")).int().half().requires_grad_(True)
+        ref_inputs = torch.randn(sequences*seq_length, hidden_dim,
+                                 dtype=dtype, device=torch.device("cuda")).int().to(dtype=dtype).requires_grad_(True)
 
-        self.tst_inputs = self.ref_inputs.clone().detach().requires_grad_(True)
-        self.dense = fused_dense.FusedDense(1024, 3072)
-        self.dense.half()
-        self.dense.cuda()
+        tst_inputs = ref_inputs.clone().detach().requires_grad_(True)
+        dense = fused_dense.FusedDense(1024, 3072)
+        dense.to(dtype=dtype)
+        dense.cuda()
 
-
-    def test_fused_dense(self) :
-        y_tst = self.dense(self.tst_inputs)
-        y_ref = torch.matmul(self.ref_inputs,self.dense.weight.t())+self.dense.bias
-        dy = torch.randn_like(y_tst).half()
+        y_tst = dense(tst_inputs)
+        y_ref = torch.matmul(ref_inputs, dense.weight.t())+dense.bias
+        dy = torch.randn_like(y_tst).to(dtype=dtype)
         y_tst.backward(dy)
-        dw_ref = torch.matmul(dy.t(), self.ref_inputs)
-        dx_ref = torch.matmul(dy, self.dense.weight.clone())
+        dw_ref = torch.matmul(dy.t(), ref_inputs)
+        dx_ref = torch.matmul(dy, dense.weight.clone())
         db_ref = dy.sum(0, False)
 
+        torch.testing.assert_close(
+            ref_inputs,  tst_inputs,  atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(
+            y_ref,  y_tst,  atol=1e-3, rtol=1e-3, equal_nan=True)
+        torch.testing.assert_close(
+            dw_ref, dense.weight.grad, atol=1e-3, rtol=1e-3, equal_nan=True)
+        torch.testing.assert_close(
+            dx_ref, tst_inputs.grad, atol=1e-3, rtol=1e-3, equal_nan=True)
+        torch.testing.assert_close(
+            db_ref, dense.bias.grad, atol=1e-3, rtol=1e-3, equal_nan=True)
 
-        self.assertTrue(torch.allclose(self.ref_inputs,  self.tst_inputs,  atol=1e-5, rtol=1e-5))
-        self.assertTrue(torch.allclose(y_ref,  y_tst,  atol=1e-3, rtol=1e-3, equal_nan=True))
-        self.assertTrue(torch.allclose(dw_ref, self.dense.weight.grad, atol=1e-3, rtol=1e-3, equal_nan=True))
-        self.assertTrue(torch.allclose(dx_ref, self.tst_inputs.grad, atol=1e-3, rtol=1e-3, equal_nan=True))
-        self.assertTrue(torch.allclose(db_ref, self.dense.bias.grad, atol=1e-3, rtol=1e-3, equal_nan=True))
+    @common_utils.parametrize("dtype", [torch.half, torch.float])
+    def test_fused_dense(self, dtype):
+        self._test_fused_dense(dtype)
 
 
-if __name__ == '__main__':
-    unittest.main()
+instantiate_device_type_tests(FusedDenseTest, globals(), only_for=("cuda",))
+
+if __name__ == "__main__":
+    common_utils.run_tests()

--- a/apex/fused_dense/fused_dense.py
+++ b/apex/fused_dense/fused_dense.py
@@ -92,5 +92,4 @@ class FusedDenseGeluDense(nn.Module):
         self.bias2 = nn.Parameter(torch.Tensor(out_features))
 
     def forward(self, input):
-        device_type = 'cuda' if torch.cuda.is_available() else 'cpu'
         return _fused_dense_gelu_dense(input, self.weight1, self.bias1, self.weight2, self.bias2)


### PR DESCRIPTION
Remove last references to apex amp and replace with torch.autocast, since apex amp is being deprecated according to this issue: https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=3781071&cmtNo=