### PR TITLE
Optimize halo exchange in spatial-parallel bottleneck layer

### DIFF
--- a/apex/contrib/bottleneck/bottleneck.py
+++ b/apex/contrib/bottleneck/bottleneck.py
@@ -317,7 +317,7 @@ class SpatialBottleneckFunction(torch.autograd.Function):
                 out1 = out1_pad[:,:,1:-1,:]
             outputs[0] = out1
         fast_bottleneck.conv_scale_bias_relu(
-            [1,1], # strides
+            [stride_1x1,stride_1x1],
             [0,0], # pre-pads
             [0,0], # post-pads
             [1,1], # dilations

--- a/apex/contrib/bottleneck/bottleneck.py
+++ b/apex/contrib/bottleneck/bottleneck.py
@@ -400,7 +400,7 @@ class SpatialBottleneckFunction(torch.autograd.Function):
                     torch.cuda.current_stream().wait_stream(stream2)
                 if spatial_group_rank > 0:
                     torch.cuda.current_stream().wait_stream(stream1)
-            
+
         fast_bottleneck.forward_rest(explicit_nhwc, stride_1x1, args, outputs)
         # save halos for backward pass
         if spatial_group_size > 1:
@@ -609,7 +609,7 @@ class SpatialBottleneck(torch.nn.Module):
     # here we put it at 1x1
 
     def __init__(self, in_channels, bottleneck_channels, out_channels, stride=1, groups=1,
-                 dilation=1, norm_func=None, use_cudnn=False, explicit_nhwc=False, 
+                 dilation=1, norm_func=None, use_cudnn=False, explicit_nhwc=False,
                  spatial_parallel_args=None):
         super(SpatialBottleneck, self).__init__()
         if groups != 1:
@@ -704,7 +704,7 @@ class SpatialBottleneck(torch.nn.Module):
                     N,C,H,W = list(x.shape)
                 self.thresholdTop = torch.tensor([1 if spatial_group_rank > 0 else 0], dtype=torch.int32, device='cuda')
                 self.thresholdBottom = torch.tensor([H-2 if spatial_group_rank < spatial_group_size - 1 else H-1], dtype=torch.int32, device='cuda')
-            
+
             if self.w_scale is None:
                 # calculate scale/bias from registered buffers
                 # TODO: make this better
@@ -746,4 +746,3 @@ class SpatialBottleneck(torch.nn.Module):
         out = self.relu(out)
 
         return out
-

--- a/apex/contrib/bottleneck/halo_exchangers.py
+++ b/apex/contrib/bottleneck/halo_exchangers.py
@@ -88,7 +88,7 @@ class HaloExchangerSendRecv(HaloExchanger):
             inc.left_right_halo_exchange_inplace(self.handle, self.left_rank, self.right_rank, left_output_halo, right_output_halo, left_input_halo, right_input_halo)
 
 class HaloExchangerPeer(HaloExchanger):
-    def __init__(self, ranks, rank_in_group, peer_pool, explicit_nhwc, numSM=0):
+    def __init__(self, ranks, rank_in_group, peer_pool, explicit_nhwc, numSM=1):
         super(HaloExchangerPeer, self).__init__(ranks, rank_in_group)
         self.diagnostics = False
         self.explicit_nhwc = explicit_nhwc

--- a/apex/contrib/csrc/bottleneck/bottleneck.cpp
+++ b/apex/contrib/csrc/bottleneck/bottleneck.cpp
@@ -8,10 +8,6 @@
 #include <iostream>
 #include <sstream>
 
-/// TODO Remove
-#define DEBUG 1
-#define DEBUG_CUDNN 1
-
 #ifdef DEBUG
 #define DEBUG_MSG(msg)                                  \
   do {                                                  \

--- a/apex/contrib/csrc/peer_memory/peer_memory_cuda.cu
+++ b/apex/contrib/csrc/peer_memory/peer_memory_cuda.cu
@@ -132,7 +132,7 @@ void tensor_strides(at::Tensor t, bool explicit_nhwc, int& stride_N, int& stride
             stride_W = t.stride(3);
         }
     } else {
-        printf("%s;%d - t.dim() must be either 3 or 4 (was %d)\n",__FILE__,__LINE__,t.dim());
+        printf("%s;%d - t.dim() must be either 3 or 4 (was %d)\n",__FILE__,__LINE__,int(t.dim()));
         assert(t.dim() == 3 || t.dim() == 4);
     }
 }

