### PR TITLE
quick fix: torch.empty() must have args

### DIFF
--- a/apex/amp/compat.py
+++ b/apex/amp/compat.py
@@ -6,12 +6,12 @@ def variable_is_tensor():
     return isinstance(v, torch.Tensor)
 
 def tensor_is_variable():
-    x = torch.empty()
+    x = torch.Tensor()
     return type(x) == torch.autograd.Variable
 
 # False for post-0.4
 def tensor_is_float_tensor():
-    x = torch.empty()
+    x = torch.Tensor()
     return type(x) == torch.FloatTensor
 
 # Akin to `torch.is_tensor`, but returns True for Variable


### PR DESCRIPTION
Fixes small bug introduced in my last PR https://github.com/NVIDIA/apex/pull/1578

credits to @MozerWang