### PR TITLE
fix(sec): upgrade numpy to 1.22.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cxxfilt>=0.2.0
 tqdm>=4.28.1
-numpy>=1.15.3
+numpy>=1.22.2
 PyYAML>=5.1
 pytest>=3.5.1
 packaging>=14.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in numpy 1.15.3
- [CVE-2021-33430](https://www.oscs1024.com/hd/CVE-2021-33430)


### What did I do？
Upgrade numpy from 1.15.3 to 1.22.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS