### PR TITLE
check for empty params in group

### DIFF
--- a/apex/optimizers/fused_adam.py
+++ b/apex/optimizers/fused_adam.py
@@ -79,7 +79,8 @@ class FusedAdam(torch.optim.Optimizer):
 
         if capturable:
             for idx, group in enumerate(self.param_groups):
-                device = 'cuda' if len(group['params']) == 0 else group['params'][0].device
+                if len(group['params']) == 0:
+                    continue
                 for item in ['lr']:
                     self.param_groups[idx][item] = group[item].to(device=device)
 
@@ -118,7 +119,8 @@ class FusedAdam(torch.optim.Optimizer):
             loss = closure()
 
         for group in self.param_groups:
-            device = 'cuda' if len(group['params']) == 0 else group['params'][0].device
+            if len(group['params']) == 0:
+                continue
             bias_correction = 1 if group['bias_correction'] else 0
             beta1, beta2 = group['betas']
 

--- a/apex/optimizers/fused_adam.py
+++ b/apex/optimizers/fused_adam.py
@@ -81,6 +81,7 @@ class FusedAdam(torch.optim.Optimizer):
             for idx, group in enumerate(self.param_groups):
                 if len(group['params']) == 0:
                     continue
+                device = group['params'][0].device
                 for item in ['lr']:
                     self.param_groups[idx][item] = group[item].to(device=device)
 
@@ -121,6 +122,7 @@ class FusedAdam(torch.optim.Optimizer):
         for group in self.param_groups:
             if len(group['params']) == 0:
                 continue
+            device = group['params'][0].device
             bias_correction = 1 if group['bias_correction'] else 0
             beta1, beta2 = group['betas']
 

--- a/apex/optimizers/fused_adam.py
+++ b/apex/optimizers/fused_adam.py
@@ -78,8 +78,8 @@ class FusedAdam(torch.optim.Optimizer):
         self.capturable = capturable
 
         if capturable:
-            device = self.param_groups[0]['params'][0].device
             for idx, group in enumerate(self.param_groups):
+                device = 'cuda' if len(group['params']) == 0 else group['params'][0].device
                 for item in ['lr']:
                     self.param_groups[idx][item] = group[item].to(device=device)
 
@@ -118,7 +118,7 @@ class FusedAdam(torch.optim.Optimizer):
             loss = closure()
 
         for group in self.param_groups:
-            device = group['params'][0].device
+            device = 'cuda' if len(group['params']) == 0 else group['params'][0].device
             bias_correction = 1 if group['bias_correction'] else 0
             beta1, beta2 = group['betas']
 

--- a/tests/L0/run_optimizers/test_fused_optimizer.py
+++ b/tests/L0/run_optimizers/test_fused_optimizer.py
@@ -130,7 +130,7 @@ class TestFusedAdam(TestFusedOptimizer):
             max_abs_diff, max_rel_diff = self.get_max_diff(ref_param, tst_param)
             self.assertLessEqual(max_abs_diff, self.max_abs_diff)
             self.assertLessEqual(max_rel_diff, self.max_rel_diff)
-
+            
     @unittest.skip('No longer support fuse scaling')
     def test_scale(self):
         nelem = 278011
@@ -189,8 +189,29 @@ class TestFusedAdam(TestFusedOptimizer):
 
             self.assertLessEqual(max_abs_diff, self.max_abs_diff)
             self.assertLessEqual(max_rel_diff, self.max_rel_diff)
+            
+    def test_frozen_model(self):
+        nelem = 1
+        adam_option = {'lr':0.01, 'betas':(0.6, 0.9), 'eps':3e-06,
+            'weight_decay':0, 'amsgrad':False}
 
+        tensor = torch.rand(nelem, dtype=torch.float, device='cuda')
+        ref_param, tst_param, ref_optim, tst_optim = \
+            self.gen_param_optim([tensor], adam_option)
 
+        #Add an empty param group which may occur for pipeline parallel p-tuning
+        tst_optim.add_param_group({"params": []})
+
+        for i in range(self.iters):
+            self.gen_grad(ref_param, tst_param)
+            ref_optim.step()
+            tst_optim.step()
+            max_abs_diff, max_rel_diff = self.get_max_diff(ref_param, tst_param)
+
+            self.assertLessEqual(max_abs_diff, self.max_abs_diff)
+            self.assertLessEqual(max_rel_diff, self.max_rel_diff)
+
+            
 class TestFusedAdagrad(TestFusedOptimizer):
     def __init__(self, *args, **kwargs):
         super(TestFusedAdagrad, self).__init__(*args, **kwargs)

--- a/tests/L0/run_optimizers/test_fused_optimizer.py
+++ b/tests/L0/run_optimizers/test_fused_optimizer.py
@@ -130,7 +130,7 @@ class TestFusedAdam(TestFusedOptimizer):
             max_abs_diff, max_rel_diff = self.get_max_diff(ref_param, tst_param)
             self.assertLessEqual(max_abs_diff, self.max_abs_diff)
             self.assertLessEqual(max_rel_diff, self.max_rel_diff)
-            
+
     @unittest.skip('No longer support fuse scaling')
     def test_scale(self):
         nelem = 278011


### PR DESCRIPTION
A Recent update fails for parameter efficient fine-training (PEFT) setup. In this setup, a small subset of params are trained and the rest of the network is frozen. When using PEFT with pipeline parallel mode, it is possible that an entire rank has no trainable params. See this error log:
<img width="1080" alt="Screen Shot 2023-02-23 at 12 20 18 PM" src="https://user-images.githubusercontent.com/108822655/221021047-db4022cc-65e2-4b54-be7f-b786dee456c4.png">


This PR checks for `len(group['params'])` and defaults to 'cuda' if params are empty.