### PR TITLE
Fix bug with grad clipping and distributed Adam

### DIFF
--- a/apex/transformer/amp/grad_scaler.py
+++ b/apex/transformer/amp/grad_scaler.py
@@ -35,6 +35,12 @@ class GradScaler(torch.cuda.amp.GradScaler):
             enabled=enabled,
         )
 
+    def _unscale_grads_(self, optimizer, *args):
+        if getattr(optimizer, "_custom_amp_unscale_grads", False):
+            return optimizer.unscale_grads(*args)
+        else:
+            return super()._unscale_grads_(optimizer, *args)
+
     def _maybe_opt_step(self, optimizer, optimizer_state, *args, **kwargs):
         retval = None
         found_inf = torch.cuda.FloatTensor([sum(v.item() for v in optimizer_state["found_inf_per_device"].values())])


### PR DESCRIPTION
I've gotten incorrect results using distributed Adam to train GPT-3 at FP16 because of a bug with gradient clipping and gradient scaling. In particular, there's an incorrect assumption that gradient clipping is applied before the gradients are unscaled, which results in extremely small gradients. The fix simply requires gradient clipping to handle the case where [`DistributedFusedAdam._grad_scale`](https://github.com/NVIDIA/apex/blob/2c3b8f9a0808e4c931a84def706885ff1d33e5f7/apex/contrib/optimizers/distributed_fused_adam.py#L436) != 1.0. Note that [`torch.cuda.amp.GradScaler.unscale_`](https://pytorch.org/docs/stable/amp.html#torch.cuda.amp.GradScaler.unscale_) does not natively support the distributed optimizer, so I have to unscale by directly manipulating `DistributedFusedAdam._grad_scale`.

While I was touching the code, I've also adopted some recommendations from @erhoo82:
- Avoid unnecessarily zeroing out GPU buffers.
- Use communication functions ([`reduce_scatter_tensor`](https://github.com/pytorch/pytorch/blob/f451e824f39516f503c2bdfd785d254b447b9557/torch/distributed/distributed_c10d.py#L2742) and [`all_gather_into_tensor`](https://github.com/pytorch/pytorch/blob/f451e824f39516f503c2bdfd785d254b447b9557/torch/distributed/distributed_c10d.py#L2274)) that do not allocate internal memory.