--- a/apex/contrib/peer_memory/peer_halo_exchanger_1d.py
+++ b/apex/contrib/peer_memory/peer_halo_exchanger_1d.py
@@ -27,7 +27,7 @@ class PeerHaloExchanger1d:
         shape = [1, 1, 1, size // halo.element_size()]
         return self.peer_pool.allocate_peer_tensors(shape, halo.dtype, False, True)
 
-    def __call__(self, y, H_split=True, explicit_nhwc=False, numSM=0, diagnostics=False):
+    def __call__(self, y, H_split=True, explicit_nhwc=False, numSM=1, diagnostics=False):
         channels_last = y.is_contiguous(memory_format=torch.channels_last) and not explicit_nhwc
         if H_split:
             if explicit_nhwc:

--- a/apex/contrib/test/bottleneck/test_bottleneck_module.py
+++ b/apex/contrib/test/bottleneck/test_bottleneck_module.py
@@ -232,7 +232,7 @@ def main():
     explicit_nhwc = True
 
     dtype = torch.float16
-    N, C, H, W = 1, 64, 200, 336
+    N, C, H, W = 1, 16, 64, 16
     Hs = ((H + 8 * world_size - 1) // (8 * world_size)) * 8
     H = Hs * world_size
     gt_bottleneck = ground_truth_bottleneck(C, dtype, explicit_nhwc)
@@ -288,7 +288,7 @@ class TestBottleneck(NcclDistributedTestBase):
     def test_bottleneck_without_peer_memory(self) -> None:
         explicit_nhwc: bool = True
         dtype: torch.dtype = torch.float16
-        N, C, H, W = 1, 64, 200, 336
+        N, C, H, W = 1, 16, 64, 16
         Hs = ((H + 8 * self.world_size - 1) // (8 * self.world_size)) * 8
         H = Hs * self.world_size
 
@@ -300,10 +300,9 @@ class TestBottleneck(NcclDistributedTestBase):
         self.assertEqual(gt, bt, **self.fp16_tolerance)
 
     def test_bottleneck_with_peer_memory(self, spatial_method=1) -> None:
-
         explicit_nhwc: bool = True
         dtype: torch.dtype = torch.float16
-        N, C, H, W = 1, 64, 200, 336
+        N, C, H, W = 1, 16, 64, 16
         Hs = ((H + 8 * self.world_size - 1) // (8 * self.world_size)) * 8
         H = Hs * self.world_size
 


### PR DESCRIPTION
This PR makes changes to the halo exchange kernels and bottleneck layers to eliminate as much overhead as possible:
- Optimize the halo exchange kernel to run with 1 SM. This required decoupling the peer buffer size from the number of CUDA threads.
- Refactor the bottleneck layer to simplify the control flow.
- Reenable unit tests for the spatial-parallel bottleneck layer.
- Remove unnecessary memory copies in bottleneck layer.
- Add new C++ functions for the bottleneck layer to call cuDNN kernels. These are relatively general and stateless to make development and debugging easier.

Running the Mask R-CNN benchmark on a DGX A100, I now see excellent overlapping when we overlap the interior convolution with the halo exchange + halo convolution (spatial method 1). There are a few memory copies when we do a partial convolution + halo correction (spatial method 3), but these might be unavoidable due to cuDNN limitations (no support for outputting tensor subregions to different output tensors, weight tensor must be contiguous).

The cuDNN wrapper functions are still a work in progress, although this PR contains all of the performance-relevant operations. I would like to entirely remove `forward_{init,out*,rest}` and `backward_{init,grad*,wgrad*,rest}`, but I would need to add `conv_scale_bias`, `conv_scale_bias_add_relu`, `drelu_dscale`, `dconv`, `dconv_add`, and `wgrad`. Perhaps there is some way to configure cuDNN from Python instead of going through the tedious process of making a new function for each case.

Pinging @thorjohnsen.