### PR TITLE
Overlap first param sync with optimizer step in distributed Adam

### DIFF
--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -1794,29 +1794,61 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                     device=self.device,
                 )
 
-        # Apply optimizer step
+        # Apply optimizer step and synchronize params
         self.state['step'] += 1
-        if self.store_param_remainders:
-            self._local_step_with_param_remainders()
-        else:
-            self._local_step()
+        if self.distributed_size > 1 and self.overlap_param_sync and self.state['buckets']:
+            # Local step and non-blocking param sync
+            # Note: Overlap param sync of first buckets with optimizer
+            # step of remaining buckets.
 
-        # Make sure all parameters are synchronized if needed
-        if self.distributed_size > 1 and self.overlap_param_sync:
-            self._try_start_bucket_param_sync()
+            # Get buckets containing "first" parameter
+            fragment = self.state['buckets'][-1].fragments[-1]
+            param_group_id = fragment.param_group_id
+            param_id = fragment.param_id
+            param = self.param_groups[param_group_id]['params'][param_id]
+            first_bucket_ids = sorted(
+                fragment.bucket_id
+                for fragment in self.state[param]['fragments']
+            )
+
+            # Local step and launch param sync for first buckets
+            self._local_step(first_bucket_ids)
+            self._start_bucket_param_sync([
+                self._params_buckets[bucket_id]
+                for bucket_id in first_bucket_ids
+            ])
+
+            # Local step for remaining buckets
+            first_bucket_ids = set(first_bucket_ids)
+            self._local_step([
+                bucket_id
+                for bucket_id in range(len(self.state['buckets']))
+                if bucket_id not in first_bucket_ids
+            ])
+
+            # Enable pre-forward hook
             for param in self.parameters():
                 param._pre_forward_hook_is_enabled = True
+
         else:
+            # Local step and blocking param sync
+            self._local_step(list(range(len(self.state['buckets']))))
             self.param_sync()
 
         return loss
 
-    def _local_step(self):
+    def _local_step(self, bucket_ids):
         """Apply optimizer step to local shard of parameter buckets"""
+
+        # Optimized implementation with BF16 params and 16-bit param
+        # remainders
+        if self.store_param_remainders:
+            self._local_step_with_param_remainders(bucket_ids)
+            return
 
         # Find param fragments for each bucket
         buffers = collections.defaultdict(list) # p_in, m, v, g, p_out
-        for bucket_id in range(len(self.state['buckets'])):
+        for bucket_id in bucket_ids:
 
             # Optimizer state buffers for local shard
             fragments = self.state['buckets'][bucket_id].fragments
@@ -1867,7 +1899,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                 group['weight_decay'],
             )
 
-    def _local_step_with_param_remainders(self):
+    def _local_step_with_param_remainders(self, bucket_ids):
         """Apply optimizer step to local shard of parameter bucket
 
         This is an experimental implementation that expects
@@ -1878,7 +1910,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
         # Find param fragments for each bucket
         buffers = collections.defaultdict(list) # p_in, p_rem, m, v, g, p_out
-        for bucket_id in range(len(self.state['buckets'])):
+        for bucket_id in bucket_ids:
 
             # State buffers for local shard
             fragments = self.state['buckets'][bucket_id].fragments

--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -1813,18 +1813,18 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
             # Local step and launch param sync for first buckets
             self._local_step(first_bucket_ids)
-            self._start_bucket_param_sync([
+            self._start_bucket_param_sync(
                 self._params_buckets[bucket_id]
                 for bucket_id in first_bucket_ids
-            ])
+            )
 
             # Local step for remaining buckets
             first_bucket_ids = set(first_bucket_ids)
-            self._local_step([
+            self._local_step(
                 bucket_id
                 for bucket_id in range(len(self.state['buckets']))
                 if bucket_id not in first_bucket_ids
-            ])
+            )
 
             # Enable pre-forward hook
             for param in self.parameters():
@@ -1838,7 +1838,12 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         return loss
 
     def _local_step(self, bucket_ids):
-        """Apply optimizer step to local shard of parameter buckets"""
+        """Apply optimizer step to local shard of parameter buckets
+
+        Arguments:
+            bucket_ids (iterable): bucket indices
+
+        """
 
         # Optimized implementation with BF16 params and 16-bit param
         # remainders
@@ -1906,6 +1911,10 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         store_params=False and store_param_remainders=True. The
         optimizer dtype must be FP32 and the params must all be BF16
         and GPU.
+
+        Arguments:
+            bucket_ids (iterable): bucket indices
+
         """
 
         # Find param fragments for each bucket


### PR DESCRIPTION
When you try overlapping forward compute with distopt param all-gathers, one all-gather is fully exposed. This PR overlaps that all-gather with the optimizer step.