### PR TITLE
Align distopt communication in interleaved pipeline parallelism

### DIFF
--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -1407,37 +1407,60 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                 # Cached gradient norm has been invalidated
                 self._grad_norm = None
 
-    def _try_start_bucket_param_sync(self):
+    def _try_start_bucket_param_sync(
+            self,
+            params=None,
+    ):
         """Attempt to launch parameter synchronization
 
-        Launches parameter synchronization if there is at least one
-        unsynchronized bucket and there are no other synchronizations
-        in progress. Parameter synchronization is asynchronous.
+        Launches parameter synchronization for buckets corresponding
+        to provided parameters, if needed. If parameters are not
+        provided and no other synchronizations are in progress,
+        attempts to find a parameter that still requires
+        synchronization. Parameter synchronization is asynchronous.
+
+        Arguments:
+            params (iterable, optional): parameters to synchronize
 
         """
 
-        # Only launch param sync if there is an unsynchronized bucket
-        # and no other syncs are in progress
-        if not any(bucket.status == self.ParameterStatus.SHARDED
+        # Default behavior: only launch param sync if no other syncs
+        # are in progress
+        if params is None:
+            params = []
+            if any(bucket.status == self.ParameterStatus.SYNCING
                    for bucket in self._params_buckets.values()):
-            return
-        if any(bucket.status == self.ParameterStatus.SYNCING
-               for bucket in self._params_buckets.values()):
-            return
-
-        # Launch param sync for all buckets containing a given param
-        for bucket_id, bucket in self._params_buckets.items():
-            if bucket.status == self.ParameterStatus.SHARDED:
-                fragment = self.state['buckets'][bucket_id].fragments[-1]
-                param_group_id = fragment.param_group_id
-                param_id = fragment.param_id
-                param = self.param_groups[param_group_id]['params'][param_id]
-                self._start_bucket_param_sync([
-                    self._params_buckets[fragment.bucket_id]
-                    for fragment in self.state[param]['fragments']
-                    if fragment.bucket_id in self._params_buckets
-                ])
                 return
+            for bucket_id, bucket in self._params_buckets.items():
+                if bucket.status == self.ParameterStatus.SHARDED:
+                    fragment = self.state['buckets'][bucket_id].fragments[-1]
+                    param_group_id = fragment.param_group_id
+                    param_id = fragment.param_id
+                    param = self.param_groups[param_group_id]['params'][param_id]
+                    params.append(param)
+                    break
+
+        # Find buckets corresponding to params
+        bucket_ids = set()
+        for param in params:
+            bucket_ids.update(
+                fragment.bucket_id
+                for fragment in self.state[param]['fragments']
+            )
+        buckets = [
+            self._params_buckets[bucket_id]
+            for bucket_id in sorted(bucket_ids)
+            if bucket_id in self._params_buckets
+        ]
+        buckets = [
+            bucket
+            for bucket in buckets
+            if bucket.status == self.ParameterStatus.SHARDED
+        ]
+
+        # Launch param sync if needed
+        if buckets:
+            self._start_bucket_param_sync(buckets)
 
     def _start_bucket_param_sync(self, buckets):
         """Synchronize parameter buckets
@@ -1449,10 +1472,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         """
 
         # Complete any outstanding param syncs
-        # Note: Not needed with contiguous param buffer since there is
-        # no memory benefit from eagerly freeing param buffers.
-        if not self.contiguous_param_buffer:
-            self._finish_bucket_param_sync()
+        self._finish_bucket_param_sync()
 
         # Initialize param state and buffers
         buckets = [

--- a/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_with_interleaving.py
+++ b/apex/transformer/pipeline_parallel/schedules/fwd_bwd_pipelining_with_interleaving.py
@@ -311,8 +311,7 @@ def _forward_backward_pipelining_with_interleaving(
         parallel_state.set_virtual_pipeline_model_parallel_rank(model_chunk_id)
 
         # launch grad synchronization (default)
-        if custom_grad_sync_func is None:
-            if is_last_microbatch_for_model_chunk(microbatch_id):
+        if custom_grad_sync_func is None and is_last_microbatch_for_model_chunk(microbatch_id):
                 enable_grad_sync()
 
         # backward step


### PR DESCRIPTION
While running NeMo-Megatron using the distributed optimizer and interleaved pipeline parallelism, we have observed excessive GPU idle time. The root cause is that asynchronous NCCL collectives slow down some GEMMs, so microbatches with overlapped reduce-scatters or all-gathers will take longer and other pipeline-parallel ranks have to wait to receive data. Our current implementation gets the worst-case behavior and the GEMM perf degradation is magnified by the total number of virtual pipeline stages. The fix is for all pipeline-parallel ranks to launch NCCL at the same time, so they're all similarly slowed down and the GEMM perf degradation doesn't compound.