### PR TITLE
CUDA_HOME not checked before use

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,8 @@ if (TORCH_MAJOR > 1) or (TORCH_MAJOR == 1 and TORCH_MINOR > 4):
     version_ge_1_5 = ["-DVERSION_GE_1_5"]
 version_dependent_macros = version_ge_1_1 + version_ge_1_3 + version_ge_1_5
 
+raise_if_cuda_home_none("get_cuda_bare_metal_version")
+
 _, bare_metal_version = get_cuda_bare_metal_version(CUDA_HOME)
 
 if "--distributed_adam" in sys.argv:


### PR DESCRIPTION
Trying to install apex:
```pip3 install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./```
and get error: 
```Processing /my/path/apex
  Running command python setup.py egg_info
  Traceback (most recent call last):
    File "<string>", line 2, in <module>
    File "<pip-setuptools-caller>", line 34, in <module>
    File "/my/path/apex/setup.py", line 132, in <module>
      _, bare_metal_version = get_cuda_bare_metal_version(CUDA_HOME)
    File "/my/path/apex/setup.py", line 17, in get_cuda_bare_metal_version
      raw_output = subprocess.check_output([cuda_dir + "/bin/nvcc", "-V"], universal_newlines=True)
  TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```
This happened because my CUDA_HOME isn't specified and equal to None and ```cuda_dir + "/bin/nvcc" -> None + str``` 
CUDA_HOME not checked before use.