### PR TITLE
[Transformer] Do not use batch_isend_irecv for UCC

### DIFF
--- a/apex/transformer/pipeline_parallel/p2p_communication.py
+++ b/apex/transformer/pipeline_parallel/p2p_communication.py
@@ -60,7 +60,7 @@ def _run_p2pops(
     need_to_sync = p2p_group.name() != default_group.name()
     reqs = []
 
-    if batch_p2p_comm:
+    if batch_p2p_comm and p2p_group.name() == "nccl":
         ops = []
         if tensor_send_prev is not None:
             send_prev_op = torch.distributed.P2POp(
@@ -101,9 +101,9 @@ def _run_p2pops(
             reqs = torch.distributed.batch_isend_irecv(ops)
     else:
         # sync before communication if needed
-        if need_to_sync and any(
+        if need_to_sync and any([
             tensor_send_prev is not None, tensor_recv_prev is not None,
-            tensor_send_next is not None, tensor_recv_next is not None):
+            tensor_send_next is not None, tensor_recv_next is not None]):
             torch.cuda.synchronize()
 
         if tensor_send_prev is not None:


### PR DESCRIPTION
Transformer tests are failing on UCC because it does not support the latest version of coalescing used in `batch_isend_irecv`:
```
  File "/usr/local/lib/python3.10/dist-packages/torch/distributed/distributed_c10d.py", line 1575, in _coalescing_manager
    group._start_coalescing(device)
RuntimeError: Backend uccdoes not implement startCoalescing
```
This is a workaround.