### PR TITLE
Support overlapped grad sync with Megatron interleaved pipeline parallelism

### DIFF
--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -492,7 +492,6 @@ class NcclPipelineParallelWithToyParallelMLP(NcclDistributedTestBase):
         self._forward_backward_test_impl(forward_only=False, sequence_parallel_enabled=True, model_type=ModelType.encoder_or_decoder, dtype=torch.half)
 
 
-@unittest.skipIf(torch.cuda.device_count() < 4 or torch.cuda.device_count() % 2 != 0, "Requires >= 4 GPUs")
 class NcclPipelineParallelWithCustomSyncContextHandler(NcclDistributedTestBase):
 
     GLOBAL_BATCH_SIZE = 32
@@ -503,19 +502,118 @@ class NcclPipelineParallelWithCustomSyncContextHandler(NcclDistributedTestBase):
     def world_size(self) -> int:
         return min(torch.cuda.device_count(), 8)
 
-    def _forward_backward_test_impl(
-        self,
-        fwd_bwd_func: FwdStepFunc,
-    ) -> None:
+    @unittest.skipIf(torch.cuda.device_count() < 2 or torch.cuda.device_count() % 2 != 0, "Requires >= 2 GPUs")
+    def test_pipelining_without_interleaving_with_custom_sync_context_handler(self) -> None:
 
         # Parallel configuration
         world_size = torch.cuda.device_count()
         tensor_model_parallel_world_size = 1
-        data_parallel_size = 2
+        data_parallel_size = 2 if world_size > 2 else 1
         pipeline_model_parallel_world_size = world_size // data_parallel_size
-        virtual_pipeline_model_parallel_size = None
-        if fwd_bwd_func == _forward_backward_pipelining_with_interleaving:
-            virtual_pipeline_model_parallel_size = 2
+
+        # Initialize pipeline parallelism
+        parallel_state.initialize_model_parallel(
+            tensor_model_parallel_size_=tensor_model_parallel_world_size,
+            pipeline_model_parallel_size_=pipeline_model_parallel_world_size,
+        )
+        pp_utils._reconfigure_microbatch_calculator(
+            rank=parallel_state.get_tensor_model_parallel_rank(),
+            rampup_batch_size=None,
+            global_batch_size=self.GLOBAL_BATCH_SIZE,
+            micro_batch_size=self.MICRO_BATCH_SIZE,
+            data_parallel_size=parallel_state.get_data_parallel_world_size(),
+        )
+        pp_utils.update_num_microbatches(0)
+
+        # Construct synthetic data
+        dtype = get_dtype_for_comparison()
+        hidden_size = self.HIDDEN_SIZE
+        microbatch_size = self.MICRO_BATCH_SIZE
+        global_batch_shape = (
+            self.GLOBAL_BATCH_SIZE
+            // parallel_state.get_data_parallel_world_size(),
+            hidden_size,
+            hidden_size,
+        )
+        batch = None
+        if parallel_state.is_pipeline_first_stage():
+            batch = (torch.ones(global_batch_shape, dtype=dtype).cuda(), )
+
+        # Construct model
+        model = build_model(
+            testing_utils.model_provider_func,
+            wrap_with_ddp=True,
+            hidden_size=hidden_size,
+        )[0]
+        model = model.to(dtype)
+        model.module.apply(get_init_weights_func(0))
+
+        # Construct context that destroys all grads on exit
+        has_entered_grad_sync_context = False
+        has_exited_grad_sync_context = False
+        has_called_grad_sync_func = False
+        @contextlib.contextmanager
+        def custom_grad_sync_context():
+            try:
+                nonlocal has_entered_grad_sync_context
+                has_entered_grad_sync_context = True
+                yield
+            finally:
+                nonlocal has_exited_grad_sync_context
+                has_exited_grad_sync_context = True
+                for param in model.parameters():
+                    param.grad = None
+        def custom_grad_sync_func():
+            nonlocal has_called_grad_sync_func
+            has_called_grad_sync_func = True
+
+        # Training step with pipeline parallelism
+        loss = forward_backward_pipelining_without_interleaving(
+            testing_utils.fwd_step_func,
+            batch,
+            model,
+            forward_only=False,
+            tensor_shape=(microbatch_size, hidden_size, hidden_size),
+            dtype=dtype,
+            async_comm=False,
+            grad_scaler=None,
+            deallocate_pipeline_outputs=False,
+            sequence_parallel_enabled=False,
+            custom_sync_context_handler=custom_grad_sync_context,
+            custom_grad_sync_func=custom_grad_sync_func,
+        )
+        torch.cuda.synchronize()
+
+        # Check if model has initialized gradients
+        has_any_grads = any(param.grad is not None for param in model.parameters())
+        has_all_grads = all(param.grad is not None for param in model.parameters())
+
+        # Check context behavior
+        self.assertTrue(has_entered_grad_sync_context, 'Has not entered custom sync context')
+        self.assertTrue(has_exited_grad_sync_context, 'Has not exited custom sync context')
+        self.assertEqual(
+            has_any_grads,
+            has_all_grads,
+            'Expected gradients to all be uninitialized or all be initialized',
+        )
+        self.assertEqual(
+            has_all_grads,
+            parallel_state.is_pipeline_first_stage(),
+            'Expected gradients to be initialized only in first pipeline stage',
+        )
+
+        # Clean up
+        parallel_state.destroy_model_parallel()
+
+    @unittest.skipIf(torch.cuda.device_count() < 4 or torch.cuda.device_count() % 2 != 0, "Requires >= 4 GPUs")
+    def test_pipelining_with_interleaving_with_custom_sync_context_handler(self) -> None:
+
+        # Parallel configuration
+        world_size = torch.cuda.device_count()
+        tensor_model_parallel_world_size = 1
+        data_parallel_size = 2 if world_size > 4 else 1
+        pipeline_model_parallel_world_size = world_size // data_parallel_size
+        virtual_pipeline_model_parallel_size = 2
 
         # Initialize pipeline parallelism
         parallel_state.initialize_model_parallel(
@@ -553,37 +651,28 @@ class NcclPipelineParallelWithCustomSyncContextHandler(NcclDistributedTestBase):
             virtual_pipeline_model_parallel_size=virtual_pipeline_model_parallel_size,
             hidden_size=hidden_size,
         )
