### PR TITLE
Empty CUDA cache in transformer unit tests

### DIFF
--- a/apex/transformer/testing/distributed_test_base.py
+++ b/apex/transformer/testing/distributed_test_base.py
@@ -35,6 +35,7 @@ class DistributedTestBase(common_distributed.MultiProcessTestCase):
         self._spawn_processes()
 
     def tearDown(self) -> None:
+        torch.cuda.empty_cache()
         super().tearDown()
 
     @property

--- a/tests/L0/run_transformer/test_batch_sampler.py
+++ b/tests/L0/run_transformer/test_batch_sampler.py
@@ -77,6 +77,10 @@ class MegatronPretrainingRandomSampler:
 # Samples 8 tensors in total.
 # First sample 4 tensors twice, then sample 2 tensors fourth.
 class TestBatchSamplerBehavior(common_utils.TestCase):
+    def tearDown(self) -> None:
+        torch.cuda.empty_cache()
+        super().tearDown()
+
     def test_batch_sampler_behavior(self):
         dataset = MyIterableDataset(0, 100)
 

--- a/tests/L0/run_transformer/test_fused_softmax.py
+++ b/tests/L0/run_transformer/test_fused_softmax.py
@@ -57,6 +57,10 @@ class TestFusedScaleMaskSoftmax(common_utils.TestCase):
         )
         return fused_fn, torch_fn
 
+    def tearDown(self) -> None:
+        torch.cuda.empty_cache()
+        super().tearDown()
+
     def test_fused_scale_mask_softmax(self):
         """
         attention_scores.shape = [4, 12, 24, 24]
@@ -244,6 +248,10 @@ class TestGenericFusedSoftmaxKernel(common_utils.TestCase):
             klen.extend([2048, 3123, 4096, 4128, 7234, 8192])
 
         self.q_k_lens = itertools.product(qlen, klen)
+
+    def tearDown(self) -> None:
+        torch.cuda.empty_cache()
+        super().tearDown()
 
     def test_forward(self, allmasked: bool=False):
         import generic_scaled_masked_softmax_cuda


### PR DESCRIPTION
Fixes an OOM issue when running `TORCH_ALLOW_TF32_CUBLAS_OVERRIDE=0 python /opt/pytorch/apex/tests/L0/run_test.py --include run_transformer` on A100x8.

Because `run_test.py` runs all test as a unified suite of all the tests in `run_transformer`. 
https://github.com/NVIDIA/apex/blob/806f9b0f6e321e105029a45f5cbab95f1d6d6434/tests/L0/run_test.py#L82
PyTorch uses the same CUDA cache in most of these tests and the amount of cached memory increases.

But why OOM failure is this happening on A100x8 (cards with the largest memory)? Because `test_fused_softmax` allocates a large amount of memory if a GPU has more than 40GB available:
https://github.com/NVIDIA/apex/blob/806f9b0f6e321e105029a45f5cbab95f1d6d6434/tests/L0/run_transformer/test_fused_softmax.py#L241-L244

The solution is to clear CUDA cache in `TearDown ` to prevent OOM.