### PR TITLE
Using regular layernorm for ONNX and TS export

### DIFF
--- a/apex/normalization/fused_layer_norm.py
+++ b/apex/normalization/fused_layer_norm.py
@@ -286,7 +286,7 @@ class FusedLayerNorm(torch.nn.Module):
             init.zeros_(self.bias)
 
     def forward(self, input):
-        if not input.is_cuda:
+        if torch.jit.is_tracing() or torch.jit.is_scripting() or not input.is_cuda:
             return F.layer_norm(input, self.normalized_shape, self.weight, self.bias, self.eps)
         if self.elementwise_affine:
             return fused_layer_norm_affine(input, self.weight, self.bias, self.normalized_shape, self.eps)
@@ -379,7 +379,7 @@ class FusedRMSNorm(torch.nn.Module):
             init.ones_(self.weight)
 
     def forward(self, input):
-        if not input.is_cuda:
+        if torch.jit.is_tracing() or torch.jit.is_scripting() or not input.is_cuda:
             return manual_rms_norm(input, self.normalized_shape, self.weight, self.eps)
 
         if self.elementwise_affine:
@@ -409,7 +409,7 @@ class MixedFusedLayerNorm(FusedLayerNorm):
 
     def forward(self, input: torch.Tensor):
         # NOTE (mkozuki): CPU path is here mainly for unittest sake.
-        if not input.is_cuda:
+        if torch.jit.is_tracing() or torch.jit.is_scripting() or not input.is_cuda:
             return F.layer_norm(input, self.normalized_shape, self.weight, self.bias, self.eps)
         return mixed_dtype_fused_layer_norm_affine(input, self.weight, self.bias, self.normalized_shape, self.eps)
 
@@ -432,6 +432,6 @@ class MixedFusedRMSNorm(FusedRMSNorm):
     def forward(self, input: torch.Tensor):
         # NOTE (mkozuki): CPU path is here mainly for unittest sake.
         # TODO Manual RMS Norm Implementation Here
-        if not input.is_cuda:
+        if torch.jit.is_tracing() or torch.jit.is_scripting() or not input.is_cuda:
             return manual_rms_norm(input, self.normalized_shape, self.weight, self.eps)
         return mixed_dtype_fused_rms_norm_affine(input, self.weight, self.normalized_shape, self.eps)

--- a/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
+++ b/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
@@ -233,8 +233,6 @@ class TestFusedLayerNorm(common_utils.TestCase):
 
         tols = {'rtol': None, 'atol': None} if dtype == torch.half else bf16_bwd_thresholds
         torch.testing.assert_close(native_x.grad, fused_x.grad, **tols, check_dtype=False)