-        if fwd_bwd_func == forward_backward_pipelining_without_interleaving:
-            model = model[0]
-            model = model.to(dtype)
-            model.module.apply(get_init_weights_func(0))
-        elif fwd_bwd_func == _forward_backward_pipelining_with_interleaving:
-            for module in model:
-                module.to(dtype)
-                module.module.apply(get_init_weights_func(0))
+        for module in model:
+            module.to(dtype)
+            module.module.apply(get_init_weights_func(0))
 
-        # Construct custom context that destroys all grads on exit
-        has_entered_context = False
-        has_exited_context = False
+        # Construct context that keeps track whenever entered/exited
+        grad_sync_context_enter_count = 0
+        grad_sync_context_exit_count = 0
         @contextlib.contextmanager
-        def custom_context():
+        def custom_grad_sync_context():
             try:
-                nonlocal has_entered_context
-                has_entered_context = True
+                nonlocal grad_sync_context_enter_count
+                grad_sync_context_enter_count += 1
                 yield
             finally:
-                nonlocal has_exited_context
-                has_exited_context = True
-                if isinstance(model, list):
-                    for module in model:
-                        for param in module.parameters():
-                            param.grad = None
-                else:
-                    for param in model.parameters():
+                nonlocal grad_sync_context_exit_count
+                grad_sync_context_exit_count += 1
+                for module in model:
+                    for param in module.parameters():
                         param.grad = None
 
         # Training step with pipeline parallelism
-        loss = fwd_bwd_func(
+        loss = _forward_backward_pipelining_with_interleaving(
             testing_utils.fwd_step_func,
             batch,
             model,
@@ -594,43 +683,31 @@ class NcclPipelineParallelWithCustomSyncContextHandler(NcclDistributedTestBase):
             grad_scaler=None,
             deallocate_pipeline_outputs=False,
             sequence_parallel_enabled=False,
-            custom_sync_context_handler=custom_context,
+            custom_sync_context_handler=custom_grad_sync_context,
         )
         torch.cuda.synchronize()
 
-        # Check if model has initialized gradients
-        if isinstance(model, list):
-            has_grads = any(
-                any(param.grad is not None for param in module.parameters())
-                for module in model
-            )
-        else:
-            has_grads = any(param.grad is not None for param in model.parameters())
-
         # Check context behavior
-        self.assertTrue(has_entered_context, 'Has not entered custom sync context')
-        self.assertTrue(has_exited_context, 'Has not exited custom sync context')
+        self.assertTrue(
+            grad_sync_context_enter_count > 0,
+            'Has not entered custom sync context',
+        )
         self.assertEqual(
-            has_grads,
-            parallel_state.is_pipeline_first_stage(),
-            'Expected to exit custom sync context '
-            'before last backward pass in first pipeline stage '
-            'and after all backward passes in other pipeline stages'
+            grad_sync_context_enter_count,
+            grad_sync_context_exit_count,
+            'Has not entered and exited custom sync context '
+            'the same number of times',
+        )
+        self.assertEqual(
+            grad_sync_context_exit_count,
+            virtual_pipeline_model_parallel_size + 1,
+            'Expected to exit custom sync context once per model chunk '
+            'and once at the function end',
         )
 
         # Clean up
         parallel_state.destroy_model_parallel()
 
-    def test_pipelining_without_interleaving_with_custom_sync_context_handler(self) -> None:
-        self._forward_backward_test_impl(
-            fwd_bwd_func=forward_backward_pipelining_without_interleaving,
-        )
-
-    @unittest.skipIf(torch.cuda.device_count() < 8 or torch.cuda.device_count() % 2 != 0, "Requires >= 8 GPUs")
-    def test_pipelining_with_interleaving_with_custom_sync_context_handler(self) -> None:
-        self._forward_backward_test_impl(
-            fwd_bwd_func=_forward_backward_pipelining_with_interleaving,
-        )
 
 if __name__ == "__main__":
     common_utils.run_tests()


### PR DESCRIPTION
This PR makes similar changes as https://github.com/NVIDIA/apex/pull/1475. In particular, it provides an option to pass a custom `no_sync` context into [`apex.transformer.pipeline_parallel.schedules.fwd_bwd_pipelining_with_interleaving._forward_backward_pipelining_with_interleaving`](https://github.com/NVIDIA/apex/blob/2c3b8f9a0808e4c931a84def706885ff1d33e5f7/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_with_interleaving.py#L26). In the first pipeline stage, gradient reductions will be overlapped with the final backward pass. In other pipeline stages, the caller is expected to manually perform gradient reductions (in the bubble overhead).