### PR TITLE
check `CUDA_HOME` before using it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ if not torch.cuda.is_available():
         "If you wish to cross-compile for a single specific architecture,\n"
         'export TORCH_CUDA_ARCH_LIST="compute capability" before running setup.py.\n',
     )
-    if os.environ.get("TORCH_CUDA_ARCH_LIST", None) is None:
+    if os.environ.get("TORCH_CUDA_ARCH_LIST", None) is None and CUDA_HOME is not None:
         _, bare_metal_major, bare_metal_minor = get_cuda_bare_metal_version(CUDA_HOME)
         if int(bare_metal_major) == 11:
             os.environ["TORCH_CUDA_ARCH_LIST"] = "6.0;6.1;6.2;7.0;7.5;8.0"


### PR DESCRIPTION
Related: #1498

I verified this by

```
$ docker run -it pytorch/pytorch:1.12.1-cuda11.3-cudnn8-runtime /bin/bash
<install vim & git>
$ git clone https://github.com/crcrpar/apex -b check_cuda_home_var
$ cd apex
< modify setup.py so that CUDA_HOME is None>
$ root@mkozuki-desktop:/workspace/apex# pip install -v -e .
Using pip 22.1.2 from /opt/conda/lib/python3.7/site-packages/pip (python 3.7)
Obtaining file:///workspace/apex
  Running command python setup.py egg_info
  CUDA_HOME: None

  Warning: Torch did not find available GPUs on this system.
   If your intention is to cross-compile, this is not an error.
  By default, Apex will cross-compile for Pascal (compute capabilities 6.0, 6.1, 6.2),
  Volta (compute capability 7.0), Turing (compute capability 7.5),
  and, if the CUDA version is >= 11.0, Ampere (compute capability 8.0).
  If you wish to cross-compile for a single specific architecture,
  export TORCH_CUDA_ARCH_LIST="compute capability" before running setup.py.



  torch.__version__  = 1.12.1


  running egg_info
  creating /tmp/pip-pip-egg-info-evcs6qcb/apex.egg-info
  writing /tmp/pip-pip-egg-info-evcs6qcb/apex.egg-info/PKG-INFO
  writing dependency_links to /tmp/pip-pip-egg-info-evcs6qcb/apex.egg-info/dependency_links.txt
  writing top-level names to /tmp/pip-pip-egg-info-evcs6qcb/apex.egg-info/top_level.txt
  writing manifest file '/tmp/pip-pip-egg-info-evcs6qcb/apex.egg-info/SOURCES.txt'
  reading manifest file '/tmp/pip-pip-egg-info-evcs6qcb/apex.egg-info/SOURCES.txt'
  adding license file 'LICENSE'
  writing manifest file '/tmp/pip-pip-egg-info-evcs6qcb/apex.egg-info/SOURCES.txt'
  Preparing metadata (setup.py) ... done

```