### PR TITLE
Optimize peer memory halo exchange kernel for latency

### DIFF
--- a/apex/contrib/bottleneck/halo_exchangers.py
+++ b/apex/contrib/bottleneck/halo_exchangers.py
@@ -88,14 +88,24 @@ class HaloExchangerSendRecv(HaloExchanger):
             inc.left_right_halo_exchange_inplace(self.handle, self.left_rank, self.right_rank, left_output_halo, right_output_halo, left_input_halo, right_input_halo)
 
 class HaloExchangerPeer(HaloExchanger):
-    def __init__(self, ranks, rank_in_group, peer_pool, explicit_nhwc, numSM=1):
+    def __init__(self, ranks, rank_in_group, peer_pool, explicit_nhwc, numSM=0):
         super(HaloExchangerPeer, self).__init__(ranks, rank_in_group)
         self.diagnostics = False
         self.explicit_nhwc = explicit_nhwc
         self.numSM = numSM
         self.peer_pool = peer_pool
-        self.signals = peer_pool.allocate_peer_tensors([2,4], torch.int32, False, False)
-        self.signals[self.rank_in_group].zero_()
+
+    def _allocate_peer_tensor(self, halo):
+
+        # Compute size in bytes
+        # Note: Pad buffer so each CUDA block gets required buffer size
+        size = 4 * halo.numel() * halo.element_size()
+        size_per_block = 128 * 2 * 16   # 128 threads each require two 128b buffers
+        size = (size + size_per_block - 1) // size_per_block * size_per_block
+
+        # Construct dtype peer buffer with desired size
+        shape = [1, 1, 1, size // halo.element_size()]
+        return self.peer_pool.allocate_peer_tensors(shape, halo.dtype, False, True)
 
     def left_right_halo_exchange(self, left_output_halo, right_output_halo, left_input_halo=None, right_input_halo=None):
         inplace = False if left_input_halo is None and right_input_halo is None else True
@@ -103,13 +113,12 @@ class HaloExchangerPeer(HaloExchanger):
             left_input_halo = torch.empty_like(right_output_halo)
             right_input_halo = torch.empty_like(left_output_halo)
         channels_last = left_output_halo.is_contiguous(memory_format=torch.channels_last) and not self.explicit_nhwc
-        left_tx = self.peer_pool.allocate_peer_tensors(list(left_output_halo.shape), left_output_halo.dtype, channels_last, True)
-        right_tx = self.peer_pool.allocate_peer_tensors(list(right_output_halo.shape), right_output_halo.dtype, channels_last, True)
+        left_tx = self._allocate_peer_tensor(left_input_halo)
+        right_tx = self._allocate_peer_tensor(right_input_halo)
         pm.push_pull_halos_1d(
-                self.diagnostics, self.explicit_nhwc, self.numSM,
+                self.diagnostics, self.explicit_nhwc, self.numSM, self.rank_in_group,
                 self.left_zero, left_output_halo,  left_tx[self.rank_in_group],  right_tx[self.wrap_around_left_rank_in_group], left_input_halo,
                 self.right_zero, right_output_halo, right_tx[self.rank_in_group], left_tx[self.wrap_around_right_rank_in_group],  right_input_halo,
-                self.signals[self.wrap_around_left_rank_in_group], self.signals[self.wrap_around_right_rank_in_group], self.signals[self.rank_in_group]
                 )
         if not inplace:
             return left_input_halo, right_input_halo

--- a/apex/contrib/csrc/peer_memory/peer_memory_cuda.cu
+++ b/apex/contrib/csrc/peer_memory/peer_memory_cuda.cu
@@ -5,9 +5,7 @@
 #include <cstdio>
 #include <cassert>
 #include <cuda_runtime_api.h>
-#include <cooperative_groups.h>
 #include "nccl.h"
-namespace cg = cooperative_groups;
 
 #define CUDACHECK(cmd) do {                         \
   cudaError_t err = cmd;                            \
@@ -21,6 +19,8 @@ namespace cg = cooperative_groups;
 } while(0)
 
 namespace {
+
+constexpr int THREADS_PER_CTA = 128;
 
 /* Basic deleter function for from_blob function.
 void deleter(void* ptr)
@@ -117,209 +117,195 @@ void tensor_strides(at::Tensor t, bool explicit_nhwc, int& stride_N, int& stride
     }
 }
 
-template<class T> 
-__device__ void __zero(T* dst)
+template<class T>
+inline __device__ void __zero(T* dst)
 {
     *dst = T(0);
 }
 
-__device__ void __zero(int4* dst)
+inline __device__ void __zero(int2* dst)
 {
-    int4 v;
-    v.x = v.y = v.z = v.w = 0;
-    *dst = v;
+    *dst = {0, 0};
 }
 
-template<class T, bool is_HWC, bool zero>
-__device__ void strided_copy_kernel(
-	T* dst, const int dst_stride_C, const int dst_stride_H, const int dst_stride_W, 
-	const T* src, const int src_stride_C, const int src_stride_H, const int src_stride_W, 
-	const int NC, const int NH, const int NW
+template<class T, bool channels_last, bool zero>
+inline __device__ void push_pull_tensor(
+        const T* __restrict__ data_in,
+        const int data_in_stride_C,
+        const int data_in_stride_H,
+        const int data_in_stride_W,
+	T* __restrict__ data_out,
+        const int data_out_stride_C,
+        const int data_out_stride_H,
+        const int data_out_stride_W,
+        int4* local_peer,
+        int4* remote_peer,
+	const int NC,
+        const int NH,
+        const int NW,
+        const int thread_id,
+        const int block_id,
+        const int num_blocks
 	)
 {
-    size_t tot_num_threads = gridDim.x * blockDim.x;
-    size_t thread_id = blockIdx.x * blockDim.x + threadIdx.x;
-    const size_t count = NC*NH*NW;
-    for (size_t i = thread_id;  i < count;  i += tot_num_threads)
-    {
-	size_t c,h,w;
-	if (is_HWC) {
-	    w = i / NC;
-	    c = i - w * NC;
-	    h = w / NW;
-	    w = w - h * NW;
-	}
-	else {
-	    h = i / NW;
-	    w = i - h * NW;
-	    c = h / NH;
-            h = h - c * NH;
-	}
-	size_t dst_off = c*dst_stride_C + h*dst_stride_H + w*dst_stride_W;
-	if (zero) {
-	    __zero(dst+dst_off);
-	} else {
-	    size_t src_off = c*src_stride_C + h*src_stride_H + w*src_stride_W;
-	    dst[dst_off] = src[src_off];
-	}
+    // 128b=16B NVLink flit
+    // Note: Use last 4B as a semaphore
+    static_assert(sizeof(T) <= 12);
+    union Flit {
+        T payload;
+        uint uints[4];
+    };
+    // Communication bit indicates whether flit has been received from
+    // a remote GPU
+    constexpr uint communication_mask = 1 << 0;
+    // Status bit is used to choose the active peer buffer in an
+    // alternating double buffer scheme. We use buffer 1 if the bits
+    // match, use buffer 2 if the bits differ, and invert the bit
+    // after finishing with a buffer.
+    constexpr uint status_mask = 1 << 1;
+
+    // Split peer memory into two sets of buffers
+
+    // Note: Each block owns a THREADS_PER_CTA*2*16B chunk of peer
+    // memory. This chunk
+    const int peer_offset1 = block_id * THREADS_PER_CTA * 2 + thread_id;
+    const int peer_offset2 = peer_offset1 + THREADS_PER_CTA;
+    volatile int* local_peer1 = reinterpret_cast<volatile int*>(local_peer + peer_offset1);
+    volatile int* local_peer2 = reinterpret_cast<volatile int*>(local_peer + peer_offset2);
+    volatile int* remote_peer1 = reinterpret_cast<volatile int*>(remote_peer + peer_offset1);
+    volatile int* remote_peer2 = reinterpret_cast<volatile int*>(remote_peer + peer_offset2);
+
+    // Iterate through tensor entries
+    const int global_id = thread_id + block_id * THREADS_PER_CTA;
+    const int num_threads = num_blocks * THREADS_PER_CTA;
+    const int count = NC*NH*NW;
+    for (int i = global_id; i < count; i += num_threads) {
+        // Calculate buffer positions
+        int c, h, w;
+        if (channels_last) {
+            c = i % NC;
+            const int j = i / NC;
+            w = j % NW;
+            h = j / NW;
+        } else {
+            w = i % NW;
+            const int j = i / NW;
+            h = j % NH;
+            c = j / NH;
+        }
+
+        if (zero) {
+            T* oh = data_out + c*data_out_stride_C + h*data_out_stride_H + w*data_out_stride_W;
+	    __zero(oh);
+        } else {
+            // Data buffer entries
+            const T* ih = data_in + c*data_in_stride_C + h*data_in_stride_H + w*data_in_stride_W;
+            T* oh = data_out + c*data_out_stride_C + h*data_out_stride_H + w*data_out_stride_W;
+
+            // Determine which peer memory buffer to use
+            // Note: The status bit is not affected by asynchronous
+            // communication from the remote GPU.
+            Flit local_message1, local_message2;
+            asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" :
+                         "=r"(local_message1.uints[0]),
+                         "=r"(local_message1.uints[1]),
+                         "=r"(local_message1.uints[2]),
+                         "=r"(local_message1.uints[3])
+                         : "l"(local_peer1) : "memory");
+            asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" :
+                         "=r"(local_message2.uints[0]),
+                         "=r"(local_message2.uints[1]),
+                         "=r"(local_message2.uints[2]),
+                         "=r"(local_message2.uints[3])
+                         : "l"(local_peer2) : "memory");
+            const uint status1 = local_message1.uints[3] & status_mask;
+            const uint status2 = local_message2.uints[3] & status_mask;
+            const bool peer1_is_active = (status1 ^ status2) == 0;
+            volatile int* ox = peer1_is_active ? remote_peer1 : remote_peer2;
+            volatile int* ix = peer1_is_active ? local_peer1 : local_peer2;
+            const uint status = peer1_is_active ? status1 : status2;
+            Flit recv_message = peer1_is_active ? local_message1 : local_message2;
+
+            // Send flit to remote GPU
+            // Note: Set communication bit and keep status bit
+            Flit send_message;
+            send_message.payload = *ih;
+            send_message.uints[3] = communication_mask | status;
+            asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" ::
+                         "l"(ox),
+                         "r"(send_message.uints[0]),
+                         "r"(send_message.uints[1]),
+                         "r"(send_message.uints[2]),
+                         "r"(send_message.uints[3])
+                         : "memory");
+
+            // Recieve flit from peer
+            while ((recv_message.uints[3] & communication_mask) == 0) {
+                asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" :
+                             "=r"(recv_message.uints[0]),
+                             "=r"(recv_message.uints[1]),
+                             "=r"(recv_message.uints[2]),
+                             "=r"(recv_message.uints[3])
+                             : "l"(ix) : "memory");
+            }
+            *oh = recv_message.payload;
+
+            // Reset semaphore
+            // Note: Clear communication bit and invert status bit
+            uint flag = ~status & status_mask;
+            asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" ::
+                         "l"(ix),
+                         "n"(0),
+                         "n"(0),
+                         "n"(0),
+                         "r"(flag)
+                         : "memory");
+            if (i + num_threads < count) {
+                __threadfence_system();
+            }
+        }
     }
 }
 
-template<bool top_zero, bool btm_zero> 
-__device__ void checked_signal(
-	volatile int* signal1_flag, volatile int* signal2_flag,
-	const int v1, const int v2, const int v3, const int v4
-	)
-{
-    cg::this_grid().sync();
-    bool is_main_thread = (blockIdx.x == 0 && threadIdx.x == 0) ? true : false;
-    if (is_main_thread) {
-	// flush all writes to global memory
-	__threadfence_system();
-	// wait for top or bottom neighbor to clear signal
-	register int r1, r2, r3, r4;
-	if (!(top_zero || btm_zero)) {
-	    bool top_zeroed=false, top_done=false;
-	    bool btm_zeroed=false, btm_done=false;
-	    do {
-		do {
-		    if (!top_zeroed) {
-			asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(r1), "=r"(r2), "=r"(r3), "=r"(r4) : "l"(signal1_flag) : "memory");
-			if (r1 != v1 || r2 != v2 || r3 != v3 || r4 != v4) top_zeroed = true;
-		    }
-		    if (!btm_zeroed) {
-			asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(r1), "=r"(r2), "=r"(r3), "=r"(r4) : "l"(signal2_flag) : "memory");
-			if (r1 != v1 || r2 != v2 || r3 != v3 || r4 != v4) btm_zeroed = true;
-		    }
-		} while((top_zeroed == top_done) && (btm_zeroed == btm_done));
-		if (!top_done && top_zeroed) {
-		    // signal to top neighbor my output is ready
-		    asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(signal1_flag), "r"(v1), "r"(v2), "r"(v3), "r"(v4) : "memory");
-		    top_done = true;
-		}
-		if (!btm_done && btm_zeroed) {
-		    // signal to bottom neighbor my output is ready
-		    asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(signal2_flag), "r"(v1), "r"(v2), "r"(v3), "r"(v4) : "memory");
-		    btm_done = true;
-		}
-	    } while (!top_done || !btm_done);
-	} else if (top_zero) {
-	    bool btm_zeroed=false, btm_done=false;
-	    do {
-		do {
-		    if (!btm_zeroed) {
-			asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(r1), "=r"(r2), "=r"(r3), "=r"(r4) : "l"(signal2_flag) : "memory");
-			if (r1 != v1 || r2 != v2 || r3 != v3 || r4 != v4) btm_zeroed = true;
-		    }
-		} while(btm_zeroed == btm_done);
-		if (!btm_done && btm_zeroed) {
-		    // signal to bottom neighbor my output is ready
-		    asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(signal2_flag), "r"(v1), "r"(v2), "r"(v3), "r"(v4) : "memory");
-		    btm_done = true;
-		}
-	    } while (!btm_done);
-
-	} else if (btm_zero) {
-	    bool top_zeroed=false, top_done=false;
-	    do {
-		do {
-		    if (!top_zeroed) {
-			asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(r1), "=r"(r2), "=r"(r3), "=r"(r4) : "l"(signal1_flag) : "memory");
-			if (r1 != v1 || r2 != v2 || r3 != v3 || r4 != v4) top_zeroed = true;
-		    }
-		} while(top_zeroed == top_done);
-		if (!top_done && top_zeroed) {
-		    // signal to top neighbor my output is ready
-		    asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(signal1_flag), "r"(v1), "r"(v2), "r"(v3), "r"(v4) : "memory");
-		    top_done = true;
-		}
-	    } while (!top_done);
-	}
-    }
-}
-
-__device__ void wait_for(
-	volatile int* wait_flag,
-	const int v1, const int v2, const int v3, const int v4
-	)
-{
-    bool is_main_thread = (blockIdx.x == 0 && threadIdx.x == 0) ? true : false;
-    if (is_main_thread) {
-    	register int r1, r2, r3, r4;
-	// wait for senders to signal their output is read
-	do {
-	    asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(r1), "=r"(r2), "=r"(r3), "=r"(r4) : "l"(wait_flag) : "memory");
-	} while (r1 != v1 || r2 != v2 || r3 != v3 || r4 != v4);
-    }
-    cg::this_grid().sync();  // all threads wait for main
-}
-
-
-__device__ void clear_flag(
-	volatile int* wait_flag
-	)
-{
-    cg::this_grid().sync();  // wait for all threads in kernel to finish
-    bool is_main_thread = (blockIdx.x == 0 && threadIdx.x == 0) ? true : false;
-    if (is_main_thread) {
-	register int r1, r2, r3, r4;
-	r1 = 0;  r2 = 0;  r3 = 0;  r4 = 0;
-	asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(wait_flag), "r"(r1), "r"(r2), "r"(r3), "r"(r4) : "memory");
-    }
-}
-
-template<class T, bool is_HWC, bool top_zero, bool btm_zero>
-#if __CUDA_ARCH__ == 700 || __CUDA_ARCH__ == 800 || __CUDA_ARCH__ == 900
-__launch_bounds__(128, 16)
+template<class T, bool channels_last, bool top_zero, bool btm_zero>
+#if __CUDA_ARCH__ >= 700
+__launch_bounds__(THREADS_PER_CTA)
 #endif
 __global__ void push_pull_halos_1d_kernel(
         // top halo,
-        const T* toh, int toh_stride_C, int toh_stride_H, int toh_stride_W,     // top output halo
-        T* tox, int tox_stride_C, int tox_stride_H, int tox_stride_W,           // top output tx buffer
-        T* tix, int tix_stride_C, int tix_stride_H, int tix_stride_W,           // top input tx buffer
-        T* tih, int tih_stride_C, int tih_stride_H, int tih_stride_W,           // top input halo
+        T* toh, int toh_stride_C, int toh_stride_H, int toh_stride_W,           // top output halo (local)
+        const T* tih, int tih_stride_C, int tih_stride_H, int tih_stride_W,     // top input halo (local)
+        int4* tox,                                                              // top output transfer buffer (remote peer)
+        int4* tix,                                                              // top input transfer buffer (local peer)
         // btm halo
-        const T* boh, int boh_stride_C, int boh_stride_H, int boh_stride_W,     // btm output halo
-        T* box, int box_stride_C, int box_stride_H, int box_stride_W,           // btm output tx buffer
-        T* bix, int bix_stride_C, int bix_stride_H, int bix_stride_W,           // btm input tx buffer
-        T* bih, int bih_stride_C, int bih_stride_H, int bih_stride_W,           // btm input halo
+        T* boh, int boh_stride_C, int boh_stride_H, int boh_stride_W,           // btm output halo (local)
+        const T* bih, int bih_stride_C, int bih_stride_H, int bih_stride_W,     // btm input halo (local)
+        int4* box,                                                              // btm output transfer buffer (remote peer)
+        int4* bix,                                                              // btm input transfer buffer (local peer)
         // dimensions
         int NC, int NH, int NW,
-        // signals
-        int* signal1_flag,
-        int* signal2_flag,
-        int* wait1_flag,
-        int* wait2_flag
+        bool top_first                                                          // whether to launch communicate top halo first
         )
 {
-    // push top output halo to transfer buffer
-    if (!top_zero) strided_copy_kernel<T,is_HWC,false>(tox, tox_stride_C, tox_stride_H, tox_stride_W, toh, toh_stride_C, toh_stride_H, toh_stride_W, NC, NH, NW);
-    // push btm output halo to transfer buffer
-    if (!btm_zero) strided_copy_kernel<T,is_HWC,false>(box, box_stride_C, box_stride_H, box_stride_W, boh, boh_stride_C, boh_stride_H, boh_stride_W, NC, NH, NW);
-    // signal to top and btm neigbhbors that output halos are ready to be read
-    // the choice of values for v1-v4 is arbitrary and does not matter, as long as all ranks use the same values
-    if (!(top_zero || btm_zero)) {
-	checked_signal<false,false>(signal1_flag, signal2_flag, -987751720, 840868300, -225529332, 281513358);
-    } else if (top_zero) {
-	checked_signal<true,false>(signal1_flag, signal2_flag, -987751720, 840868300, -225529332, 281513358);
-    } else if (btm_zero) {
-	checked_signal<false,true>(signal1_flag, signal2_flag, -987751720, 840868300, -225529332, 281513358);
-    }
-    // pull top halo from transfer buffer in peer memory to input
-    if (top_zero) {
-	strided_copy_kernel<T,is_HWC,true>(tih, tih_stride_C, tih_stride_H, tih_stride_W, tix, tix_stride_C, tix_stride_H, tix_stride_W, NC, NH, NW);
+    const int num_blocks_side = gridDim.x / 2;
+    const int block_id_side = (blockIdx.x < num_blocks_side
+                               ? blockIdx.x
+                               : blockIdx.x - num_blocks_side);
+    const bool in_top_block = top_first == (blockIdx.x < num_blocks_side);
+    if (in_top_block) {
+        push_pull_tensor<T,channels_last,top_zero>(
+            tih, tih_stride_C, tih_stride_H, tih_stride_W,
+            toh, toh_stride_C, toh_stride_H, toh_stride_W,
+            tix, tox,
+            NC, NH, NW,
+            threadIdx.x, block_id_side, num_blocks_side);
     } else {
-    	wait_for(wait1_flag, -987751720, 840868300, -225529332, 281513358);
-	strided_copy_kernel<T,is_HWC,false>(tih, tih_stride_C, tih_stride_H, tih_stride_W, tix, tix_stride_C, tix_stride_H, tix_stride_W, NC, NH, NW);
-	clear_flag(wait1_flag);
-    }
-    // pull btm halo from transfer buffer in peer memory to input
-    if (btm_zero) {
-	strided_copy_kernel<T,is_HWC,true>(bih, bih_stride_C, bih_stride_H, bih_stride_W, bix, bix_stride_C, bix_stride_H, bix_stride_W, NC, NH, NW);
-    } else {
-	wait_for(wait2_flag, -987751720, 840868300, -225529332, 281513358);
-	strided_copy_kernel<T,is_HWC,false>(bih, bih_stride_C, bih_stride_H, bih_stride_W, bix, bix_stride_C, bix_stride_H, bix_stride_W, NC, NH, NW);
-	clear_flag(wait2_flag);
+        push_pull_tensor<T,channels_last,btm_zero>(
+            bih, bih_stride_C, bih_stride_H, bih_stride_W,
+            boh, boh_stride_C, boh_stride_H, boh_stride_W,
+            bix, box,
+            NC, NH, NW,
+            threadIdx.x, block_id_side, num_blocks_side);
     }
 }
 
@@ -408,223 +394,214 @@ at::Tensor blob_view_int(int64_t raw, std::vector<int64_t> shape, bool channels_
 void push_pull_halos_1d(
 	bool diagnostics,
         bool explicit_nhwc,
-        int numSM,                      // number of SMs to use
-	bool top_zero,			// true if top halo should be zeroed
-        at::Tensor top_out_halo,        // top output halo in sender device memory
-        at::Tensor top_out_tx,          // top output transfer buffer in sender peer pool memory
-	at::Tensor top_inp_tx,		// top input transfer buffer in top neighbor peer pool memory
-        at::Tensor top_inp_halo,        // top input halo in receiver device memory
-	bool btm_zero,			// true if btm halo should be zeroed
-        at::Tensor btm_out_halo,        // btm output halo in sender device memory
-        at::Tensor btm_out_tx,          // btm output transfer buffer in sender peer pool memory
-	at::Tensor btm_inp_tx,		// btm input transfer buffer in btm neighbor peer pool memory
-        at::Tensor btm_inp_halo,        // btm input halo in receiver device memory
-        at::Tensor top_signal,          // top input signal in receiver device memory
-        at::Tensor btm_signal,          // btm input signal in receiver device memory
-        at::Tensor waits                // top and btm signals for this rank
+        int numSM,                      // number of SMs to use (zero corresponds to all SMs)
+        int peer_rank,                  // rank in spatial parallel group
+	bool top_zero,			// if top halo should be zeroed
+        at::Tensor top_in_halo,         // top input halo buffer (in local device memory, sent to top neighbor)
+	at::Tensor top_in_transfer,	// top input transfer buffer (in local peer memory)
+        at::Tensor top_out_transfer,    // top output transfer buffer (in top neighbor peer memory)
+        at::Tensor top_out_halo,        // top output halo buffer (in local device memory, received from top neighbor)
+	bool btm_zero,			// if btm halo should be zeroed
+        at::Tensor btm_in_halo,         // btm input halo buffer (in local device memory, sent to btm neighbor)
+	at::Tensor btm_in_transfer,	// btm input transfer buffer (in local peer memory)
+        at::Tensor btm_out_transfer,    // btm output transfer buffer (in btm neighbor peer memory)
+        at::Tensor btm_out_halo         // btm output halo buffer (in local device memory, received from btm neighbor)
         )
 {
     // basic checks of inputs
-    TORCH_CHECK(top_out_halo.is_cuda());
-    TORCH_CHECK(top_out_tx.is_cuda());
-    TORCH_CHECK(top_inp_tx.is_cuda());
-    TORCH_CHECK(top_inp_halo.is_cuda());
-    TORCH_CHECK(btm_out_halo.is_cuda());
-    TORCH_CHECK(btm_out_tx.is_cuda());
-    TORCH_CHECK(btm_inp_tx.is_cuda());
-    TORCH_CHECK(btm_inp_halo.is_cuda());
-    TORCH_CHECK(top_signal.is_cuda());
-    TORCH_CHECK(btm_signal.is_cuda());
-    TORCH_CHECK(waits.is_cuda());
     TORCH_CHECK(!(top_zero && btm_zero));
+    TORCH_CHECK(top_in_halo.is_cuda());
+    TORCH_CHECK(top_out_transfer.is_cuda());
+    TORCH_CHECK(top_in_transfer.is_cuda());
+    TORCH_CHECK(top_out_halo.is_cuda());
+    TORCH_CHECK(btm_in_halo.is_cuda());
+    TORCH_CHECK(btm_out_transfer.is_cuda());
+    TORCH_CHECK(btm_in_transfer.is_cuda());
+    TORCH_CHECK(btm_out_halo.is_cuda());
 
-    // shapes and strides
+    // tensor shapes
+    int tih_N, tih_C, tih_H, tih_W;
+    tensor_shape(top_in_halo, explicit_nhwc, tih_N, tih_C, tih_H, tih_W);
     int toh_N, toh_C, toh_H, toh_W;
     tensor_shape(top_out_halo, explicit_nhwc, toh_N, toh_C, toh_H, toh_W);
-    int tox_N, tox_C, tox_H, tox_W;
-    tensor_shape(top_out_tx, explicit_nhwc, tox_N, tox_C, tox_H, tox_W);
-    int tix_N, tix_C, tix_H, tix_W;
-    tensor_shape(top_inp_tx, explicit_nhwc, tix_N, tix_C, tix_H, tix_W);
-    int tih_N, tih_C, tih_H, tih_W;
-    tensor_shape(top_inp_halo, explicit_nhwc, tih_N, tih_C, tih_H, tih_W);
-    TORCH_CHECK(
-            (toh_N == tox_N && tox_N == tix_N && tix_N == tih_N) &&
-            (toh_C == tox_C && tox_C == tix_C && tix_C == tih_C) &&
-            (toh_H == tox_H && tox_H == tix_H && tix_H == tih_H) &&
-            (toh_W == tox_W && tox_W == tix_W && tix_W == tih_W));
+    int bih_N, bih_C, bih_H, bih_W;
+    tensor_shape(btm_in_halo, explicit_nhwc, bih_N, bih_C, bih_H, bih_W);
     int boh_N, boh_C, boh_H, boh_W;
     tensor_shape(btm_out_halo, explicit_nhwc, boh_N, boh_C, boh_H, boh_W);
-    int box_N, box_C, box_H, box_W;
-    tensor_shape(btm_out_tx, explicit_nhwc, box_N, box_C, box_H, box_W);
-    int bix_N, bix_C, bix_H, bix_W;
-    tensor_shape(btm_inp_tx, explicit_nhwc, bix_N, bix_C, bix_H, bix_W);
-    int bih_N, bih_C, bih_H, bih_W;
-    tensor_shape(btm_inp_halo, explicit_nhwc, bih_N, bih_C, bih_H, bih_W);
-    TORCH_CHECK(
-            (boh_N == box_N && box_N == bix_N && bix_N == bih_N) &&
-            (boh_C == box_C && box_C == bix_C && bix_C == bih_C) &&
-            (boh_H == box_H && box_H == bix_H && bix_H == bih_H) &&
-            (boh_W == box_W && box_W == bix_W && bix_W == bih_W));
-    TORCH_CHECK(
-	    (toh_N == boh_N) &&
-	    (toh_C == boh_C) &&
-	    (toh_H == boh_H) &&
-	    (toh_W == boh_W));
-    int NC=toh_C, NH=toh_H, NW=toh_W;
-    if (diagnostics) printf("NC=%d, NH=%d, NW=%d\n",NC,NH,NW);
+    TORCH_CHECK(toh_N == tih_N && tih_N == boh_N && boh_N == bih_N &&
+                toh_C == tih_C && tih_C == boh_C && boh_C == bih_C &&
+                toh_H == tih_H && tih_H == boh_H && boh_H == bih_H &&
+                toh_W == tih_W && tih_W == boh_W && boh_W == bih_W);
+    int NN=toh_N, NC=toh_C, NH=toh_H, NW=toh_W;
+    if (diagnostics) printf("NN=%d, NC=%d, NH=%d, NW=%d\n",NN,NC,NH,NW);
+    TORCH_CHECK(NN == 1);
 
+    // tensor strides
+    int tih_stride_N, tih_stride_C, tih_stride_H, tih_stride_W;
+    tensor_strides(top_in_halo, explicit_nhwc, tih_stride_N, tih_stride_C, tih_stride_H, tih_stride_W);
     int toh_stride_N, toh_stride_C, toh_stride_H, toh_stride_W;
     tensor_strides(top_out_halo, explicit_nhwc, toh_stride_N, toh_stride_C, toh_stride_H, toh_stride_W);
-    int tox_stride_N, tox_stride_C, tox_stride_H, tox_stride_W;
-    tensor_strides(top_out_tx, explicit_nhwc, tox_stride_N, tox_stride_C, tox_stride_H, tox_stride_W);
-    int tix_stride_N, tix_stride_C, tix_stride_H, tix_stride_W;
-    tensor_strides(top_inp_tx, explicit_nhwc, tix_stride_N, tix_stride_C, tix_stride_H, tix_stride_W);
-    int tih_stride_N, tih_stride_C, tih_stride_H, tih_stride_W;
-    tensor_strides(top_inp_halo, explicit_nhwc, tih_stride_N, tih_stride_C, tih_stride_H, tih_stride_W);
+    int bih_stride_N, bih_stride_C, bih_stride_H, bih_stride_W;
+    tensor_strides(btm_in_halo, explicit_nhwc, bih_stride_N, bih_stride_C, bih_stride_H, bih_stride_W);
     int boh_stride_N, boh_stride_C, boh_stride_H, boh_stride_W;
     tensor_strides(btm_out_halo, explicit_nhwc, boh_stride_N, boh_stride_C, boh_stride_H, boh_stride_W);
-    int box_stride_N, box_stride_C, box_stride_H, box_stride_W;
-    tensor_strides(btm_out_tx, explicit_nhwc, box_stride_N, box_stride_C, box_stride_H, box_stride_W);
-    int bix_stride_N, bix_stride_C, bix_stride_H, bix_stride_W;
-    tensor_strides(btm_inp_tx, explicit_nhwc, bix_stride_N, bix_stride_C, bix_stride_H, bix_stride_W);
-    int bih_stride_N, bih_stride_C, bih_stride_H, bih_stride_W;
-    tensor_strides(btm_inp_halo, explicit_nhwc, bih_stride_N, bih_stride_C, bih_stride_H, bih_stride_W);
 
     // determine if nhwc
-    auto is_nhwc = (toh_stride_C == 1) ? true : false;
+    bool is_nhwc = (toh_stride_C == 1);
     if (diagnostics) printf("is_nhwc = %s\n",is_nhwc?"true":"false");
+
+    // determine whether to communicate top halo first
+    bool top_first = peer_rank % 2 != 0;
+
+    // peer memory buffers
+    int tox_size = top_out_transfer.numel() * top_out_transfer.element_size();
+    int tix_size = top_in_transfer.numel() * top_in_transfer.element_size();
+    int box_size = btm_out_transfer.numel() * btm_out_transfer.element_size();
+    int bix_size = btm_in_transfer.numel() * btm_in_transfer.element_size();
+    if (!top_zero) {
+        TORCH_CHECK(top_out_transfer.is_contiguous());
+        TORCH_CHECK(top_in_transfer.is_contiguous());
+        TORCH_CHECK(tox_size == tix_size);
+    }
+    if (!btm_zero) {
+        TORCH_CHECK(btm_out_transfer.is_contiguous());
+        TORCH_CHECK(btm_in_transfer.is_contiguous());
+        TORCH_CHECK(box_size == bix_size);
+    }
 
     // figure out launch parameters
     int device;
     cudaGetDevice(&device);
     cudaDeviceProp prop;
     cudaGetDeviceProperties(&prop, device);
-    assert(numSM > 0 && numSM <= prop.multiProcessorCount);
+    if (numSM <= 0 || numSM > prop.multiProcessorCount) {
+      numSM = prop.multiProcessorCount;
+    }
     auto current_stream = at::cuda::getCurrentCUDAStream();
-    const int numThreads = 128;
-    dim3 block(numThreads,1,1);
-    AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, top_out_halo.scalar_type(), "push_pull_halos_1d_kernel", [&]{
-	    if (diagnostics) printf("size(scalar_t) = %ld\n",sizeof(scalar_t));
-            scalar_t* toh_p = top_out_halo.data_ptr<scalar_t>();
-            scalar_t* tox_p = top_out_tx.data_ptr<scalar_t>();
-            scalar_t* tix_p = top_inp_tx.data_ptr<scalar_t>();
-            scalar_t* tih_p = top_inp_halo.data_ptr<scalar_t>();
-            scalar_t* boh_p = btm_out_halo.data_ptr<scalar_t>();
-            scalar_t* box_p = btm_out_tx.data_ptr<scalar_t>();
-            scalar_t* bix_p = btm_inp_tx.data_ptr<scalar_t>();
-            scalar_t* bih_p = btm_inp_halo.data_ptr<scalar_t>();
-	    if (diagnostics) printf("waypoint1\n");
-	    int* top_signal_p = top_signal.data_ptr<int>() + 4;
-	    int* btm_signal_p = btm_signal.data_ptr<int>();
-	    int* top_wait_p = waits.data_ptr<int>();
-	    int* btm_wait_p = waits.data_ptr<int>() + 4;
-	    if (diagnostics) printf("waypoint2\n");
+    dim3 block(THREADS_PER_CTA,1,1);
 
-            // do int4 vector loads if channel count permits
-            int elem_size_in_bytes = toh_C * sizeof(scalar_t);
-            int elem_size_in_int4 = (elem_size_in_bytes / 16);
-	    if (diagnostics) printf("elem_size_in_bytes = %d, elem_size_in_int4 = %d\n",elem_size_in_bytes,elem_size_in_int4);
-            if (is_nhwc && elem_size_in_int4*16 == elem_size_in_bytes) {
-                // can do int4 transfers
-	        int divisor = toh_C / elem_size_in_int4;
-		if (diagnostics) printf("CAN DO INT4 :: divisor = %d\n",divisor);
-		toh_stride_N /= divisor;   toh_stride_H /= divisor;    toh_stride_W /= divisor;
-		tox_stride_N /= divisor;   tox_stride_H /= divisor;    tox_stride_W /= divisor;
-		tix_stride_N /= divisor;   tix_stride_H /= divisor;    tix_stride_W /= divisor;
-		tih_stride_N /= divisor;   tih_stride_H /= divisor;    tih_stride_W /= divisor;
-		boh_stride_N /= divisor;   boh_stride_H /= divisor;    boh_stride_W /= divisor;
-		box_stride_N /= divisor;   box_stride_H /= divisor;    box_stride_W /= divisor;
-		bix_stride_N /= divisor;   bix_stride_H /= divisor;    bix_stride_W /= divisor;
-		bih_stride_N /= divisor;   bih_stride_H /= divisor;    bih_stride_W /= divisor;
-		NC /= divisor;
-		if (diagnostics) {
-                    printf("divisor=%d\n",divisor);
-                    printf("toh_stride :: N=%d, C=%d, H=%d, W=%d\n",toh_stride_N,toh_stride_C,toh_stride_H,toh_stride_W);
-                    printf("tox_stride :: N=%d, C=%d, H=%d, W=%d\n",tox_stride_N,tox_stride_C,tox_stride_H,tox_stride_W);
-                    printf("tix_stride :: N=%d, C=%d, H=%d, W=%d\n",tix_stride_N,tix_stride_C,tix_stride_H,tix_stride_W);
-                    printf("tih_stride :: N=%d, C=%d, H=%d, W=%d\n",tih_stride_N,tih_stride_C,tih_stride_H,tih_stride_W);
-                    printf("boh_stride :: N=%d, C=%d, H=%d, W=%d\n",boh_stride_N,boh_stride_C,boh_stride_H,boh_stride_W);
-                    printf("box_stride :: N=%d, C=%d, H=%d, W=%d\n",box_stride_N,box_stride_C,box_stride_H,box_stride_W);
-                    printf("bix_stride :: N=%d, C=%d, H=%d, W=%d\n",bix_stride_N,bix_stride_C,bix_stride_H,bix_stride_W);
-                    printf("bih_stride :: N=%d, C=%d, H=%d, W=%d\n",bih_stride_N,bih_stride_C,bih_stride_H,bih_stride_W);
-                    printf("NC=%d, NH=%d, NW=%d\n",NC,NH,NW);
-                }
-		void *kernelArgs[] = {
-		    (int4**)&toh_p, &toh_stride_C, &toh_stride_H, &toh_stride_W,
-		    (int4**)&tox_p, &tox_stride_C, &tox_stride_H, &tox_stride_W,
-		    (int4**)&tix_p, &tix_stride_C, &tix_stride_H, &tix_stride_W,
-		    (int4**)&tih_p, &tih_stride_C, &tih_stride_H, &tih_stride_W,
-		    (int4**)&boh_p, &boh_stride_C, &boh_stride_H, &boh_stride_W,
-		    (int4**)&box_p, &box_stride_C, &box_stride_H, &box_stride_W,
-		    (int4**)&bix_p, &bix_stride_C, &bix_stride_H, &bix_stride_W,
-		    (int4**)&bih_p, &bih_stride_C, &bih_stride_H, &bih_stride_W,
-		    &NC, &NH, &NW,
-		    &top_signal_p, &btm_signal_p, &top_wait_p, &btm_wait_p
-		};
-		if (top_zero) {
-		    int numBlocksPerSm;
-		    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSm, push_pull_halos_1d_kernel<int4,true,true,false>, numThreads, 0);
-		    dim3 grid(numSM*numBlocksPerSm,1,1);
-		    cudaLaunchCooperativeKernel((void*)push_pull_halos_1d_kernel<int4,true,true,false>, grid, block, kernelArgs, 0, current_stream);
-		} else if (btm_zero) {
-		    int numBlocksPerSm;
-		    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSm, push_pull_halos_1d_kernel<int4,true,false,true>, numThreads, 0);
-		    dim3 grid(numSM*numBlocksPerSm,1,1);
-		    cudaLaunchCooperativeKernel((void*)push_pull_halos_1d_kernel<int4,true,false,true>, grid, block, kernelArgs, 0, current_stream);
-		} else {
-		    int numBlocksPerSm;
-		    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSm, push_pull_halos_1d_kernel<int4,true,false,false>, numThreads, 0);
-		    dim3 grid(numSM*numBlocksPerSm,1,1);
-		    cudaLaunchCooperativeKernel((void*)push_pull_halos_1d_kernel<int4,true,false,false>, grid, block, kernelArgs, 0, current_stream);
-		}
+    // helper macros to launch templated kernel
+#define LAUNCH_PUSH_PULL_HALO_KERNEL_BASE(T, IS_HWC, TOP_ZERO, BTM_ZERO, KERNEL_ARGS, NUM_ELEMENTS) \
+    do {                                                                \
+        /* kernel configuration */                                      \
+        int numBlocksPerSm;                                             \
+        cudaOccupancyMaxActiveBlocksPerMultiprocessor(                  \
+            &numBlocksPerSm,                                            \
+            push_pull_halos_1d_kernel<T,IS_HWC,TOP_ZERO,BTM_ZERO>,      \
+            THREADS_PER_CTA,                                            \
+            0);                                                         \
+        dim3 grid(numSM*numBlocksPerSm,1,1);                            \
+        if (grid.x % 2 != 0) {                                          \
+            /* require even number of blocks (half for top, half for bottom) */ \
+            grid.x -= 1;                                                \
+        }                                                               \
+        if ((grid.x / 2) * THREADS_PER_CTA > NUM_ELEMENTS) {            \
+            /* only need enough blocks to cover top and bottom halo elements */ \
+            grid.x = 2 * ((NUM_ELEMENTS + THREADS_PER_CTA - 1) / THREADS_PER_CTA); \
+        }                                                               \
+        if (!TOP_ZERO) {                                                \
+            /* require 2*128b=32B peer memory per thread */             \
+            if ((grid.x / 2) * THREADS_PER_CTA * 32 > tox_size) {       \
+                grid.x = 2 * (tox_size / (THREADS_PER_CTA * 32));       \
+            }                                                           \
+        }                                                               \
+        if (!BTM_ZERO) {                                                \
+            /* require 2*128b=32B peer memory per thread */             \
+            if ((grid.x / 2) * THREADS_PER_CTA * 32 > box_size) {       \
+                grid.x = 2 * (box_size / (THREADS_PER_CTA * 32));       \
+            }                                                           \
+        }                                                               \
+        TORCH_CHECK(grid.x >= 2);                                       \
+                                                                        \
+        /* launch kernel */                                             \
+        cudaLaunchCooperativeKernel(                                    \
+            (void*)push_pull_halos_1d_kernel<T,IS_HWC,TOP_ZERO,BTM_ZERO>, \
+            grid,                                                       \
+            block,                                                      \
+            KERNEL_ARGS,                                                \
+            0,                                                          \
+            current_stream);                                            \
+    } while (false)
+#define LAUNCH_PUSH_PULL_HALO_KERNEL(T, IS_HWC, KERNEL_ARGS, NUM_ELEMENTS) \
+    do {                                                                \
+        if (top_zero) {                                                 \
+            LAUNCH_PUSH_PULL_HALO_KERNEL_BASE(T, IS_HWC, true, false, KERNEL_ARGS, NUM_ELEMENTS); \
+        } else if (btm_zero) {                                          \
+            LAUNCH_PUSH_PULL_HALO_KERNEL_BASE(T, IS_HWC, false, true, KERNEL_ARGS, NUM_ELEMENTS); \
+        } else {                                                        \
+            LAUNCH_PUSH_PULL_HALO_KERNEL_BASE(T, IS_HWC, false, false, KERNEL_ARGS, NUM_ELEMENTS); \
+        }                                                               \
+    } while (false)
+
+    AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Half, top_out_halo.scalar_type(), "push_pull_halos_1d_kernel", [&]{
+	if (diagnostics) printf("size(scalar_t) = %ld\n",sizeof(scalar_t));
+        scalar_t* toh_p = top_out_halo.data_ptr<scalar_t>();
+        scalar_t* tih_p = top_in_halo.data_ptr<scalar_t>();
+        int4* tox_p = reinterpret_cast<int4*>(top_out_transfer.data_ptr<scalar_t>());
+        int4* tix_p = reinterpret_cast<int4*>(top_in_transfer.data_ptr<scalar_t>());
+        scalar_t* boh_p = btm_out_halo.data_ptr<scalar_t>();
+        scalar_t* bih_p = btm_in_halo.data_ptr<scalar_t>();
+        int4* box_p = reinterpret_cast<int4*>(btm_out_transfer.data_ptr<scalar_t>());
+        int4* bix_p = reinterpret_cast<int4*>(btm_in_transfer.data_ptr<scalar_t>());
+        if (diagnostics) printf("waypoint1\n");
+
+        // do int2 vector loads if channel count permits
+        int elem_size_in_bytes = toh_C * sizeof(scalar_t);
+        int elem_size_in_int2 = (elem_size_in_bytes / 8);
+        if (diagnostics) printf("elem_size_in_bytes = %d, elem_size_in_int2 = %d\n",elem_size_in_bytes,elem_size_in_int2);
+        if (is_nhwc && elem_size_in_int2*8 == elem_size_in_bytes) {
+            // can do int2 transfers
+            int divisor = 8 / sizeof(scalar_t);
+            if (diagnostics) printf("CAN DO INT2 :: divisor = %d\n",divisor);
+            toh_stride_N /= divisor;   toh_stride_H /= divisor;    toh_stride_W /= divisor;
+            tih_stride_N /= divisor;   tih_stride_H /= divisor;    tih_stride_W /= divisor;
+            boh_stride_N /= divisor;   boh_stride_H /= divisor;    boh_stride_W /= divisor;
+            bih_stride_N /= divisor;   bih_stride_H /= divisor;    bih_stride_W /= divisor;
+            NC /= divisor;
+            if (diagnostics) {
+                printf("divisor=%d\n",divisor);
+                printf("tih_stride :: N=%d, C=%d, H=%d, W=%d\n",tih_stride_N,tih_stride_C,tih_stride_H,tih_stride_W);
+                printf("toh_stride :: N=%d, C=%d, H=%d, W=%d\n",toh_stride_N,toh_stride_C,toh_stride_H,toh_stride_W);
+                printf("bih_stride :: N=%d, C=%d, H=%d, W=%d\n",bih_stride_N,bih_stride_C,bih_stride_H,bih_stride_W);
+                printf("boh_stride :: N=%d, C=%d, H=%d, W=%d\n",boh_stride_N,boh_stride_C,boh_stride_H,boh_stride_W);
+                printf("NC=%d, NH=%d, NW=%d\n",NC,NH,NW);
+            }
+            void *kernel_args[] = {
+                (int2**)&toh_p, &toh_stride_C, &toh_stride_H, &toh_stride_W,
+                (int2**)&tih_p, &tih_stride_C, &tih_stride_H, &tih_stride_W,
+                &tox_p, &tix_p,
+                (int2**)&boh_p, &boh_stride_C, &boh_stride_H, &boh_stride_W,
+                (int2**)&bih_p, &bih_stride_C, &bih_stride_H, &bih_stride_W,
+                &box_p, &bix_p,
+                &NC, &NH, &NW,
+                &top_first
+            };
+            int num_elem = NC*NH*NW;
+            LAUNCH_PUSH_PULL_HALO_KERNEL(int2, true, kernel_args, num_elem);
+        } else {
+            // cannot do int2 transfers
+            if (diagnostics) printf("CAN NOT DO INT2\n");
+            void *kernel_args[] = {
+                &toh_p, &toh_stride_C, &toh_stride_H, &toh_stride_W,
+		&tih_p, &tih_stride_C, &tih_stride_H, &tih_stride_W,
+                &tox_p, &tix_p,
+                &boh_p, &boh_stride_C, &boh_stride_H, &boh_stride_W,
+                &bih_p, &bih_stride_C, &bih_stride_H, &bih_stride_W,
+                &box_p, &bix_p,
+                &NC, &NH, &NW,
+                &top_first
+            };
+            int num_elem = NC*NH*NW;
+            if (is_nhwc) {
+                LAUNCH_PUSH_PULL_HALO_KERNEL(scalar_t, true, kernel_args, num_elem);
             } else {
-                // cannot do int4 transfers
-		if (diagnostics) printf("CAN NOT DO INT4\n");
-		void *kernelArgs[] = {
-		    &toh_p, &toh_stride_C, &toh_stride_H, &toh_stride_W,
-		    &tox_p, &tox_stride_C, &tox_stride_H, &tox_stride_W,
-		    &tix_p, &tix_stride_C, &tix_stride_H, &tix_stride_W,
-		    &tih_p, &tih_stride_C, &tih_stride_H, &tih_stride_W,
-		    &boh_p, &boh_stride_C, &boh_stride_H, &boh_stride_W,
-		    &box_p, &box_stride_C, &box_stride_H, &box_stride_W,
-		    &bix_p, &bix_stride_C, &bix_stride_H, &bix_stride_W,
-		    &bih_p, &bih_stride_C, &bih_stride_H, &bih_stride_W,
-		    &NC, &NH, &NW,
-		    &top_signal_p, &btm_signal_p, &top_wait_p, &btm_wait_p
-		};
-                int numBlocksPerSm;
-                if (is_nhwc) {
-		    if (top_zero) {
-			cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSm, push_pull_halos_1d_kernel<scalar_t,true,true,false>, numThreads, 0);
-			dim3 grid(numSM*numBlocksPerSm,1,1);
-			cudaLaunchCooperativeKernel((void*)push_pull_halos_1d_kernel<scalar_t,true,true,false>, grid, block, kernelArgs, 0, current_stream);
-		    } else if (btm_zero) {
-			cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSm, push_pull_halos_1d_kernel<scalar_t,true,false,true>, numThreads, 0);
-			dim3 grid(numSM*numBlocksPerSm,1,1);
-			cudaLaunchCooperativeKernel((void*)push_pull_halos_1d_kernel<scalar_t,true,false,true>, grid, block, kernelArgs, 0, current_stream);
-		    } else {
-			cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSm, push_pull_halos_1d_kernel<scalar_t,true,false,false>, numThreads, 0);
-			dim3 grid(numSM*numBlocksPerSm,1,1);
-			cudaLaunchCooperativeKernel((void*)push_pull_halos_1d_kernel<scalar_t,true,false,false>, grid, block, kernelArgs, 0, current_stream);
-		    }
-                } else {
-		    if (top_zero) {
-			cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSm, push_pull_halos_1d_kernel<scalar_t,false,true,false>, numThreads, 0);
-			dim3 grid(numSM*numBlocksPerSm,1,1);
-			cudaLaunchCooperativeKernel((void*)push_pull_halos_1d_kernel<scalar_t,false,true,false>, grid, block, kernelArgs, 0, current_stream);
-		    } else if (btm_zero) {
-			cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSm, push_pull_halos_1d_kernel<scalar_t,false,false,true>, numThreads, 0);
-			dim3 grid(numSM*numBlocksPerSm,1,1);
-			cudaLaunchCooperativeKernel((void*)push_pull_halos_1d_kernel<scalar_t,false,false,true>, grid, block, kernelArgs, 0, current_stream);
-		    } else {
-			cudaOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocksPerSm, push_pull_halos_1d_kernel<scalar_t,false,false,false>, numThreads, 0);
-			dim3 grid(numSM*numBlocksPerSm,1,1);
-			cudaLaunchCooperativeKernel((void*)push_pull_halos_1d_kernel<scalar_t,false,false,false>, grid, block, kernelArgs, 0, current_stream);
-		    }
-                }
-	    }
-        } );
+                LAUNCH_PUSH_PULL_HALO_KERNEL(scalar_t, false, kernel_args, num_elem);
+            }
+        }
+    } );
+
+#undef LAUNCH_PUSH_PULL_HALO_KERNEL_BASE
+#undef LAUNCH_PUSH_PULL_HALO_KERNEL
 }
 
 } } }
