### PR TITLE
[Transformer] Update test routines

### DIFF
--- a/apex/transformer/testing/commons.py
+++ b/apex/transformer/testing/commons.py
@@ -289,10 +289,8 @@ def initialize_distributed(backend="nccl"):
 
 
 def print_separator(message):
-    torch.distributed.barrier()
     filler_len = (78 - len(message)) // 2
     filler = "-" * filler_len
     string = "\n" + filler + " {} ".format(message) + filler
     if torch.distributed.get_rank() == 0:
         print(string, flush=True)
-    torch.distributed.barrier()

--- a/tests/L0/run_transformer/test_bert_minimal.py
+++ b/tests/L0/run_transformer/test_bert_minimal.py
@@ -234,7 +234,7 @@ class BertTestBase:
             args.pipeline_model_parallel_size,
             async_comm,
         )
-        torch.distributed.barrier()
+        torch.cuda.synchronize()
 
 
 class NcclBertTest(BertTestBase, NcclDistributedTestBase):

--- a/tests/L0/run_transformer/test_dynamic_batchsize.py
+++ b/tests/L0/run_transformer/test_dynamic_batchsize.py
@@ -139,7 +139,7 @@ def run_interleaved_with_dynamic_batch_size(
             else:
                 optimizer.zero_grad(set_to_none=True)
 
-    torch.distributed.barrier()
+    torch.cuda.synchronize()
 
 
 class DynamicBatchsizeTestBase:
@@ -199,17 +199,14 @@ class DynamicBatchsizeTestBase:
                     raise RuntimeError(msg)
                 finally:
                     parallel_state.destroy_model_parallel()
-        print_separator("TEST RESULT")
         if failures:
-            torch.distributed.barrier()
-            if torch.distributed.get_rank() == 0:
-                print("\n".join(failures))
+            print_separator("TEST FAILED:")
+            print("\n".join(failures))
             msg = f"{len(failures)} / {n_tests} cases failed"
             raise RuntimeError(msg)
         else:
-            torch.distributed.barrier()
             if torch.distributed.get_rank() == 0:
-                print("### PASS!")
+                print_separator("TEST RESULT: ### PASS!")
 
 
 class NcclDynamicBatchsizeTest(DynamicBatchsizeTestBase, NcclDistributedTestBase):

--- a/tests/L0/run_transformer/test_gpt_minimal.py
+++ b/tests/L0/run_transformer/test_gpt_minimal.py
@@ -216,7 +216,7 @@ class GptTestBase:
                 model, optim, args.pipeline_model_parallel_size, async_comm)
 
             parallel_state.destroy_model_parallel()
-        torch.distributed.barrier()
+        torch.cuda.synchronize()
 
 
 class NcclGptTest(GptTestBase, NcclDistributedTestBase):


### PR DESCRIPTION
The main reason for existence of this PR is that `torch.distributed.<communication>()` without process group being specified (like fixed barriers) can do some nasty things. On single node there are no visible issues whatsoever. However, on multiple nodes with non-IB connections (like Ethernet) the `torch.distributed.<communication>()` hangs causing the timeout-failure. 
Why is this happening on multi node with Ethernet? Because `torch.distributed.<communication>()` attempts to use default PG with NCCL backend over all available ranks. Using all ranks would be only possible if all communications of NCCL were gone through TCP, which we are targeting to avoid by using UCC to do the TCP job.

Please let me know if there are other communications without specified process groups. 
cc @crcrpar @eqy @Fuzzkatt 