### PR TITLE
Fix incorrect initialization of GenericFusedScaleMaskSoftmax

### DIFF
--- a/apex/transformer/functional/fused_softmax.py
+++ b/apex/transformer/functional/fused_softmax.py
@@ -115,7 +115,7 @@ class GenericScaledMaskedSoftmax(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, output_grads):
-        import generic_scaled_masked_softmax_cuda_new
+        import generic_scaled_masked_softmax_cuda
 
         softmax_results, scale_t = ctx.saved_tensors
 
@@ -293,7 +293,7 @@ class GenericFusedScaleMaskSoftmax(FusedScaleMaskSoftmax):
         self, input_in_fp16, input_in_bf16, scaled_masked_softmax_fusion, mask_func, softmax_in_fp32, scale,
     ):
         super().__init__(input_in_fp16, input_in_bf16, AttnMaskType.padding, scaled_masked_softmax_fusion, mask_func, softmax_in_fp32, scale)
-        self.scaled_masked_softmax_fusion = generic_scaled_masked_softmax
+        self.fused_softmax_func = generic_scaled_masked_softmax
 
     def is_kernel_available(self, mask, b, np, sq, sk):
         if self.scaled_masked_softmax_fusion and 0 < sk:  # user want to fuse  # sk must be 1 ~

--- a/tests/L0/run_transformer/test_fused_softmax.py
+++ b/tests/L0/run_transformer/test_fused_softmax.py
@@ -9,6 +9,7 @@ from torch.testing._internal import common_utils
 
 from apex.transformer import AttnMaskType
 from apex.transformer.functional import FusedScaleMaskSoftmax
+from apex.transformer.functional.fused_softmax import GenericFusedScaleMaskSoftmax
 
 
 def attention_mask_func(attention_scores, attention_mask):
@@ -327,6 +328,31 @@ class TestGenericFusedSoftmaxKernel(common_utils.TestCase):
 
         self.q_k_lens = itertools.product(qlen, klen)
 
+    def _setup_generic_fused_softmax(
+        self,
+        input_in_fp16,
+        input_in_bf16,
+        scale=None,
+        softmax_in_fp32=False,
+    ):
+        fused_fn = GenericFusedScaleMaskSoftmax(
+            input_in_fp16=input_in_fp16,
+            input_in_bf16=input_in_bf16,
+            mask_func=attention_mask_func,
+            scale=scale,
+            softmax_in_fp32=softmax_in_fp32,
+            scaled_masked_softmax_fusion=True,
+        )
+        torch_fn = GenericFusedScaleMaskSoftmax(
+            input_in_fp16=input_in_fp16,
+            input_in_bf16=input_in_bf16,
+            mask_func=attention_mask_func,
+            scale=scale,
+            softmax_in_fp32=softmax_in_fp32,
+            scaled_masked_softmax_fusion=False,
+        )
+        return fused_fn, torch_fn
+
     def tearDown(self) -> None:
         torch.cuda.empty_cache()
         super().tearDown()
@@ -366,6 +392,51 @@ class TestGenericFusedSoftmaxKernel(common_utils.TestCase):
     def test_allmask_backward(self):
         self.test_backward(True)
 
+    def test_generic_fused_scale_mask_softmax(self):
+        """
+        attention_scores.shape = [4, 12, 24, 24]
+        mask.shape = [4, 1, 24, 24]
+        """
+        for (dtype, scale, softmax_in_fp32, shape) in itertools.product(
+            (torch.half, torch.bfloat16), (None, 2.0), (False, True), ((4, 12, 24, 24), (32, 12, 4, 214))
+        ):
+            msg = f"{dtype}-{scale}-{softmax_in_fp32}"
+            input_in_fp16 = dtype == torch.half
+            input_in_bf16 = dtype == torch.bfloat16
+            if not (scale is None or softmax_in_fp32):
+                with self.assertRaises(RuntimeError, msg=msg):
+                    self._setup_generic_fused_softmax(
+                        input_in_fp16,
+                        input_in_bf16,
+                        scale,
+                        softmax_in_fp32,
+                    )
+                return
+            fused_fn, torch_fn = self._setup_generic_fused_softmax(
+                input_in_fp16,
+                input_in_bf16,
+                scale,
+                softmax_in_fp32,
+            )
+
+            attention_scores_0 = (
+                torch.randn(shape)
+                .to(device="cuda", dtype=dtype)
+                .requires_grad_(True)
+            )
+            with torch.no_grad():
+                attention_scores_1 = attention_scores_0.clone().requires_grad_(True)
+            mask_shape = (shape[0],) + (1,) + shape[2:]
+            mask = torch.randint(0, 2, mask_shape, device="cuda").bool()
+            expected = fused_fn(attention_scores_0, mask)
+            actual = torch_fn(attention_scores_1, mask)
+            self.assertEqual(actual, expected, msg=msg)
+
+            g0 = torch.rand_like(actual)
+            with torch.no_grad():
+                g1 = g0.clone()
+            expected.backward(g0)
+            actual.backward(g1)
 
 if __name__ == "__main__":
     common_utils.run_tests()


### PR DESCRIPTION
### Summary

Fixes an error in the initialization of GenericFusedScaleMaskSoftmax which leads to `generic_scaled_masked_softmax` never actually being called.

Fixes import error in `GenericScaledMaskedSoftmax.backward` which had also gone unnoticed.

Also adds a test for GenericFusedScaleMaskSoftmax similar to the one for FusedScaleMaskSoftmax to prevent future errors.  

### Details

Currently when GenericFusedScaleMaskSoftmax is initialized we set `self.scaled_masked_softmax_fusion` to to the `generic_scaled_masked_softmax` function. I believe this is done in error as the function called by the fused forward is `self.fused_softmax_func` and not `self.scaled_masked_softmax_fusion` (which is supposed to be the flag that indicates whether to use the fused version).

In practice this means that when GenericFusedScaleMaskSoftmax is initialized it actually does not use `generic_scaled_masked_softmax` at all and `is_kernel_available` will return True even when initialized with `scaled_masked_softmax_fusion = False`.