-

--- a/apex/contrib/csrc/peer_memory/peer_memory_cuda.cuh
+++ b/apex/contrib/csrc/peer_memory/peer_memory_cuda.cuh
@@ -17,7 +17,7 @@
 #pragma once
 #include <torch/extension.h>
 #ifndef _peer_memory_h_
-#define _peer_memory_h_ 
+#define _peer_memory_h_
 
 namespace apex { namespace contrib { namespace peer_memory {
     int64_t allocate_raw(int64_t size);
@@ -32,19 +32,17 @@ namespace apex { namespace contrib { namespace peer_memory {
         bool diagnostics,
         bool explicit_nhwc,
         int numSM,                      // number of SMs to use
-	bool top_zero,			// true if top halo should be zeroed
-        at::Tensor top_out_halo,        // top output halo in sender device memory
-        at::Tensor top_out_tx,          // top output transfer buffer in sender peer pool memory
-	at::Tensor top_inp_tx,		// top input transfer buffer in top neighbor peer pool memory
-        at::Tensor top_inp_halo,        // top input halo in receiver device memory
-	bool btm_zero,			// true if btm halo should be zeroed
-        at::Tensor btm_out_halo,        // btm output halo in sender device memory
-        at::Tensor btm_out_tx,          // btm output transfer buffer in sender peer pool memory
-	at::Tensor btm_inp_tx,		// btm input transfer buffer in btm neighbor peer pool memory
-        at::Tensor btm_inp_halo,        // btm input halo in receiver device memory
-        at::Tensor top_signal,          // top input signal in receiver device memory
-        at::Tensor btm_signal,          // btm input signal in receiver device memory
-        at::Tensor waits                // top and btm signals for this rank
+        int peer_rank,                  // rank in spatial parallel group
+	bool top_zero,			// if top halo should be zeroed
+        at::Tensor top_out_halo,        // top output halo buffer (in local device memory, received from top neighbor)
+	at::Tensor top_inp_transfer,    // top input transfer buffer (in local peer memory)
+        at::Tensor top_out_transfer,    // top output transfer buffer (in top neighbor peer memory)
+        at::Tensor top_inp_halo,        // top input halo buffer (in local device memory, sent to top neighbor)
+	bool btm_zero,			// if btm halo should be zeroed
+        at::Tensor btm_out_halo,        // btm output halo buffer (in local device memory, received from btm neighbor)
+	at::Tensor btm_inp_transfer,	// btm input transfer buffer (in local peer memory)
+        at::Tensor btm_out_transfer,    // btm output transfer buffer (in btm neighbor peer memory)
+        at::Tensor btm_inp_halo         // btm input halo buffer (in local device memory, sent to btm neighbor)
         );
 } } }
 #endif

--- a/apex/contrib/peer_memory/peer_halo_exchanger_1d.py
+++ b/apex/contrib/peer_memory/peer_halo_exchanger_1d.py
@@ -27,7 +27,7 @@ class PeerHaloExchanger1d:
         shape = [1, 1, 1, size // halo.element_size()]
         return self.peer_pool.allocate_peer_tensors(shape, halo.dtype, False, True)
 
-    def __call__(self, y, H_split=True, explicit_nhwc=False, numSM=1, diagnostics=False):
+    def __call__(self, y, H_split=True, explicit_nhwc=False, numSM=0, diagnostics=False):
         channels_last = y.is_contiguous(memory_format=torch.channels_last) and not explicit_nhwc
         if H_split:
             if explicit_nhwc:

--- a/apex/contrib/peer_memory/peer_halo_exchanger_1d.py
+++ b/apex/contrib/peer_memory/peer_halo_exchanger_1d.py
@@ -13,9 +13,19 @@ class PeerHaloExchanger1d:
         self.high_zero = True if self.peer_rank == self.peer_group_size - 1 else False
 
         self.peer_pool = peer_pool
-        self.signals = peer_pool.allocate_peer_tensors([2,4], torch.int32, False, False)
-        self.signals[self.peer_rank].zero_()
         self.half_halo = half_halo
+
+    def _allocate_peer_tensor(self, halo):
+
+        # Compute size in bytes
+        # Note: Pad buffer so each CUDA block gets required buffer size
+        size = 4 * halo.numel() * halo.element_size()
+        size_per_block = 128 * 2 * 16   # 128 threads each require two 128b buffers
+        size = (size + size_per_block - 1) // size_per_block * size_per_block
+
+        # Construct dtype peer buffer with desired size
+        shape = [1, 1, 1, size // halo.element_size()]
+        return self.peer_pool.allocate_peer_tensors(shape, halo.dtype, False, True)
 
     def __call__(self, y, H_split=True, explicit_nhwc=False, numSM=1, diagnostics=False):
         channels_last = y.is_contiguous(memory_format=torch.channels_last) and not explicit_nhwc
@@ -24,42 +34,41 @@ class PeerHaloExchanger1d:
                 _, Hs, _, _ = list(y.shape)
                 H = Hs - 2*self.half_halo
                 low_out_halo = y[:,self.half_halo:2*self.half_halo,:,:]
-                low_tx = self.peer_pool.allocate_peer_tensors(list(low_out_halo.shape), low_out_halo.dtype, False, True)
+                low_tx = self._allocate_peer_tensor(low_out_halo)
                 low_inp_halo = y[:,:self.half_halo,:,:]
                 high_out_halo = y[:,H:H+self.half_halo,:,:]
-                high_tx = self.peer_pool.allocate_peer_tensors(list(high_out_halo.shape), high_out_halo.dtype, False, True)
+                high_tx = self._allocate_peer_tensor(high_out_halo)
                 high_inp_halo = y[:,H+self.half_halo:H+2*self.half_halo,:,:]
             else:
                 _, _, Hs, _ = list(y.shape)
                 H = Hs - 2*self.half_halo
                 low_out_halo = y[:,:,self.half_halo:2*self.half_halo,:]
-                low_tx = self.peer_pool.allocate_peer_tensors(list(low_out_halo.shape), low_out_halo.dtype, channels_last, True)
+                low_tx = self._allocate_peer_tensor(low_out_halo)
                 low_inp_halo = y[:,:,:self.half_halo,:]
                 high_out_halo = y[:,:,H:H+self.half_halo,:]
-                high_tx = self.peer_pool.allocate_peer_tensors(list(high_out_halo.shape), high_out_halo.dtype, channels_last, True)
+                high_tx = self._allocate_peer_tensor(high_out_halo)
                 high_inp_halo = y[:,:,H+self.half_halo:H+2*self.half_halo,:]
         else:
             if explicit_nhwc:
                 _, _, Ws, _ = list(y.shape)
                 W = Ws - 2*self.half_halo
                 low_out_halo = y[:,:,self.half_halo:2*self.half_halo,:]
-                low_tx = self.peer_pool.allocate_peer_tensors(list(low_out_halo.shape), low_out_halo.dtype, False, True)
+                low_tx = self._allocate_peer_tensor(low_out_halo)
                 low_inp_halo = y[:,:,:self.half_halo,:]
                 high_out_halo = y[:,:,W:W+self.half_halo,:]
-                high_tx = self.peer_pool.allocate_peer_tensors(list(high_out_halo.shape), high_out_halo.dtype, False, True)
+                high_tx = self._allocate_peer_tensor(high_out_halo)
                 high_inp_halo = y[:,:,W+self.half_halo:W+2*self.half_halo,:]
             else:
                 _, _, _, Ws = list(y.shape)
                 W = Ws - 2*self.half_halo
                 low_out_halo = y[:,:,:,self.half_halo:2*self.half_halo]
-                low_tx = self.peer_pool.allocate_peer_tensors(list(low_out_halo.shape), low_out_halo.dtype, channels_last, True)
+                low_tx = self._allocate_peer_tensor(low_out_halo)
                 low_inp_halo = y[:,:,:,:self.half_halo]
                 high_out_halo = y[:,:,:,W:W+self.half_halo]
-                high_tx = self.peer_pool.allocate_peer_tensors(list(high_out_halo.shape), high_out_halo.dtype, channels_last, True)
+                high_tx = self._allocate_peer_tensor(high_out_halo)
                 high_inp_halo = y[:,:,:,W+self.half_halo:W+2*self.half_halo]
         pm.push_pull_halos_1d(
-                diagnostics, explicit_nhwc, numSM,
-                self.low_zero, low_out_halo, low_tx[self.peer_rank], high_tx[self.low_neighbor], low_inp_halo, 
+                diagnostics, explicit_nhwc, numSM, self.peer_rank,
+                self.low_zero, low_out_halo, low_tx[self.peer_rank], high_tx[self.low_neighbor], low_inp_halo,
                 self.high_zero, high_out_halo, high_tx[self.peer_rank], low_tx[self.high_neighbor], high_inp_halo,
-                self.signals[self.low_neighbor], self.signals[self.high_neighbor], self.signals[self.peer_rank]
                 )

--- a/apex/contrib/test/bottleneck/test_bottleneck_module.py
+++ b/apex/contrib/test/bottleneck/test_bottleneck_module.py
@@ -250,7 +250,7 @@ def main():
     spatial_group_size = world_size
     spatial_communicator = None
 
-    peer_pool = PeerMemoryPool(64 * 1024 * 1024, 2 * 1024 * 1024, ranks)
+    peer_pool = PeerMemoryPool(0, 64 * 1024 * 1024, ranks)
 
     # class HaloExchangerNoComm(HaloExchanger):
     #    def __init__(self, ranks, rank_in_group):
@@ -264,7 +264,7 @@ def main():
     # halex = HaloExchangerAllGather(ranks, rank_in_group)
     # halex = HaloExchangerSendRecv(ranks, rank_in_group)
 
-    halex = HaloExchangerPeer(ranks, rank_in_group, peer_pool, explicit_nhwc, numSM=1)
+    halex = HaloExchangerPeer(ranks, rank_in_group, peer_pool, explicit_nhwc, numSM=0)
     # print("halex.signals = %s" % (str(halex.signals)))
     # Make sure peer memory halo exchanger has finished initializing flags on all ranks before proceeding
     # torch.cuda.synchronize()
@@ -312,8 +312,8 @@ class TestBottleneck(NcclDistributedTestBase):
         rank_in_group = self.rank % self.world_size
 
         spatial_group_size, spatial_communicator = self.world_size, None
-        peer_pool = PeerMemoryPool(64 * 1024 * 1024, 2 * 1024 * 1024, ranks)
-        halo_exchanger_peer = HaloExchangerPeer(ranks, rank_in_group, peer_pool, explicit_nhwc, numSM=1)
+        peer_pool = PeerMemoryPool(0, 64 * 1024 * 1024, ranks)
+        halo_exchanger_peer = HaloExchangerPeer(ranks, rank_in_group, peer_pool, explicit_nhwc, numSM=0)
         bt2 = n_way_spatial(
             halo_exchanger_peer, gt_bottleneck, gt, explicit_nhwc, self.world_size, self.rank, fp32_reduce=True
         )

--- a/apex/contrib/test/peer_memory/test_peer_halo_exchange_module.py
+++ b/apex/contrib/test/peer_memory/test_peer_halo_exchange_module.py
@@ -264,7 +264,7 @@ def main():
     world_size = torch.distributed.get_world_size()
     torch.cuda.set_device(rank)
     peer_ranks = [i for i in range(world_size)]
-    pool = PeerMemoryPool(64 * 1024, 2 * 1024 * 1024, peer_ranks)
+    pool = PeerMemoryPool(0, 2 * 1024 * 1024, peer_ranks)
 
     num_steps = 100
 


### PR DESCRIPTION
This PR optimizes the peer memory halo exchange to minimize latency:
- Each CUDA thread performs its communication independently, which allows us to avoid cooperative group syncs. With enough threads, we avoid memory fences entirely. The downside is that we can only achieve 50% bandwidth since we pack data and flags into the same communication packets.
- Use an alternating double-buffer scheme, which allows push-only communication.
- The kernel does multiple rounds of communication in the cases where the number of SMs or the peer buffers are too small. This is important since the optimal peer memory requirements have increased by 4x, or more if the tensors are not nicely NHWC.  The only strict requirement is that the peer buffer sizes are aligned to 4096B.

Running on two DGX-1 V100s:
   | Version | Data type |   Kernel time |
   |-----------|-------|--------------------|
   | Baseline  | FP32  | 19.9 us |
   | Baseline  | FP16  |  17.2 us |
   | Optimized | FP32  | 15.2 us |
   | Optimized | FP16  | 11.4 us |

<details> <summary> Details </summary>

- I performed the halo exchange required for 3x3 convolution on a [1,336,336,64] NHWC tensor.
- To isolate the kernel time from the communication time, I delayed GPU 0 so it would always launch the kernel well after GPU 1.

</details>

Running the Mask R-CNN benchmark:

   | GPUs | Step time |
   |------|---------------|
   |    1 |       37.7 ms |
   |    2 |        34.8 ms |
   |    4 |        33.6 ms |

~The unit tests for the [halo exchanger](https://github.com/NVIDIA/apex/blob/master/apex/contrib/test/peer_memory/test_peer_halo_exchange_module.py) and the [bottleneck module](https://github.com/NVIDIA/apex/blob/master/apex/contrib/test/peer_memory/test_peer_halo_exchange_module.py) all pass for me on DGX-1 V100s.~ Pinging @thorjohnsen.