### PR TITLE
Ability to handle varying batch sizes

### DIFF
--- a/apex/transformer/pipeline_parallel/p2p_communication.py
+++ b/apex/transformer/pipeline_parallel/p2p_communication.py
@@ -267,8 +267,10 @@ def _communicate(
                 torch.cuda.synchronize()
             tensor_recv_next_waitfunc = tensor_recv_next_wait
     else:
-        # To protect against race condition when using batch_isend_irecv().
-        torch.cuda.synchronize()
+        # Need to identify if its last batch (Multiple ways to do this)
+        if not last_batch:
+            # To protect against race condition when using batch_isend_irecv().
+            torch.cuda.synchronize()
 
     # If using scatter-gather optimization, gather smaller chunks.
     if scatter_gather_optimization_doable:

--- a/apex/transformer/pipeline_parallel/schedules/common.py
+++ b/apex/transformer/pipeline_parallel/schedules/common.py
@@ -292,6 +292,14 @@ def forward_step(
     input_tensor = [inp.get() if isinstance(inp, FutureTensor) else inp for inp in input_tensor]
 
     unwrapped_model.set_input_tensor(input_tensor)
+
+    # Sometimes we might have empty batches . 
+    # E.g num_samples = 12, global_batch_size = 8, micro_batch_size = 4
+    # The second micro batch of the second global batch will be empty. 
+    # NOTE : the forward_step_func() below can handle varying batch sizes, but cant handle 0. 
+    number_of_input_examples = batch[0].shape()[0]
+    if number_of_input_examples == 0:
+        return
     with torch.cuda.amp.autocast(
         enabled=not disable_autocast and dtype in (torch.half, torch.bfloat16),
         dtype=dtype,

--- a/apex/transformer/pipeline_parallel/utils.py
+++ b/apex/transformer/pipeline_parallel/utils.py
@@ -133,7 +133,9 @@ def get_kth_microbatch(batch: Optional[List[torch.Tensor]], k: int) -> List[torc
     microbatch = list()
     for x in batch:
         size = x.size(0)
-        assert size > start and size >= end
+        #(Even if indices are not within bounds sublisting will work). 
+        # When microbatch size is smaller than expected this assert throws error. 
+        #assert size > start and size >= end  
         microbatch.append(x[start:end])
     assert len(microbatch) > 0
     return microbatch


### PR DESCRIPTION
ML Perf wants to be able to run validation on entire dataset including last partial batch. (drop_last=False)
Pytorch lightning natively supports running the model on different batch sizes. Nemo supports producing all the batches (including the last partial batch)
E.g Number of samples = 100, Global Batch size = 8, Micro batch size = 4 => Nemo will create 12 global batches of size 8, and one global batch of size 4. Pytorch lightning can also handle passing in these different batch sizes. So the idea is to fix the apex code to be able to handle this. 
**For tensor parallelism alone the fix is very straight forward.**
-> Remove assert statement in utils.py so that it can return smaller batches in get_kth_microbatch() function
-> In case a full microbatch is empty we just return and not call the model
**For pipeline parallelism the fix is more involved**
-> We need to make sure we dont run synchronize if we are in the last batch (From my local testing with 2 gpus, 1 gpu exits and goes to validation_epoch_end function, while the other is trying to synchornize(). So it gets stuck)
-> We need to make sure we are able to modify the second element of send and receive tensor shape to be able to adjust to the varying batch size. 

**NOTE : My current implementation is just to show the changes and not exactly the working solution.** 