-        # check that export() is working
-        verify(fused, fused_x)
         
     @common_utils.parametrize(
         "dtype, elementwise_affine",
@@ -267,10 +265,45 @@ class TestFusedLayerNorm(common_utils.TestCase):
 
         tols = {'rtol': 1e-3, 'atol': 1e-3} if dtype == torch.half else bf16_bwd_thresholds
         torch.testing.assert_close(native_x.grad.cuda(), fused_x.grad, **tols, check_dtype=False)
-        # check that export() is working
-        self.verify_norm(fused, fused_x, dtype)
+
 
 instantiate_device_type_tests(TestFusedLayerNorm, globals(), only_for=("cuda",))
 
+def _verify_export(fused, fused_x):
+    # check that export() is working
+    onnx_str = torch.onnx.export_to_pretty_string(fused, (fused_x,),
+                                                  input_names=['x_in'],
+    )
+    assert('x_in' in onnx_str)
+    assert('ReduceMean' in onnx_str)
+
+        
+def test_export_fused_rms_norm():
+    batch_size = 16
+    normalized_shape = [32, 16]
+    fused = FusedRMSNorm(
+        normalized_shape=normalized_shape, elementwise_affine=True
+    ).cuda()
+    fused_m = MixedFusedRMSNorm(
+        normalized_shape=normalized_shape, elementwise_affine=True
+    ).cuda()
+    native_x, fused_x = _prep_inputs(batch_size, normalized_shape, torch.float32)
+    _verify_export(fused, fused_x)
+    _verify_export(fused_m, fused_x)
+    
+
+def test_export_fused_layer_norm():
+    batch_size = 16
+    normalized_shape = [32, 16]
+    fused = FusedLayerNorm(
+        normalized_shape=normalized_shape, elementwise_affine=True
+    ).cuda()
+    fused_m = MixedFusedLayerNorm(
+        normalized_shape=normalized_shape, elementwise_affine=True
+    ).cuda()
+    native_x, fused_x = _prep_inputs(batch_size, normalized_shape, torch.float32)
+    _verify_export(fused, fused_x)
+    _verify_export(fused_m, fused_x)
+    
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
+++ b/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
@@ -232,7 +232,6 @@ class TestFusedLayerNorm(common_utils.TestCase):
 
         tols = {'rtol': None, 'atol': None} if dtype == torch.half else bf16_bwd_thresholds
         torch.testing.assert_close(native_x.grad, fused_x.grad, **tols, check_dtype=False)
-        
     @common_utils.parametrize(
         "dtype, elementwise_affine",
         list(product(autocast_dtypes, (True, False)))
@@ -300,6 +299,5 @@ class TestFusedLayerNorm(common_utils.TestCase):
         self._verify_export(fused_m, fused_x)
         
 instantiate_device_type_tests(TestFusedLayerNorm, globals(), only_for=("cuda",))
-    
 if __name__ == "__main__":
     common_utils.run_tests()

--- a/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
+++ b/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
@@ -1,5 +1,4 @@
 import torch
-from torch.onnx.verification import verify
 from apex.normalization import FusedLayerNorm
 from apex.normalization import FusedRMSNorm
 from apex.normalization import MixedFusedLayerNorm
@@ -266,44 +265,41 @@ class TestFusedLayerNorm(common_utils.TestCase):
         tols = {'rtol': 1e-3, 'atol': 1e-3} if dtype == torch.half else bf16_bwd_thresholds
         torch.testing.assert_close(native_x.grad.cuda(), fused_x.grad, **tols, check_dtype=False)
 
+    def _verify_export(self, fused, fused_x):
+        # check that export() is working
+        onnx_str = torch.onnx.export_to_pretty_string(fused, (fused_x,),
+                                                      input_names=['x_in'],
+        )
+        assert 'x_in' in onnx_str
+        assert 'ReduceMean' in onnx_str
 
-instantiate_device_type_tests(TestFusedLayerNorm, globals(), only_for=("cuda",))
-
-def _verify_export(fused, fused_x):
-    # check that export() is working
-    onnx_str = torch.onnx.export_to_pretty_string(fused, (fused_x,),
-                                                  input_names=['x_in'],
-    )
-    assert('x_in' in onnx_str)
-    assert('ReduceMean' in onnx_str)
-
+    def test_rms_export(self):
+        batch_size = 16
+        normalized_shape = [32, 16]
+        fused = FusedRMSNorm(
+            normalized_shape=normalized_shape, elementwise_affine=True
+        ).cuda()
+        fused_m = MixedFusedRMSNorm(
+            normalized_shape=normalized_shape, elementwise_affine=True
+        ).cuda()
+        native_x, fused_x = _prep_inputs(batch_size, normalized_shape, torch.float32)
+        self._verify_export(fused, fused_x)
+        self._verify_export(fused_m, fused_x)
         
-def test_export_fused_rms_norm():
-    batch_size = 16
-    normalized_shape = [32, 16]
-    fused = FusedRMSNorm(
-        normalized_shape=normalized_shape, elementwise_affine=True
-    ).cuda()
-    fused_m = MixedFusedRMSNorm(
-        normalized_shape=normalized_shape, elementwise_affine=True
-    ).cuda()
-    native_x, fused_x = _prep_inputs(batch_size, normalized_shape, torch.float32)
-    _verify_export(fused, fused_x)
-    _verify_export(fused_m, fused_x)
-    
-
-def test_export_fused_layer_norm():
-    batch_size = 16
-    normalized_shape = [32, 16]
-    fused = FusedLayerNorm(
-        normalized_shape=normalized_shape, elementwise_affine=True
-    ).cuda()
-    fused_m = MixedFusedLayerNorm(
-        normalized_shape=normalized_shape, elementwise_affine=True
-    ).cuda()
-    native_x, fused_x = _prep_inputs(batch_size, normalized_shape, torch.float32)
-    _verify_export(fused, fused_x)
-    _verify_export(fused_m, fused_x)
+    def test_layer_norm_export(self):
+        batch_size = 16
+        normalized_shape = [32, 16]
+        fused = FusedLayerNorm(
+            normalized_shape=normalized_shape, elementwise_affine=True
+        ).cuda()
+        fused_m = MixedFusedLayerNorm(
+            normalized_shape=normalized_shape, elementwise_affine=True
+        ).cuda()
+        native_x, fused_x = _prep_inputs(batch_size, normalized_shape, torch.float32)
+        self._verify_export(fused, fused_x)
+        self._verify_export(fused_m, fused_x)
+        
+instantiate_device_type_tests(TestFusedLayerNorm, globals(), only_for=("cuda",))
     
 if __name__ == "__main__":
     common_utils.run_tests()


### PR DESCRIPTION
Here, we can't use Autograd.Function and Apex nodes when exporting. 
There may be better way to do that - but that at least let onnx.export, torch.jit.script(0 and torch.trace_module() be used. 
We used to replace Apex norm nodes with regular norms in Nemo - better to address at the source.
 