### PR TITLE
fix bug when CUDA_HOME is None

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ this_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def get_cuda_bare_metal_version(cuda_dir):
+    if not cuda_dir:
+        return '', ''
     raw_output = subprocess.check_output([cuda_dir + "/bin/nvcc", "-V"], universal_newlines=True)
     output = raw_output.split()
     release_idx = output.index("release") + 1


### PR DESCRIPTION
when install apex on cpu platform(no support CUDA), the installation throw the following error:
`
  Running command python setup.py egg_info
  Traceback (most recent call last):
    File "<string>", line 2, in <module>
    File "<pip-setuptools-caller>", line 34, in <module>
    File "/home/x/x/apex/setup.py", line 131, in <module>
      _, bare_metal_version = get_cuda_bare_metal_version(CUDA_HOME)
    File "/home/x/x/apex/setup.py", line 17, in get_cuda_bare_metal_version
      raw_output = subprocess.check_output([cuda_dir + "/bin/nvcc", "-V"], universal_newlines=True)
  TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
`
This PR will fix it.
