### PR TITLE
optimize mask generator for n:m sparsity and fix a bug

### DIFF
--- a/apex/contrib/sparsity/sparse_masklib.py
+++ b/apex/contrib/sparsity/sparse_masklib.py
@@ -2,7 +2,7 @@ import sys
 import torch
 import numpy as np
 import collections
-from itertools import permutations
+from itertools import permutations, combinations
 
 
 """ compute density (helper fn to compute % NNZs in a tensor) """
@@ -27,9 +27,12 @@ def compute_valid_1d_patterns(m,n):
     global valid_m4n2_1d_patterns
 
     if m==4  and n==2 and valid_m4n2_1d_patterns  is not None: return valid_m4n2_1d_patterns
-    patterns = torch.zeros(m)
-    patterns[:n] = 1
-    valid_patterns = torch.Tensor(list(set(permutations(patterns.tolist()))))
+    valid_patterns = []
+    for i in list(combinations(range(0, m), n)):
+        cur_pattern = np.zeros(m, dtype=np.int32)
+        cur_pattern[list(i)] = 1
+        valid_patterns.append(cur_pattern)
+    valid_patterns = torch.Tensor(valid_patterns)
     if m == 4  and n == 2: valid_m4n2_1d_patterns  = valid_patterns       
     return valid_patterns
 

--- a/apex/contrib/sparsity/sparse_masklib.py
+++ b/apex/contrib/sparsity/sparse_masklib.py
@@ -96,7 +96,7 @@ def mn_2d_greedy(matrix, m, n):
                 rowCounter[currMatrixEntry[0]] += 1
                 colCounter[currMatrixEntry[1]] += 1
 
-    return torch.tensor(mask.cuda())
+    return torch.tensor(mask).cuda()
 
 def m4n2_2d_greedy(mat, density):
     return mn_2d_greedy(mat, 4, 2)


### PR DESCRIPTION
1. First thing of this pr, optimize mask generator:

for m:n 1-d sparsity, we first need to get a mask list, the original implementation take permutation and set to get the list:

```python
""" return all possible m:n patterns in a 1d vector """
valid_m4n2_1d_patterns = None
def compute_valid_1d_patterns(m,n):
    # Early exit if patterns was already created.
    global valid_m4n2_1d_patterns

    if m==4  and n==2 and valid_m4n2_1d_patterns  is not None: return valid_m4n2_1d_patterns
    patterns = torch.zeros(m)
    patterns[:n] = 1
    valid_patterns = torch.Tensor(list(set(permutations(patterns.tolist()))))
    if m == 4  and n == 2: valid_m4n2_1d_patterns  = valid_patterns       
    return valid_patterns
```

How ever, the algorithm complexity of the permutation is m!, when I take m=16, we need to generate 16!=20 922 789 888 000 candidate first, which is unreachable, so I re-design the algrithim, which reduce the complexity to m^2, then we can do best mask at n:m sparsity with big m.

```python
""" return all possible m:n patterns in a 1d vector """
valid_m4n2_1d_patterns = None
def compute_valid_1d_patterns(m,n):
    # Early exit if patterns was already created.
    global valid_m4n2_1d_patterns

    if m==4  and n==2 and valid_m4n2_1d_patterns  is not None: return valid_m4n2_1d_patterns
    valid_patterns = []
    for i in list(combinations(range(0, m), n)):
        cur_pattern = np.zeros(m, dtype=np.int32)
        cur_pattern[list(i)] = 1
        valid_patterns.append(cur_pattern)
    valid_patterns = torch.Tensor(valid_patterns)
    if m == 4  and n == 2: valid_m4n2_1d_patterns  = valid_patterns       
    return valid_patterns
```

2. Fix a bug

```python
""" m:n 2d structured pruning: greedy method to select mask """
def mn_2d_greedy(matrix, m, n):
    # Convert to numpy
    mat = matrix.cpu().detach().numpy()
    mask = np.ones(mat.shape, dtype=int)

    rowCount = int(mat.shape[0]/m) * m
    colCount = int(mat.shape[1]/m) * m
    for rowStartIdx in range(0, rowCount, m):
        rowEndIdx = rowStartIdx + m
        for colStartIdx in range(0, colCount, m):
            colEndIdx = colStartIdx + m
            matrixSub = np.absolute(np.squeeze(mat[rowStartIdx:rowEndIdx, colStartIdx:colEndIdx]))
            maskSub = np.squeeze(mask[rowStartIdx:rowEndIdx, colStartIdx:colEndIdx])
            maskSub.fill(0.0)
            matrixVecView = matrixSub.reshape(-1)
            maskVecView   = maskSub.reshape(-1)
            linearIdx = np.argsort(matrixVecView)
            matrixIdx = [(int(x/m), x % m) for x in linearIdx]
            rowCounter = collections.Counter()
            colCounter = collections.Counter()
            for currIdx in range(len(linearIdx) - 1, -1, -1):
                currMatrixEntry = matrixIdx[currIdx]
                if (rowCounter[currMatrixEntry[0]] == n) or (colCounter[currMatrixEntry[1]] == n):
                    continue
                #end if
                maskSub[currMatrixEntry[0], currMatrixEntry[1]] = 1.0
                rowCounter[currMatrixEntry[0]] += 1
                colCounter[currMatrixEntry[1]] += 1

    return torch.tensor(mask.cuda())
```

the last line shoule be `torch.tensor(mask).cuda()` otherwise an exception will be thrown (ndarray do not have attribute named cuda).