### PR TITLE
Support for FP32 input dtype

### DIFF
--- a/csrc/layer_norm_cuda.cpp
+++ b/csrc/layer_norm_cuda.cpp
@@ -180,7 +180,7 @@ std::vector<at::Tensor> layer_norm_affine(
   CHECK_INPUT(beta);
   int n1,n2;
   check_args(input,normalized_shape,gamma,beta,n1,n2);
-  at::Tensor output = at::empty_like(input);
+  at::Tensor output = at::empty_like(input, gamma.options().dtype(gamma.scalar_type()));
   const auto stats_dtype = (input.scalar_type() == at::ScalarType::Half || input.scalar_type() == at::ScalarType::BFloat16) ? at::ScalarType::Float : input.scalar_type();
   at::Tensor mean = at::empty({n1}, input.options().dtype(stats_dtype));
   at::Tensor invvar = at::empty_like(mean);


### PR DESCRIPTION
The Megatron code was recently updated to use apex's layernorm code.
However, the layernorm code in the previous Megatron was considered for fp32, but the apex code was not considered, so I made a PR.
In the case of code using `--fp32-residual-connection` in Megatron, fp32 dtype is used for layernorm input, but when learning with bf16 or fp16, there is a problem that layernorm of apex cannot be used.