### PR TITLE
Support grad_output with noncontiguous strides in LinearWithGradAccum…

### DIFF
--- a/apex/transformer/tensor_parallel/layers.py
+++ b/apex/transformer/tensor_parallel/layers.py
@@ -391,7 +391,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
             return grad_input, None, None, None, None, None, None
 
         # Convert the tensor shapes to 2D for execution compatibility
-        grad_output = grad_output.view(
+        grad_output = grad_output.reshape(
             grad_output.shape[0] * grad_output.shape[1], grad_output.shape[2]
         )
         total_input = total_input.view(total_input.shape[0] * total_input.shape[1], total_input.shape[2])


### PR DESCRIPTION
…ulationAndAsyncCommunication

```python
30: │ /mnt/nvme/home/uwu/conda/nemo-113/lib/python3.8/site-packages/apex/transform │
30: │ er/tensor_parallel/layers.py:394 in backward                                 │
30: │                                                                              │
30: │   391 │   │   │   return grad_input, None, None, None, None, None, None      │
30: │   392 │   │                                                                  │
30: │   393 │   │   # Convert the tensor shapes to 2D for execution compatibility  │
30: │ ❱ 394 │   │   grad_output = grad_output.view(                                │
30: │   395 │   │   │   grad_output.shape[0] * grad_output.shape[1], grad_output.s │
30: │   396 │   │   )                                                              │
30: │   397 │   │   total_input = total_input.view(total_input.shape[0] * total_in │
30: ╰──────────────────────────────────────────────────────────────────────────────╯
RuntimeError: view size is not compatible with input tensor's size and stride 
(at least one dimension spans across two contiguous subspaces). Use 
.reshape(...) instead.
```
To solve this I replaced the `view` with a `reshape` in `LinearWithGradAccumulationAndAsyncCommunication.backward`