### PR TITLE
Add type hints to distributed Adam optimizer

### DIFF
--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -6,7 +6,7 @@ import inspect
 import io
 import itertools
 import threading
-from typing import Any, Callable, Iterable, List, Optional, Set, Tuple
+from typing import Any, Callable, Iterable, List, Optional, Set, Tuple, Union
 
 import torch
 from torch.distributed.distributed_c10d import _get_default_group
@@ -19,70 +19,83 @@ try:
     from torch.distributed.distributed_c10d import get_global_rank
 except ImportError:
     from torch.distributed.distributed_c10d import _get_global_rank
+
     get_global_rank = _get_global_rank
 try:
     from torch.distributed.distributed_c10d import reduce_scatter_tensor
 except ImportError:
     from torch.distributed.distributed_c10d import _reduce_scatter_base
+
     reduce_scatter_tensor = _reduce_scatter_base
 try:
     from torch.distributed.distributed_c10d import all_gather_into_tensor
 except ImportError:
     from torch.distributed.distributed_c10d import _all_gather_base
+
     all_gather_into_tensor = _all_gather_base
 
 # Import context manager to coalesce NCCL calls
 # Note: Replace these backward compatibility shims once PyTorch
 # exposes a stable public API for coalescing communication.
 from torch.distributed.distributed_c10d import _coalescing_manager
-if 'device' not in inspect.signature(_coalescing_manager).parameters:
+
+if "device" not in inspect.signature(_coalescing_manager).parameters:
     # PyTorch <=1.13.1 does not have device arg
     _coalescing_manager_no_device_arg = _coalescing_manager
+
     @contextlib.contextmanager
     def _coalescing_manager(group, device, reqs):
         with _coalescing_manager_no_device_arg(group, reqs):
             yield
-if 'reqs' in inspect.signature(_coalescing_manager).parameters:
+
+
+if "reqs" in inspect.signature(_coalescing_manager).parameters:
     # PyTorch <=2.0.1 handles synchronization externally to coalescing
     # manager
     _coalescing_manager_with_reqs_arg = _coalescing_manager
+
     class _CoalescingManager:
         def __init__(self):
             self.works: List[torch.distributed.Work] = []
+
         def append(self, work: torch.distributed.Work) -> None:
             if work:
                 self.works.append(work)
+
         def wait(self) -> None:
             for work in self.works:
                 work.wait()
+
     @contextlib.contextmanager
     def _coalescing_manager(
-            group: Optional[torch.distributed.ProcessGroup] = None,
-            device: Optional[torch.device] = None,
-            async_ops: bool = False,
+        group: Optional[torch.distributed.ProcessGroup] = None,
+        device: Optional[torch.device] = None,
+        async_ops: bool = False,
     ) -> contextlib.AbstractContextManager:
         assert device is not None
         cm = _CoalescingManager()
         with _coalescing_manager_with_reqs_arg(
-                group,
-                device,
-                cm.works,
+            group,
+            device,
+            cm.works,
         ):
             yield cm
         if not async_ops:
             cm.wait()
+
     def _coalescing_manager_append_work(
-            cm: _CoalescingManager,
-            work: torch.distributed.Work,
+        cm: _CoalescingManager,
+        work: torch.distributed.Work,
     ) -> None:
         """Add asynchronous request to coalescing manager"""
         cm.append(work)
+
 else:
     # PyTorch >2.0.1 handles synchronization within coalescing
     # manager
     def _coalescing_manager_append_work(
-            cm: torch.distributed._CoalescingManager,
-            work: torch.distributed.Work,
+        cm: torch.distributed._CoalescingManager,
+        work: torch.distributed.Work,
     ) -> None:
         """Dummy function for backward compatibility
 
@@ -92,27 +105,32 @@ else:
         """
         pass
 
+
 # Import optional CUDA kernels
 _FOUND_DEPRECATED_FUSED_ADAM: bool = False
 try:
     import fused_adam_cuda
+
     _FOUND_DEPRECATED_FUSED_ADAM = True
 except ImportError:
     import warnings
+
     warnings.warn(
-        'Could not find recommended CUDA kernels when importing '
-        '`DistributedFusedAdam`. '
-        'For best performance, Apex should be installed with '
-        '`--deprecated_fused_adam`.'
+        "Could not find recommended CUDA kernels when importing "
+        "`DistributedFusedAdam`. "
+        "For best performance, Apex should be installed with "
+        "`--deprecated_fused_adam`."
     )
 
+
 def _round_to_multiple(
-        number: int,
-        multiple: int,
-        round_up: bool = True,
+    number: int,
+    multiple: int,
+    round_up: bool = True,
 ) -> int:
     """Assumes arguments are positive integers"""
-    return (number+multiple-1 if round_up else number) // multiple * multiple
+    return (number + multiple - 1 if round_up else number) // multiple * multiple
+
 
 def _devices_match(device1: torch.device, device2: torch.device) -> bool:
     """Whether two PyTorch devices are equivalent"""
@@ -120,7 +138,7 @@ def _devices_match(device1: torch.device, device2: torch.device) -> bool:
     device2 = torch.device(device2)
     if device1.type != device2.type:
         return False
-    if device1.type == 'cuda':
+    if device1.type == "cuda":
         index1 = device1.index
         index2 = device2.index
         if index1 is None:
@@ -131,10 +149,11 @@ def _devices_match(device1: torch.device, device2: torch.device) -> bool:
             return False
     return True
 
+
 def _multi_tensor_copy(
-        buffers_in: List[torch.Tensor],
-        buffers_out: List[torch.Tensor],
-        dummy_overflow_buf: Optional[torch.Tensor] = None,
+    buffers_in: List[torch.Tensor],
+    buffers_out: List[torch.Tensor],
+    dummy_overflow_buf: Optional[torch.Tensor] = None,
 ) -> None:
     """Copy between corresponding buffers
 
@@ -157,21 +176,18 @@ def _multi_tensor_copy(
 
     # Copy each group of buffers
     for key, buffers in buffer_groups.items():
-
         # Check if buffers support fused kernel
         is_cuda_in, dtype_in, is_cuda_out, dtype_out = key
         supported_dtypes = (torch.float32, torch.float16)
         use_fused_kernel = (
-            (dtype_in in supported_dtypes and dtype_out in supported_dtypes)
-            or
-            (dtype_in == torch.uint8 and dtype_out == torch.uint8)
-        )
+            dtype_in in supported_dtypes and dtype_out in supported_dtypes
+        ) or (dtype_in == torch.uint8 and dtype_out == torch.uint8)
         use_fused_kernel = use_fused_kernel and is_cuda_in and is_cuda_out
 
         # Copy buffers
         if use_fused_kernel and _FOUND_DEPRECATED_FUSED_ADAM:
             if dummy_overflow_buf is None:
-                dummy_overflow_buf = torch.zeros([1], dtype=torch.int32, device='cuda')
+                dummy_overflow_buf = torch.zeros([1], dtype=torch.int32, device="cuda")
             multi_tensor_applier(
                 fused_adam_cuda.maybe_cast_mt,
                 dummy_overflow_buf,
@@ -181,14 +197,15 @@ def _multi_tensor_copy(
             for buf_in, buf_out in buffers:
                 buf_out.copy_(buf_in)
 
+
 @contextlib.contextmanager
 def _disable_pre_forward_hook(
-        param: torch.nn.Parameter,
+    param: torch.nn.Parameter,
 ) -> contextlib.AbstractContextManager:
     """Prevent parameter from calling pre-forward hook"""
     hook_is_enabled = getattr(
         param,
-        '_pre_forward_hook_is_enabled',
+        "_pre_forward_hook_is_enabled",
         False,
     )
     if hook_is_enabled:
@@ -198,6 +215,7 @@ def _disable_pre_forward_hook(
     finally:
         if hook_is_enabled:
             param._pre_forward_hook_is_enabled = True
+
 
 class DistributedFusedAdam(torch.optim.Optimizer):
     """Adam optimizer with ZeRO algorithm.
@@ -332,15 +350,16 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
     class StateBucket:
         """Optimizer state for a bucket"""
+
         def __init__(
-                self,
-                bucket_size: int,
-                shard_size: int,
-                dtype: torch.dtype,
-                device: torch.device,
-                contiguous_buffer_offset: int = 0,
-                store_params: bool = False,
-                store_param_remainders: bool = False,
+            self,
+            bucket_size: int,
+            shard_size: int,
+            dtype: torch.dtype,
+            device: torch.device,
+            contiguous_buffer_offset: int = 0,
+            store_params: bool = False,
+            store_param_remainders: bool = False,
         ):
             # Size of parameter bucket
             self.bucket_size: int = bucket_size
@@ -356,25 +375,34 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             self.params_shard: Optional[torch.Tensor] = None
             if store_params:
                 self.params_shard = torch.zeros(
-                    [shard_size], dtype=dtype, device=device,
+                    [shard_size],
+                    dtype=dtype,
+                    device=device,
                 )
             # Local shard of parameter remainders
             self.param_remainders_shard: Optional[torch.Tensor] = None
             if store_param_remainders:
                 self.param_remainders_shard = torch.zeros(
-                    [shard_size], dtype=torch.int16, device=device,
+                    [shard_size],
+                    dtype=torch.int16,
+                    device=device,
                 )
             # Local shard of first moment estimate
             self.exp_avg_shard: torch.Tensor = torch.zeros(
-                [shard_size], dtype=dtype, device=device,
+                [shard_size],
+                dtype=dtype,
+                device=device,
             )
             # Local shard of second moment estimate
             self.exp_avg_sq_shard: torch.Tensor = torch.zeros(
-                [shard_size], dtype=dtype, device=device,
+                [shard_size],
+                dtype=dtype,
+                device=device,
             )
 
     class GradientStatus(enum.Enum):
         """Status of gradients within a bucket"""
+
         # Gradients are ready to use
         READY = enum.auto()
         # Bucket is partially filled with unreduced gradients
@@ -386,6 +414,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
     class GradientBucket:
         """Gradient buffers and state for a bucket"""
+
         def __init__(self):
             # Local shard of gradients
             self.grads_shard: Optional[torch.Tensor] = None
@@ -400,6 +429,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
     class ParameterStatus(enum.Enum):
         """Status of parameters within a bucket"""
+
         # Parameters are sharded between processes
         SHARDED = enum.auto()
         # Asynchronous communication is in progress
@@ -409,6 +439,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
     class ParameterBucket:
         """Parameter buffers and state for a bucket"""
+
         def __init__(self):
             # Local shard of parameters
             self.params_shard: Optional[torch.Tensor] = None
@@ -424,40 +455,47 @@ class DistributedFusedAdam(torch.optim.Optimizer):
     _custom_amp_unscale_grads: bool = True
 
     def __init__(
-            self,
-            params,
-            lr: float = 1e-3,
-            bias_correction: bool = True,
-            betas: Tuple[float, float] = (0.9, 0.999),
-            eps: float = 1e-8,
-            adam_w_mode: bool = True,
-            weight_decay: float = 0.,
-            amsgrad: bool = False,
-            dtype: torch.dtype = torch.float32,
-            grad_sync_dtype: Optional[torch.dtype] = None,
-            param_sync_dtype: Optional[torch.dtype] = None,
-            device: Optional[torch.device] = 'cuda',
-            process_group: Optional[torch.distributed.ProcessGroup] = None,
-            distributed_process_group: Optional[torch.distributed.ProcessGroup] = None,
-            redundant_process_group: Optional[torch.distributed.ProcessGroup] = None,
-            average_grad_sync: bool = True,
-            overlap_grad_sync: bool = True,
-            overlap_param_sync: bool = False,
-            bucket_cap_mb: float = 100.,
-            pipeline_size: int = 2,
-            contiguous_param_buffer: bool = False,
-            contiguous_grad_buffer: bool = False,
-            store_params: bool = True,
-            store_param_remainders: bool = False,
+        self,
+        params: Union[Iterable[torch.nn.Parameter], Iterable[dict]],
+        lr: float = 1e-3,
+        bias_correction: bool = True,
+        betas: Tuple[float, float] = (0.9, 0.999),
+        eps: float = 1e-8,
+        adam_w_mode: bool = True,
+        weight_decay: float = 0.0,
+        amsgrad: bool = False,
+        dtype: torch.dtype = torch.float32,
+        grad_sync_dtype: Optional[torch.dtype] = None,
+        param_sync_dtype: Optional[torch.dtype] = None,
+        device: Optional[torch.device] = "cuda",
+        process_group: Optional[torch.distributed.ProcessGroup] = None,
+        distributed_process_group: Optional[torch.distributed.ProcessGroup] = None,
+        redundant_process_group: Optional[torch.distributed.ProcessGroup] = None,
+        average_grad_sync: bool = True,
+        overlap_grad_sync: bool = True,
+        overlap_param_sync: bool = False,
+        bucket_cap_mb: float = 100.0,
+        pipeline_size: int = 2,
+        contiguous_param_buffer: bool = False,
+        contiguous_grad_buffer: bool = False,
+        store_params: bool = True,
+        store_param_remainders: bool = False,
     ):
-        defaults = dict(lr=lr, bias_correction=bias_correction,
-                        betas=betas, eps=eps, weight_decay=weight_decay)
+        defaults = dict(
+            lr=lr,
+            bias_correction=bias_correction,
+            betas=betas,
+            eps=eps,
+            weight_decay=weight_decay,
+        )
         super().__init__(params, defaults)
 
         # Adam options
         self.adam_w_mode: bool = adam_w_mode
         if amsgrad:
-            raise RuntimeError('DistributedFusedAdam does not support the AMSGrad variant.')
+            raise RuntimeError(
+                "DistributedFusedAdam does not support the AMSGrad variant."
+            )
 
         # Datatype options
         if grad_sync_dtype is None:
@@ -465,49 +503,48 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         if param_sync_dtype is None:
             param_sync_dtype = dtype
         supported_dtypes = (torch.float32, torch.float16, torch.bfloat16)
-        if (dtype not in supported_dtypes
+        if (
+            dtype not in supported_dtypes
             or grad_sync_dtype not in supported_dtypes
-            or param_sync_dtype not in supported_dtypes):
+            or param_sync_dtype not in supported_dtypes
+        ):
             raise RuntimeError(
-                'Unsupported dtypes for DistributedFusedAdam '
-                f'(dtype={dtype}, '
-                f'grad_sync_dtype={grad_sync_dtype}, '
-                f'param_sync_dtype={param_sync_dtype}))'
+                "Unsupported dtypes for DistributedFusedAdam "
+                f"(dtype={dtype}, "
+                f"grad_sync_dtype={grad_sync_dtype}, "
+                f"param_sync_dtype={param_sync_dtype}))"
             )
         self.dtype: torch.dtype = dtype
         self.grad_sync_dtype: torch.dtype = grad_sync_dtype
         self.param_sync_dtype: torch.dtype = param_sync_dtype
 
         # Device options
-        if not _devices_match(device, 'cuda'):
+        if not _devices_match(device, "cuda"):
             raise RuntimeError(
-                'Invalid device for DistributedFusedAdam '
-                f'(device={device})'
+                "Invalid device for DistributedFusedAdam " f"(device={device})"
             )
-        self.device: torch.device = torch.device('cuda', torch.cuda.current_device())
+        self.device: torch.device = torch.device("cuda", torch.cuda.current_device())
 
         # Process groups
         self.process_group: torch.distributed.ProcessGroup = (
-            _get_default_group()
-            if process_group is None
-            else process_group
+            _get_default_group() if process_group is None else process_group
         )
         self.distributed_process_group: torch.distributed.ProcessGroup = (
             self.process_group
             if distributed_process_group is None
             else distributed_process_group
         )
-        self.redundant_process_group: Optional[torch.distributed.ProcessGroup] = (
-            redundant_process_group
+        self.redundant_process_group: Optional[
+            torch.distributed.ProcessGroup
+        ] = redundant_process_group
+        self.process_group_size: int = torch.distributed.get_world_size(
+            self.process_group
         )
-        self.process_group_size: int = (
-            torch.distributed.get_world_size(self.process_group)
+        self.distributed_rank: int = torch.distributed.get_rank(
+            self.distributed_process_group
         )
-        self.distributed_rank: int = (
-            torch.distributed.get_rank(self.distributed_process_group)
-        )
-        self.distributed_size: int = (
-            torch.distributed.get_world_size(self.distributed_process_group)
+        self.distributed_size: int = torch.distributed.get_world_size(
+            self.distributed_process_group
         )
         self.redundant_size: int = (
             1
@@ -516,10 +553,10 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         )
         if self.process_group_size != self.distributed_size * self.redundant_size:
             raise RuntimeError(
-                'Invalid process group configuration '
-                f'(process group size = {self.process_group_size}, '
-                f'distributed process group size = {self.distributed_size}, '
-                f'redundant process group size = {self.redundant_size})'
+                "Invalid process group configuration "
+                f"(process group size = {self.process_group_size}, "
+                f"distributed process group size = {self.distributed_size}, "
+                f"redundant process group size = {self.redundant_size})"
             )
         self.process_group_root: int = get_global_rank(self.process_group, 0)
 
@@ -538,17 +575,16 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         if store_param_remainders:
             if store_params:
                 raise RuntimeError(
-                    'Attempted to construct DistributedFusedAdam '
-                    'with store_params=True and store_param_remainders=True'
+                    "Attempted to construct DistributedFusedAdam "
+                    "with store_params=True and store_param_remainders=True"
                 )
-            if (self.dtype != torch.float32
-                or self.param_sync_dtype != torch.bfloat16):
+            if self.dtype != torch.float32 or self.param_sync_dtype != torch.bfloat16:
                 raise RuntimeError(
-                    'DistributedFusedAdam requires '
-                    'BF16 params and FP32 optimizer state '
-                    'when storing parameter remainders '
-                    f'(dtype={self.dtype}, '
-                    f'param_sync_dtype={self.param_sync_dtype}))'
+                    "DistributedFusedAdam requires "
+                    "BF16 params and FP32 optimizer state "
+                    "when storing parameter remainders "
+                    f"(dtype={self.dtype}, "
+                    f"param_sync_dtype={self.param_sync_dtype}))"
                 )
         self.store_params: bool = store_params
         self.store_param_remainders: bool = store_param_remainders
@@ -556,19 +592,19 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         # Determine bucket sizes
         dtype_size = torch.finfo(self.grad_sync_dtype).bits // 8
         self.alignment: int = 128 // dtype_size
-        bucket_size = 1024*1024*bucket_cap_mb / dtype_size
+        bucket_size = 1024 * 1024 * bucket_cap_mb / dtype_size
         shard_size = int(bucket_size / self.distributed_size)
         shard_size = _round_to_multiple(shard_size, self.alignment, round_up=False)
         shard_size = max(shard_size, self.alignment)
         self.default_shard_size: int = shard_size
 
         # Optimizer state
-        self.state['buckets']: List[StateBucket] = []
-        self.state['step']: int = 0
+        self.state["buckets"]: List[StateBucket] = []
+        self.state["step"]: int = 0
 
         # Gradient state
-        self._grads_buckets: Dict[int, GradientBucket] = (
-            collections.defaultdict(self.GradientBucket)
+        self._grads_buckets: Dict[int, GradientBucket] = collections.defaultdict(
+            self.GradientBucket
         )
         # Param state
         self._params_buckets: Dict[int, ParameterBucket] = collections.OrderedDict()
@@ -583,14 +619,14 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         self._grad_buffer: Optional[torch.Tensor] = None
 
         # Side streams for optimizer step and communication
-        self._pipeline_streams: List[torch.cuda.Stream] = (
-            [torch.cuda.Stream() for _ in range(self.pipeline_size+1)]
-        )
+        self._pipeline_streams: List[torch.cuda.Stream] = [
+            torch.cuda.Stream() for _ in range(self.pipeline_size + 1)
+        ]
 
         # Scale by factor before optimizer step. Used for grad
         # clipping and gradient scaler.
-        self._grad_scale: torch.Tensor = (
-            torch.full([], 1.0, dtype=torch.float32, device=self.device)
+        self._grad_scale: torch.Tensor = torch.full(
+            [], 1.0, dtype=torch.float32, device=self.device
         )
         # Norm of parameter gradients. Used for gradient clipping and
         # gradient scaler.
@@ -601,13 +637,13 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         # that is intended to detect non-finite values. It shouldn't
         # have any effect with the kernels used in the optimizer, but
         # we still set it to zero out of an abundance of caution.
-        self._dummy_overflow_buf: torch.Tensor = (
-            torch.zeros([1], dtype=torch.int32, device=self.device)
+        self._dummy_overflow_buf: torch.Tensor = torch.zeros(
+            [1], dtype=torch.int32, device=self.device
         )
 
         # Check if collectives have no_copy option
         self._gather_no_copy: bool = (
-            'no_copy' in inspect.getfullargspec(torch.distributed.gather).args
+            "no_copy" in inspect.getfullargspec(torch.distributed.gather).args
         )
 
         # Make sure parameter values are same across processes
@@ -626,7 +662,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         process_group = self.process_group
         with _coalescing_manager(process_group, self.device, async_ops=True) as cm:
             for param_group in self.param_groups:
-                for param in param_group['params']:
+                for param in param_group["params"]:
                     _coalescing_manager_append_work(
                         cm,
                         torch.distributed.broadcast(
@@ -634,32 +670,33 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                             src=self.process_group_root,
                             group=process_group,
                             async_op=True,
-                        )
+                        ),
                     )
         cm.wait()
 
     def _make_post_backward_hook(
-            self,
-            param: torch.nn.Parameter,
-            param_group_id: int,
-            param_id: int,
+        self,
+        param: torch.nn.Parameter,
+        param_group_id: int,
+        param_id: int,
     ) -> Callable:
         """Create callback function to call after param generates grad
 
         Lazily initialize parameter and try launching grad sync.
 
         """
+
         def post_backward_hook(*unused) -> None:
-            if getattr(param, '_pre_forward_hook_is_enabled', False):
+            if getattr(param, "_pre_forward_hook_is_enabled", False):
                 raise RuntimeError(
-                    'A parameter called its post-backward hook '
-                    'before its pre-forward hook. '
-                    'Please manually interact with the parameter '
-                    'before the forward pass (e.g. by calling data_ptr) '
-                    'or run DistributedFusedAdam with overlap_param_sync=False.'
+                    "A parameter called its post-backward hook "
+                    "before its pre-forward hook. "
+                    "Please manually interact with the parameter "
+                    "before the forward pass (e.g. by calling data_ptr) "
+                    "or run DistributedFusedAdam with overlap_param_sync=False."
                 )
             with self._lock:
-                need_to_initialize = 'fragments' not in self.state[param]
+                need_to_initialize = "fragments" not in self.state[param]
                 if need_to_initialize:
                     self._init_param_state(param, param_group_id, param_id)
                 if self.greedy_grad_copy:
@@ -669,13 +706,14 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                             params=[param],
                             ignore_last_bucket=need_to_initialize,
                         )
+
         return post_backward_hook
 
     def _register_post_backward_hooks(self) -> None:
         """Attach hooks for gradient synchronization"""
         self._grad_accs = []
         for param_group_id, group in enumerate(self.param_groups):
-            for param_id, param in enumerate(group['params']):
+            for param_id, param in enumerate(group["params"]):
                 if param.requires_grad:
                     param_tmp = param.expand_as(param)
                     grad_acc = param_tmp.grad_fn.next_functions[0][0]
@@ -688,10 +726,10 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                     self._grad_accs.append(grad_acc)
 
     def _make_pre_forward_hook(
-            self,
-            param: torch.nn.Parameter,
-            param_group_id: int,
-            param_id: int,
+        self,
+        param: torch.nn.Parameter,
+        param_group_id: int,
+        param_id: int,
     ) -> Callable:
         """Create callback function to call before param forward pass
 
@@ -699,13 +737,15 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         param sync.
 
         """
+
         def pre_forward_hook(*unused) -> None:
             with self._lock:
-                if 'fragments' not in self.state[param]:
+                if "fragments" not in self.state[param]:
                     return
                 self._param_copy(param)
                 if self.overlap_param_sync:
                     self._try_start_bucket_param_sync()
+
         return pre_forward_hook
 
     def _register_pre_forward_hooks(self) -> None:
@@ -718,63 +758,121 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
         """
         for param_group_id, group in enumerate(self.param_groups):
-            for param_id, param in enumerate(group['params']):
-
+            for param_id, param in enumerate(group["params"]):
                 # Monkey-patch parameter class
                 cls = param.__class__
-                if not getattr(cls, '_has_pre_forward_hook', False):
-
+                if not getattr(cls, "_has_pre_forward_hook", False):
                     # Monkey-patch magic methods to call __getattribute__
                     special_funcs = [
-                        '__abs__', '__add__', '__and__',
-                        '__bool__', '__complex__', '__contains__',
-                        '__deepcopy__', '__delitem__', '__div__',
-                        '__eq__', '__float__', '__floordiv__',
-                        '__ge__', '__getitem__', '__gt__', '__iadd__',
-                        '__iand__', '__idiv__', '__ifloordiv__',
-                        '__ilshift__', '__imod__', '__imul__',
-                        '__index__', '__int__', '__invert__',
-                        '__ior__', '__ipow__', '__irshift__',
-                        '__isub__', '__iter__', '__itruediv__',
-                        '__ixor__', '__le__', '__len__', '__long__',
-                        '__lshift__', '__lt__', '__matmul__',
-                        '__mod__', '__mul__', '__neg__',
-                        '__nonzero__', '__or__', '__pos__', '__pow__',
-                        '__radd__', '__rand__', '__rdiv__',
-                        '__reduce__', '__reduce_ex__', '__reversed__',
-                        '__rfloordiv__', '__rlshift__', '__rmatmul__',
-                        '__rmod__', '__rmul__', '__ror__', '__rpow__',
-                        '__rrshift__', '__rshift__', '__rsub__',
-                        '__rtruediv__', '__rxor__', '__setitem__',
-                        '__sizeof__', '__sub__', '__torch_function__',
-                        '__truediv__', '__xor__',
+                        "__abs__",
+                        "__add__",
+                        "__and__",
+                        "__bool__",
+                        "__complex__",
+                        "__contains__",
+                        "__deepcopy__",
+                        "__delitem__",
+                        "__div__",
+                        "__eq__",
+                        "__float__",
+                        "__floordiv__",
+                        "__ge__",
+                        "__getitem__",
+                        "__gt__",
+                        "__iadd__",
+                        "__iand__",
+                        "__idiv__",
+                        "__ifloordiv__",
+                        "__ilshift__",
+                        "__imod__",
+                        "__imul__",
+                        "__index__",
+                        "__int__",
+                        "__invert__",
+                        "__ior__",
+                        "__ipow__",
+                        "__irshift__",
+                        "__isub__",
+                        "__iter__",
+                        "__itruediv__",
+                        "__ixor__",
+                        "__le__",
+                        "__len__",
+                        "__long__",
+                        "__lshift__",
+                        "__lt__",
+                        "__matmul__",
+                        "__mod__",
+                        "__mul__",
+                        "__neg__",
+                        "__nonzero__",
+                        "__or__",
+                        "__pos__",
+                        "__pow__",
+                        "__radd__",
+                        "__rand__",
+                        "__rdiv__",
+                        "__reduce__",
+                        "__reduce_ex__",
+                        "__reversed__",
+                        "__rfloordiv__",
+                        "__rlshift__",
+                        "__rmatmul__",
+                        "__rmod__",
+                        "__rmul__",
+                        "__ror__",
+                        "__rpow__",
+                        "__rrshift__",
+                        "__rshift__",
+                        "__rsub__",
+                        "__rtruediv__",
+                        "__rxor__",
+                        "__setitem__",
+                        "__sizeof__",
+                        "__sub__",
+                        "__torch_function__",
+                        "__truediv__",
+                        "__xor__",
                     ]
                     for func_name in special_funcs:
+
                         def make_augmented_func() -> Callable:
-                            base_func_name = f'_base_{func_name}'
+                            base_func_name = f"_base_{func_name}"
+
                             def augmented_func(self, *args, **kwargs):
                                 return getattr(self, base_func_name)(*args, **kwargs)
+
                             return augmented_func
-                        setattr(cls, f'_base_{func_name}', getattr(cls, func_name))
+
+                        setattr(cls, f"_base_{func_name}", getattr(cls, func_name))
                         setattr(cls, func_name, make_augmented_func())
 
                     # Monkey-patch __getattribute__ to call pre-forward hook
                     def make_getattribute() -> Callable[[str], Any]:
                         special_attrs = {
-                            '_pre_forward_hook_is_enabled',
-                            '_pre_forward_hook',
-                            '__del__', '__delattr__', '__dir__', '__getattr__',
-                            '__getattribute__', '__hash__',
-                            '__init__', '__new__', '__setattr__',
+                            "_pre_forward_hook_is_enabled",
+                            "_pre_forward_hook",
+                            "__del__",
+                            "__delattr__",
+                            "__dir__",
+                            "__getattr__",
+                            "__getattribute__",
+                            "__hash__",
+                            "__init__",
+                            "__new__",
+                            "__setattr__",
                         }
+
                         def getattribute_with_pre_forward_hook(self, name: str):
                             """Variant of __getattribute__ that can call pre-forward hook"""
                             if name not in special_attrs:
-                                if getattr(self, '_pre_forward_hook_is_enabled', False):
+                                if getattr(self, "_pre_forward_hook_is_enabled", False):
                                     self._pre_forward_hook_is_enabled = False
                                     self._pre_forward_hook()
                             return object.__getattribute__(self, name)
+
                         return getattribute_with_pre_forward_hook
+
                     cls.__getattribute__ = make_getattribute()
                     cls._has_pre_forward_hook = True
 
@@ -803,10 +901,10 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         self.init_params()
 
         # Construct param buffer
-        if self.state['buckets']:
+        if self.state["buckets"]:
             buffer_size = max(
                 bucket.contiguous_buffer_offset + bucket.bucket_size
-                for bucket in self.state['buckets']
+                for bucket in self.state["buckets"]
             )
         else:
             buffer_size = 0
@@ -821,23 +919,23 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         param_flat_views = []
         param_buffer_views = []
         for i, param in enumerate(params):
-            fragment = self.state[param]['fragments'][0]
+            fragment = self.state[param]["fragments"][0]
             bucket_id = fragment.bucket_id
             param_size = param.numel()
             bucket_start, _ = fragment.bucket_range
-            buffer_offset = self.state['buckets'][bucket_id].contiguous_buffer_offset
+            buffer_offset = self.state["buckets"][bucket_id].contiguous_buffer_offset
             buffer_start = buffer_offset + bucket_start
             buffer_end = buffer_start + param_size
             buffer_view = self._param_buffer[buffer_start:buffer_end].detach()
             if not _devices_match(buffer_view.device, param.device):
                 raise RuntimeError(
-                    'Attempted to change a parameter with device={param.device} '
-                    f'into a buffer view with device={view_buffer.device}'
+                    "Attempted to change a parameter with device={param.device} "
+                    f"into a buffer view with device={view_buffer.device}"
                 )
             if buffer_view.dtype != param.dtype:
                 raise RuntimeError(
-                    f'Attempted to change a parameter with dtype={param.dtype} '
-                    f'into a buffer view with dtype={view_buffer.dtype}'
+                    f"Attempted to change a parameter with dtype={param.dtype} "
+                    f"into a buffer view with dtype={view_buffer.dtype}"
                 )
             param_flat_views.append(param.detach().view(-1))
             param_buffer_views.append(buffer_view)
@@ -857,10 +955,10 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         """Allocate contiguous buffer for grad buckets"""
         self.contiguous_grad_buffer = True
         self.init_params()  # Make sure all params are initialized
-        if self.state['buckets']:
+        if self.state["buckets"]:
             buffer_size = max(
                 bucket.contiguous_buffer_offset + bucket.bucket_size
-                for bucket in self.state['buckets']
+                for bucket in self.state["buckets"]
             )
         else:
             buffer_size = 0
@@ -873,12 +971,12 @@ class DistributedFusedAdam(torch.optim.Optimizer):
     def parameters(self) -> Iterable[torch.nn.Parameter]:
         """Returns an iterator over optimizer parameters"""
         return itertools.chain.from_iterable(
-            group['params'] for group in self.param_groups
+            group["params"] for group in self.param_groups
         )
 
     def init_params(
-            self,
-            params: Optional[Iterable[torch.nn.Parameter]] = None,
+        self,
+        params: Optional[Iterable[torch.nn.Parameter]] = None,
     ) -> None:
         """Initialize optimizer state for parameters
 
@@ -897,18 +995,14 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             params = [params]
 
         # Ignore parameters that have already been initialized
-        params = [
-            param
-            for param in params
-            if 'fragments' not in self.state[param]
-        ]
+        params = [param for param in params if "fragments" not in self.state[param]]
         if not params:
             return
 
         # Get indices corresponding to parameters
         id_map = dict()
         for param_group_id, group in enumerate(self.param_groups):
-            for param_id, param in enumerate(group['params']):
+            for param_id, param in enumerate(group["params"]):
                 id_map[param] = (param_group_id, param_id)
 
         # Initialize parameters
@@ -932,33 +1026,29 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         # Ignore parameters that have already been initialized
         if isinstance(params, torch.Tensor):
             params = [params]
-        params = [
-            param
-            for param in params
-            if 'fragments' not in self.state[param]
-        ]
+        params = [param for param in params if "fragments" not in self.state[param]]
         if not params:
             return
 
         # Get indices corresponding to parameters
         id_map = dict()
         for param_group_id, group in enumerate(self.param_groups):
-            for param_id, param in enumerate(group['params']):
+            for param_id, param in enumerate(group["params"]):
                 id_map[param] = [param_group_id, param_id]
         param_ids = [tuple([param] + id_map[param]) for param in params]
 
         # Mark existings bucket as fully filled
-        for bucket in self.state['buckets']:
+        for bucket in self.state["buckets"]:
             bucket.filled_size = bucket.bucket_size
 
         # Initialize optimizer state for parameters
-        start_bucket_id = len(self.state['buckets'])
+        start_bucket_id = len(self.state["buckets"])
         self.init_params(params)
-        end_bucket_id = len(self.state['buckets'])
+        end_bucket_id = len(self.state["buckets"])
 
         # Make sure all added buckets depend on provided params
         for bucket_id in range(start_bucket_id, end_bucket_id):
-            bucket = self.state['buckets'][bucket_id]
+            bucket = self.state["buckets"][bucket_id]
             bucket_size = bucket.bucket_size
             bucket.filled_size = bucket_size
             ids_in_bucket = set(
@@ -979,28 +1069,28 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                         shard_bucket_range=None,
                         shard_param_range=None,
                     )
-                    self.state[param]['fragments'].append(fragment)
+                    self.state[param]["fragments"].append(fragment)
                     bucket.fragments.append(fragment)
 
     def _init_param_state(
-            self,
-            param: torch.nn.Parameter,
-            param_group_id: int,
-            param_id: int,
+        self,
+        param: torch.nn.Parameter,
+        param_group_id: int,
+        param_id: int,
     ) -> None:
         """Initialize optimizer state for a parameter"""
 
         # Return immediately if already initialized
-        if 'fragments' in self.state[param]:
+        if "fragments" in self.state[param]:
             return
-        self.state[param]['fragments'] = []
+        self.state[param]["fragments"] = []
 
         # Make sure there is at least one bucket
-        if not self.state['buckets']:
+        if not self.state["buckets"]:
             shard_size = self.default_shard_size
             bucket_size = shard_size * self.distributed_size
             buffer_offset = 0
-            self.state['buckets'].append(
+            self.state["buckets"].append(
                 self.StateBucket(
                     bucket_size,
                     shard_size,
@@ -1017,10 +1107,9 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         param_start = 0
         param_size = param.numel()
         while param_start < param_size:
-
             # Get current bucket
-            bucket_id = len(self.state['buckets']) - 1
-            bucket = self.state['buckets'][bucket_id]
+            bucket_id = len(self.state["buckets"]) - 1
+            bucket = self.state["buckets"][bucket_id]
             fragment_id = len(bucket.fragments)
             bucket_size = bucket.bucket_size
             shard_size = bucket.shard_size
@@ -1031,7 +1120,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                 self.alignment,
                 round_up=True,
             )
-            fragment_size = min(param_size-param_start, bucket_size-bucket_start)
+            fragment_size = min(param_size - param_start, bucket_size - bucket_start)
             param_end = param_start + fragment_size
             bucket_end = bucket_start + fragment_size
 
@@ -1040,7 +1129,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                 shard_size = self.default_shard_size
                 bucket_size = shard_size * self.distributed_size
                 buffer_offset = bucket.contiguous_buffer_offset + bucket.bucket_size
-                self.state['buckets'].append(
+                self.state["buckets"].append(
                     self.StateBucket(
                         bucket_size,
                         shard_size,
@@ -1055,8 +1144,8 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
             # Fragment position within local shard
             shard_id = self.distributed_rank
-            shard_start = bucket_start - shard_size*shard_id
-            shard_end = bucket_end - shard_size*shard_id
+            shard_start = bucket_start - shard_size * shard_id
+            shard_end = bucket_end - shard_size * shard_id
             shard_start = min(max(shard_start, 0), shard_size)
             shard_end = min(max(shard_end, 0), shard_size)
             in_local_shard = shard_start < shard_end
@@ -1065,7 +1154,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             shard_param_range = None
             if in_local_shard:
                 shard_range = (shard_start, shard_end)
-                shard_bucket_start = shard_start + shard_size*shard_id
+                shard_bucket_start = shard_start + shard_size * shard_id
                 shard_bucket_end = shard_bucket_start + shard_end - shard_start
                 shard_bucket_range = (shard_bucket_start, shard_bucket_end)
                 shard_param_start = shard_bucket_start - bucket_start + param_start
@@ -1077,26 +1166,28 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                 param_group_id=param_group_id,
                 param_id=param_id,
                 bucket_id=bucket_id,
-                param_range=(param_start,param_end),
-                bucket_range=(bucket_start,bucket_end),
+                param_range=(param_start, param_end),
+                bucket_range=(bucket_start, bucket_end),
                 in_local_shard=in_local_shard,
                 shard_range=shard_range,
                 shard_bucket_range=shard_bucket_range,
                 shard_param_range=shard_param_range,
             )
-            self.state[param]['fragments'].append(fragment)
+            self.state[param]["fragments"].append(fragment)
             bucket.fragments.append(fragment)
             bucket.filled_size = bucket_end
             param_start = param_end
 
         # Initialize main param buffer
         if self.store_params:
-            for fragment in self.state[param]['fragments']:
+            for fragment in self.state[param]["fragments"]:
                 if fragment.in_local_shard:
-                    bucket = self.state['buckets'][fragment.bucket_id]
+                    bucket = self.state["buckets"][fragment.bucket_id]
                     param_start, param_end = fragment.shard_param_range
                     shard_start, shard_end = fragment.shard_range
-                    model_param_fragment = param.detach().view(-1)[param_start:param_end]
+                    model_param_fragment = param.detach().view(-1)[
+                        param_start:param_end
+                    ]
                     main_param_fragment = bucket.params_shard[shard_start:shard_end]
                     main_param_fragment.copy_(model_param_fragment)
 
@@ -1111,7 +1202,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             if self._grad_buffer is None:
                 self._init_grad_buffer()
             self._grad_buffer.zero_()
-            for bucket_id, bucket in enumerate(self.state['buckets']):
+            for bucket_id, bucket in enumerate(self.state["buckets"]):
                 bucket_size = bucket.bucket_size
                 buffer_start = bucket.contiguous_buffer_offset
                 buffer_end = buffer_start + bucket_size
@@ -1123,9 +1214,11 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             with _disable_pre_forward_hook(param):
                 if set_to_none:
                     param.grad = None
-                elif (self.contiguous_grad_buffer
-                      and param.dtype == self.grad_sync_dtype
-                      and _devices_match(param.device, self.device)):
+                elif (
+                    self.contiguous_grad_buffer
+                    and param.dtype == self.grad_sync_dtype
+                    and _devices_match(param.device, self.device)
+                ):
                     param.grad = self.grad_buffer_view(param)
                 elif param.grad is not None:
                     param.grad.zero_()
@@ -1133,29 +1226,30 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         # Reset other state
         self._grad_scale = torch.full([], 1.0, dtype=torch.float32, device=self.device)
         self._grad_norm = None
-        self._dummy_overflow_buf = torch.zeros([1], dtype=torch.int32, device=self.device)
+        self._dummy_overflow_buf = torch.zeros(
+            [1], dtype=torch.int32, device=self.device
+        )
 
     def _grad_copy(self, param: torch.nn.Parameter) -> None:
         """Copy parameter gradients to buckets"""
 
         # Initialize parameter if needed
-        if 'fragments' not in self.state[param]:
+        if "fragments" not in self.state[param]:
             for param_group_id, group in enumerate(self.param_groups):
-                for param_id, param_ in enumerate(group['params']):
+                for param_id, param_ in enumerate(group["params"]):
                     if param is param_:
                         self._init_param_state(param, param_group_id, param_id)
-            if 'fragments' not in self.state[param]:
+            if "fragments" not in self.state[param]:
                 raise RuntimeError(
-                    'Could not initialize DistributedFusedAdam with parameter'
+                    "Could not initialize DistributedFusedAdam with parameter"
                 )
 
         # Copy param grad to buckets
-        for fragment in self.state[param]['fragments']:
-
+        for fragment in self.state[param]["fragments"]:
             # Get fragment position
             bucket_id = fragment.bucket_id
             bucket = self._grads_buckets[bucket_id]
-            bucket_size = self.state['buckets'][bucket_id].bucket_size
+            bucket_size = self.state["buckets"][bucket_id].bucket_size
             grad_start, grad_end = fragment.param_range
             bucket_start, bucket_end = fragment.bucket_range
 
@@ -1168,11 +1262,13 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             if bucket.grads_bucket is None and self.contiguous_grad_buffer:
                 if self._grad_buffer is None:
                     self._init_grad_buffer()
-                buffer_start = self.state['buckets'][bucket_id].contiguous_buffer_offset
+                buffer_start = self.state["buckets"][bucket_id].contiguous_buffer_offset
                 buffer_end = buffer_start + bucket_size
                 grad_buffer = self._grad_buffer[buffer_start:buffer_end]
-                if (bucket.grads_shard is None
-                    or bucket.grads_shard.data_ptr() != grad_buffer.data_ptr()):
+                if (
+                    bucket.grads_shard is None
+                    or bucket.grads_shard.data_ptr() != grad_buffer.data_ptr()
+                ):
                     bucket.grads_bucket = grad_buffer
                     bucket.grads_bucket.zero_()
             if bucket.grads_bucket is None:
@@ -1200,10 +1296,10 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             params = [params]
         fragments = []
         for param in params:
-            if 'fragments' in self.state[param]:
+            if "fragments" in self.state[param]:
                 fragments.extend(
                     fragment
-                    for fragment in self.state[param]['fragments']
+                    for fragment in self.state[param]["fragments"]
                     if fragment.bucket_id in self._params_buckets
                 )
 
@@ -1213,8 +1309,9 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             bucket_id = fragment.bucket_id
             bucket = self._params_buckets[bucket_id]
             buckets[bucket] = bucket.status
-        if any(status != self.ParameterStatus.READY
-               for bucket, status in buckets.items()):
+        if any(
+            status != self.ParameterStatus.READY for bucket, status in buckets.items()
+        ):
             self._start_bucket_param_sync(buckets.keys())
             self._finish_bucket_param_sync()
 
@@ -1229,7 +1326,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             param_start, param_end = fragment.param_range
             if param_end > param_start:
                 bucket = self._params_buckets[bucket_id]
-                param = self.param_groups[param_group_id]['params'][param_id]
+                param = self.param_groups[param_group_id]["params"][param_id]
                 params_in.append(bucket.params_bucket[bucket_start:bucket_end])
                 params_out.append(param.detach().view(-1)[param_start:param_end])
         _multi_tensor_copy(
@@ -1242,10 +1339,10 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         for fragment in fragments:
             bucket_id = fragment.bucket_id
             bucket = self._params_buckets[bucket_id]
-            bucket_fragments = self.state['buckets'][bucket_id].fragments
+            bucket_fragments = self.state["buckets"][bucket_id].fragments
             param_group_id = fragment.param_group_id
             param_id = fragment.param_id
-            param = self.param_groups[param_group_id]['params'][param_id]
+            param = self.param_groups[param_group_id]["params"][param_id]
             bucket.params_updated.add(param)
             if len(bucket.params_updated) == len(bucket_fragments):
                 del self._params_buckets[bucket_id]
@@ -1263,11 +1360,11 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             self._init_grad_buffer()
 
         # Figure out corresponding position in grad buffer
-        fragment = self.state[param]['fragments'][0]
+        fragment = self.state[param]["fragments"][0]
         bucket_id = fragment.bucket_id
         param_size = param.numel()
         bucket_start, _ = fragment.bucket_range
-        buffer_offset = self.state['buckets'][bucket_id].contiguous_buffer_offset
+        buffer_offset = self.state["buckets"][bucket_id].contiguous_buffer_offset
         buffer_start = buffer_offset + bucket_start
         buffer_end = buffer_start + param_size
 
@@ -1285,7 +1382,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             if bucket.status not in (Status.READY, Status.SYNCING):
                 buckets.append(bucket)
                 if bucket.grads_bucket is None:
-                    bucket_size = self.state['buckets'][bucket_id].bucket_size
+                    bucket_size = self.state["buckets"][bucket_id].bucket_size
                     bucket.grads_bucket = torch.zeros(
                         [bucket_size],
                         dtype=self.grad_sync_dtype,
@@ -1296,10 +1393,10 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         self._finish_bucket_grad_sync()
 
         # Fill any unsynchronized gradients with zeros
-        for bucket_id in range(len(self.state['buckets'])):
+        for bucket_id in range(len(self.state["buckets"])):
             bucket = self._grads_buckets[bucket_id]
             if bucket.grads_shard is None:
-                shard_size = self.state['buckets'][bucket_id].shard_size
+                shard_size = self.state["buckets"][bucket_id].shard_size
                 bucket.grads_shard = torch.zeros(
                     [shard_size],
                     dtype=self.grad_sync_dtype,
@@ -1307,9 +1404,9 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                 )
 
     def _try_start_bucket_grad_sync(
-            self,
-            params: Optional[Iterable[torch.nn.Parameter]] = None,
-            ignore_last_bucket: bool = False,
+        self,
+        params: Optional[Iterable[torch.nn.Parameter]] = None,
+        ignore_last_bucket: bool = False,
     ) -> None:
         """Attempt to launch gradient synchronization
 
@@ -1331,15 +1428,15 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         if params is None:
             params = []
         for param in params:
-            for fragment in self.state[param]['fragments']:
+            for fragment in self.state[param]["fragments"]:
                 bucket_id = fragment.bucket_id
                 bucket = self._grads_buckets[bucket_id]
-                bucket_fragments = self.state['buckets'][bucket_id].fragments
+                bucket_fragments = self.state["buckets"][bucket_id].fragments
                 bucket.grads_generated.add(param)
                 if len(bucket.grads_generated) == len(bucket_fragments):
                     bucket.status = self.GradientStatus.FULLY_FILLED
                     if bucket.grads_bucket is None:
-                        bucket_size = self.state['buckets'][bucket_id].bucket_size
+                        bucket_size = self.state["buckets"][bucket_id].bucket_size
                         bucket.grads_bucket = torch.zeros(
                             [bucket_size],
                             dtype=self.grad_sync_dtype,
@@ -1349,7 +1446,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         # Launch reductions if enough buckets are ready
         filled_buckets = []
         for bucket_id, bucket in sorted(self._grads_buckets.items()):
-            if ignore_last_bucket and bucket_id == len(self.state['buckets'])-1:
+            if ignore_last_bucket and bucket_id == len(self.state["buckets"]) - 1:
                 continue
             if bucket.status == self.GradientStatus.FULLY_FILLED:
                 filled_buckets.append(bucket)
@@ -1414,7 +1511,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                                 op=reduce_op,
                                 group=group,
                                 async_op=True,
-                            )
+                            ),
                         )
                 cm.wait()
 
@@ -1431,7 +1528,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                                 op=reduce_op,
                                 group=group,
                                 async_op=True,
-                            )
+                            ),
                         )
                 cm.wait()
 
@@ -1442,7 +1539,6 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         main_stream.wait_stream(comm_stream)
         for bucket_id, bucket in sorted(self._grads_buckets.items()):
             if bucket.status == self.GradientStatus.SYNCING:
-
                 # Accumulate gradient in local shard
                 if bucket.grads_shard is None:
                     bucket.grads_shard = bucket.sync_grads_shard
@@ -1458,8 +1554,8 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                 self._grad_norm = None
 
     def _try_start_bucket_param_sync(
-            self,
-            params: Iterable[torch.nn.Parameter] = None,
+        self,
+        params: Iterable[torch.nn.Parameter] = None,
     ) -> None:
         """Attempt to launch parameter synchronization
 
@@ -1478,15 +1574,17 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         # are in progress
         if params is None:
             params = []
-            if any(bucket.status == self.ParameterStatus.SYNCING
-                   for bucket in self._params_buckets.values()):
+            if any(
+                bucket.status == self.ParameterStatus.SYNCING
+                for bucket in self._params_buckets.values()
+            ):
                 return
             for bucket_id, bucket in self._params_buckets.items():
                 if bucket.status == self.ParameterStatus.SHARDED:
-                    fragment = self.state['buckets'][bucket_id].fragments[-1]
+                    fragment = self.state["buckets"][bucket_id].fragments[-1]
                     param_group_id = fragment.param_group_id
                     param_id = fragment.param_id
-                    param = self.param_groups[param_group_id]['params'][param_id]
+                    param = self.param_groups[param_group_id]["params"][param_id]
                     params.append(param)
                     break
 
@@ -1494,8 +1592,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         bucket_ids = set()
         for param in params:
             bucket_ids.update(
-                fragment.bucket_id
-                for fragment in self.state[param]['fragments']
+                fragment.bucket_id for fragment in self.state[param]["fragments"]
             )
         buckets = [
             self._params_buckets[bucket_id]
@@ -1561,7 +1658,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                                 bucket.params_shard,
                                 group=group,
                                 async_op=True,
-                            )
+                            ),
                         )
                 cm.wait()
 
@@ -1577,8 +1674,8 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
     @contextlib.contextmanager
     def no_sync(
-            self,
-            greedy_grad_copy: None = False,
+        self,
+        greedy_grad_copy: None = False,
     ) -> contextlib.AbstractContextManager:
         """Disable overlapped gradient synchronization
 
@@ -1607,11 +1704,11 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
     def grad_sync(self) -> None:
         """Ensure that all gradients are synchronized"""
-        for bucket in self.state['buckets']:
+        for bucket in self.state["buckets"]:
             for fragment in bucket.fragments:
                 param_group_id = fragment.param_group_id
                 param_id = fragment.param_id
-                param = self.param_groups[param_group_id]['params'][param_id]
+                param = self.param_groups[param_group_id]["params"][param_id]
                 if param.grad is not None:
                     self._grad_copy(param)
                     if not self.contiguous_grad_buffer:
@@ -1628,17 +1725,17 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         else:
             while self._params_buckets:
                 bucket_id, bucket = next(iter((self._params_buckets.items())))
-                for fragment in reversed(self.state['buckets'][bucket_id].fragments):
+                for fragment in reversed(self.state["buckets"][bucket_id].fragments):
                     param_id = fragment.param_id
                     param_group_id = fragment.param_group_id
-                    param = self.param_groups[param_group_id]['params'][param_id]
+                    param = self.param_groups[param_group_id]["params"][param_id]
                     self._param_copy(param)
         self._params_buckets.clear()
 
     def _local_grad_norm(
-            self,
-            parameters: Optional[Iterable[torch.nn.Parameter]] = None,
-            norm_type: float = 2.0,
+        self,
+        parameters: Optional[Iterable[torch.nn.Parameter]] = None,
+        norm_type: float = 2.0,
     ) -> torch.Tensor:
         """Local contribution to parameter gradient norm
 
@@ -1660,48 +1757,54 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             parameters = list(parameters)
             params_set = set(parameters)
             all_params_set = set()
-            for bucket in self.state['buckets']:
+            for bucket in self.state["buckets"]:
                 for fragment in bucket.fragments:
                     param_group_id = fragment.param_group_id
                     param_id = fragment.param_id
                     all_params_set.add(
-                        self.param_groups[param_group_id]['params'][param_id]
+                        self.param_groups[param_group_id]["params"][param_id]
                     )
             if not params_set.issubset(all_params_set):
                 raise RuntimeError(
-                    'Attempted to compute gradient norm for a parameter '
-                    'that is not managed by DistributedFusedAdam'
+                    "Attempted to compute gradient norm for a parameter "
+                    "that is not managed by DistributedFusedAdam"
                 )
             if params_set == all_params_set:
                 parameters = None
 
         if parameters is None:
             # Compute norm of all local gradients
-            grad_norm_sq = multi_tensor_applier(
-                amp_C.multi_tensor_l2norm,
-                self._dummy_overflow_buf,
-                [[bucket.grads_shard for bucket in self._grads_buckets.values()]],
-                False,
-            )[0] ** 2
+            grad_norm_sq = (
+                multi_tensor_applier(
+                    amp_C.multi_tensor_l2norm,
+                    self._dummy_overflow_buf,
+                    [[bucket.grads_shard for bucket in self._grads_buckets.values()]],
+                    False,
+                )[0]
+                ** 2
+            )
         else:
             # Compute norm of selected local gradients
             grads = []
             for param in parameters:
-                if 'fragments' not in self.state[param]:
+                if "fragments" not in self.state[param]:
                     continue
-                for fragment in self.state[param]['fragments']:
+                for fragment in self.state[param]["fragments"]:
                     if fragment.in_local_shard:
                         bucket = self._grads_buckets[fragment.bucket_id]
                         shard_start, shard_end = fragment.shard_range
                         if shard_end > shard_start:
                             grads.append(bucket.grads_shard[shard_start:shard_end])
             if grads:
-                grad_norm_sq = multi_tensor_applier(
-                    amp_C.multi_tensor_l2norm,
-                    self._dummy_overflow_buf,
-                    [grads],
-                    False,
-                )[0] ** 2
+                grad_norm_sq = (
+                    multi_tensor_applier(
+                        amp_C.multi_tensor_l2norm,
+                        self._dummy_overflow_buf,
+                        [grads],
+                        False,
+                    )[0]
+                    ** 2
+                )
             else:
                 grad_norm_sq = torch.zeros([1], dtype=self.dtype, device=self.device)
 
@@ -1711,10 +1814,10 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         return grad_norm_sq
 
     def grad_norm(
-            self,
-            parameters: Optional[Iterable[torch.nn.Parameter]] = None,
-            norm_type: float = 2.0,
-            force: bool = False,
+        self,
+        parameters: Optional[Iterable[torch.nn.Parameter]] = None,
+        norm_type: float = 2.0,
+        force: bool = False,
     ) -> torch.Tensor:
         """Gradient norm of parameters in optimizer
 
@@ -1750,10 +1853,10 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         return grad_norm.detach()
 
     def clip_grad_norm(
-            self,
-            max_norm: float,
-            parameters: Optional[Iterable[torch.nn.Parameter]] = None,
-            norm_type: float = 2.0,
+        self,
+        max_norm: float,
+        parameters: Optional[Iterable[torch.nn.Parameter]] = None,
+        norm_type: float = 2.0,
     ) -> torch.Tensor:
         """Clips gradient norm of parameters in optimizer
 
@@ -1790,13 +1893,13 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
         """
         self._grad_scale *= inv_scale.view([])
-        return { self.device: torch.zeros(1, dtype=torch.float32, device=self.device) }
+        return {self.device: torch.zeros(1, dtype=torch.float32, device=self.device)}
 
     def step(
-            self,
-            closure: Optional[Callable] = None,
-            *,
-            grad_scaler: Optional[torch.cuda.amp.GradScaler] = None,
+        self,
+        closure: Optional[Callable] = None,
+        *,
+        grad_scaler: Optional[torch.cuda.amp.GradScaler] = None,
     ):
         """Apply Adam optimizer step
 
@@ -1826,36 +1929,32 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         if grad_scaler is not None:
             grad_scaler_state = grad_scaler._per_optimizer_states[id(self)]
             GradScalerOptState = torch.cuda.amp.grad_scaler.OptState
-            if grad_scaler_state['stage'] is GradScalerOptState.READY:
+            if grad_scaler_state["stage"] is GradScalerOptState.READY:
                 assert grad_scaler._scale is not None
                 self._grad_scale /= grad_scaler._scale.view([])
             grad_norm = self.grad_norm()
             found_inf = torch.logical_not(torch.isfinite(grad_norm))
             scaler_state = grad_scaler._per_optimizer_states[id(self)]
-            scaler_state['found_inf_per_device'] = {found_inf.device: found_inf.float()}
+            scaler_state["found_inf_per_device"] = {found_inf.device: found_inf.float()}
             if found_inf.item():
                 return
         self._grad_scale = self._grad_scale.to(dtype=torch.float32, device=self.device)
 
         # Initialize param shard buffers
-        for bucket_id in reversed(range(len(self.state['buckets']))):
+        for bucket_id in reversed(range(len(self.state["buckets"]))):
             bucket = self.ParameterBucket()
             self._params_buckets[bucket_id] = bucket
-            shard_size = self.state['buckets'][bucket_id].shard_size
+            shard_size = self.state["buckets"][bucket_id].shard_size
             if self.contiguous_param_buffer:
                 if self._param_buffer is None:
                     self.init_param_buffer()
-                bucket_size = self.state['buckets'][bucket_id].bucket_size
-                buffer_start = self.state['buckets'][bucket_id].contiguous_buffer_offset
+                bucket_size = self.state["buckets"][bucket_id].bucket_size
+                buffer_start = self.state["buckets"][bucket_id].contiguous_buffer_offset
                 buffer_end = buffer_start + bucket_size
-                bucket.params_bucket = (
-                    self._param_buffer[buffer_start:buffer_end]
-                )
+                bucket.params_bucket = self._param_buffer[buffer_start:buffer_end]
                 bucket_start = self.distributed_rank * shard_size
                 bucket_end = bucket_start + shard_size
-                bucket.params_shard = (
-                    bucket.params_bucket[bucket_start:bucket_end]
-                )
+                bucket.params_shard = bucket.params_bucket[bucket_start:bucket_end]
             else:
                 bucket.params_shard = torch.empty(
                     [shard_size],
@@ -1864,34 +1963,36 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                 )
 
         # Apply optimizer step and synchronize params
-        self.state['step'] += 1
-        if self.distributed_size > 1 and self.overlap_param_sync and self.state['buckets']:
+        self.state["step"] += 1
+        if (
+            self.distributed_size > 1
+            and self.overlap_param_sync
+            and self.state["buckets"]
+        ):
             # Local step and non-blocking param sync
             # Note: Overlap param sync of first buckets with optimizer
             # step of remaining buckets.
 
             # Get buckets containing "first" parameter
-            fragment = self.state['buckets'][-1].fragments[-1]
+            fragment = self.state["buckets"][-1].fragments[-1]
             param_group_id = fragment.param_group_id
             param_id = fragment.param_id
-            param = self.param_groups[param_group_id]['params'][param_id]
+            param = self.param_groups[param_group_id]["params"][param_id]
             first_bucket_ids = sorted(
-                fragment.bucket_id
-                for fragment in self.state[param]['fragments']
+                fragment.bucket_id for fragment in self.state[param]["fragments"]
             )
 
             # Local step and launch param sync for first buckets
             self._local_step(first_bucket_ids)
             self._start_bucket_param_sync(
-                self._params_buckets[bucket_id]
-                for bucket_id in first_bucket_ids
+                self._params_buckets[bucket_id] for bucket_id in first_bucket_ids
             )
 
             # Local step for remaining buckets
             first_bucket_ids = set(first_bucket_ids)
             self._local_step(
                 bucket_id
-                for bucket_id in range(len(self.state['buckets']))
+                for bucket_id in range(len(self.state["buckets"]))
                 if bucket_id not in first_bucket_ids
             )
 
@@ -1901,7 +2002,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
         else:
             # Local step and blocking param sync
-            self._local_step(list(range(len(self.state['buckets']))))
+            self._local_step(list(range(len(self.state["buckets"]))))
             self.param_sync()
 
         return loss
@@ -1921,13 +2022,12 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             return
 
         # Find param fragments for each bucket
-        buffers = collections.defaultdict(list) # p_in, m, v, g, p_out
+        buffers = collections.defaultdict(list)  # p_in, m, v, g, p_out
         for bucket_id in bucket_ids:
-
             # Optimizer state buffers for local shard
-            fragments = self.state['buckets'][bucket_id].fragments
-            exp_avg = self.state['buckets'][bucket_id].exp_avg_shard
-            exp_avg_sq = self.state['buckets'][bucket_id].exp_avg_sq_shard
+            fragments = self.state["buckets"][bucket_id].fragments
+            exp_avg = self.state["buckets"][bucket_id].exp_avg_shard
+            exp_avg_sq = self.state["buckets"][bucket_id].exp_avg_sq_shard
             grads = self._grads_buckets[bucket_id].grads_shard
             params_out = self._params_buckets[bucket_id].params_shard
 
@@ -1937,45 +2037,49 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                     param_group_id = fragment.param_group_id
                     shard_start, shard_end = fragment.shard_range
                     if self.store_params:
-                        params_shard = self.state['buckets'][bucket_id].params_shard
+                        params_shard = self.state["buckets"][bucket_id].params_shard
                         param_fragment = params_shard[shard_start:shard_end]
                     else:
                         param_id = fragment.param_id
-                        param = self.param_groups[param_group_id]['params'][param_id]
+                        param = self.param_groups[param_group_id]["params"][param_id]
                         param_start, param_end = fragment.shard_param_range
                         param_fragment = param.detach().view(-1)[param_start:param_end]
-                        param_fragment = param_fragment.to(dtype=self.dtype, device=self.device)
+                        param_fragment = param_fragment.to(
+                            dtype=self.dtype, device=self.device
+                        )
                     if shard_end > shard_start:
-                        buffers[param_group_id].append([
-                            param_fragment,
-                            exp_avg[shard_start:shard_end],
-                            exp_avg_sq[shard_start:shard_end],
-                            grads[shard_start:shard_end],
-                            params_out[shard_start:shard_end],
-                        ])
+                        buffers[param_group_id].append(
+                            [
+                                param_fragment,
+                                exp_avg[shard_start:shard_end],
+                                exp_avg_sq[shard_start:shard_end],
+                                grads[shard_start:shard_end],
+                                params_out[shard_start:shard_end],
+                            ]
+                        )
 
         # Apply optimizer step to each param group
         for group_id, group_buffers in buffers.items():
             group = self.param_groups[group_id]
-            beta1, beta2 = group['betas']
+            beta1, beta2 = group["betas"]
             multi_tensor_applier(
                 distributed_adam_cuda.multi_tensor_fused_adam,
                 self._dummy_overflow_buf,
                 list(zip(*group_buffers)),
                 self._grad_scale,
-                group['lr'],
+                group["lr"],
                 beta1,
                 beta2,
-                group['eps'],
-                self.state['step'],
+                group["eps"],
+                self.state["step"],
                 1 if self.adam_w_mode else 0,
-                1 if group['bias_correction'] else 0,
-                group['weight_decay'],
+                1 if group["bias_correction"] else 0,
+                group["weight_decay"],
             )
 
     def _local_step_with_param_remainders(
-            self,
-            bucket_ids: Iterable[int],
+        self,
+        bucket_ids: Iterable[int],
     ) -> None:
         """Apply optimizer step to local shard of parameter bucket
 
@@ -1990,14 +2094,15 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         """
 
         # Find param fragments for each bucket
-        buffers = collections.defaultdict(list) # p_in, p_rem, m, v, g, p_out
+        buffers = collections.defaultdict(list)  # p_in, p_rem, m, v, g, p_out
         for bucket_id in bucket_ids:
-
             # State buffers for local shard
-            fragments = self.state['buckets'][bucket_id].fragments
-            param_remainders_shard = self.state['buckets'][bucket_id].param_remainders_shard
-            exp_avg = self.state['buckets'][bucket_id].exp_avg_shard
-            exp_avg_sq = self.state['buckets'][bucket_id].exp_avg_sq_shard
+            fragments = self.state["buckets"][bucket_id].fragments
+            param_remainders_shard = self.state["buckets"][
+                bucket_id
+            ].param_remainders_shard
+            exp_avg = self.state["buckets"][bucket_id].exp_avg_shard
+            exp_avg_sq = self.state["buckets"][bucket_id].exp_avg_sq_shard
             grads = self._grads_buckets[bucket_id].grads_shard
             params_out = self._params_buckets[bucket_id].params_shard
 
@@ -2008,36 +2113,40 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                     param_id = fragment.param_id
                     param_start, param_end = fragment.shard_param_range
                     shard_start, shard_end = fragment.shard_range
-                    param = self.param_groups[param_group_id]['params'][param_id]
+                    param = self.param_groups[param_group_id]["params"][param_id]
                     param_fragment = param.detach().view(-1)[param_start:param_end]
-                    param_fragment = param_fragment.to(dtype=torch.bfloat16, device=self.device)
+                    param_fragment = param_fragment.to(
+                        dtype=torch.bfloat16, device=self.device
+                    )
                     if shard_end > shard_start:
-                        buffers[param_group_id].append([
-                            param_fragment,
-                            param_remainders_shard[shard_start:shard_end],
-                            exp_avg[shard_start:shard_end],
-                            exp_avg_sq[shard_start:shard_end],
-                            grads[shard_start:shard_end],
-                            params_out[shard_start:shard_end],
-                        ])
+                        buffers[param_group_id].append(
+                            [
+                                param_fragment,
+                                param_remainders_shard[shard_start:shard_end],
+                                exp_avg[shard_start:shard_end],
+                                exp_avg_sq[shard_start:shard_end],
+                                grads[shard_start:shard_end],
+                                params_out[shard_start:shard_end],
+                            ]
+                        )
 
         # Apply optimizer step to each param group
         for group_id, group_buffers in buffers.items():
             group = self.param_groups[group_id]
-            beta1, beta2 = group['betas']
+            beta1, beta2 = group["betas"]
             multi_tensor_applier(
                 distributed_adam_cuda.multi_tensor_fused_adam_with_param_remainders,
                 self._dummy_overflow_buf,
                 list(zip(*group_buffers)),
                 self._grad_scale,
-                group['lr'],
+                group["lr"],
                 beta1,
                 beta2,
-                group['eps'],
-                self.state['step'],
+                group["eps"],
+                self.state["step"],
                 1 if self.adam_w_mode else 0,
-                1 if group['bias_correction'] else 0,
-                group['weight_decay'],
+                1 if group["bias_correction"] else 0,
+                group["weight_decay"],
             )
 
     def state_dict(self, gather_on_root: bool = True) -> dict:
@@ -2079,10 +2188,12 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         max_state_size = max(state_sizes)
 
         # Construct workspace buffers
-        chunk_size = self.default_shard_size * torch.finfo(self.grad_sync_dtype).bits // 8
+        chunk_size = (
+            self.default_shard_size * torch.finfo(self.grad_sync_dtype).bits // 8
+        )
         if self.distributed_rank == 0:
             gathered_state_bytes = [
-                torch.empty([size], dtype=torch.uint8, device='cpu')
+                torch.empty([size], dtype=torch.uint8, device="cpu")
                 for size in state_sizes
             ]
             gathered_state_bytes[0].copy_(
@@ -2118,11 +2229,12 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             stream_id %= self.pipeline_size
             stream = self._pipeline_streams[stream_id]
             with torch.cuda.stream(stream):
-
                 # Buffers for chunk
                 if self.distributed_rank == 0:
                     gathered_chunks = [
-                        gathered_chunks_buffers[stream_id][i*chunk_size:(i+1)*chunk_size]
+                        gathered_chunks_buffers[stream_id][
+                            i * chunk_size : (i + 1) * chunk_size
+                        ]
                         for i in range(self.distributed_size)
                     ]
                 else:
@@ -2130,7 +2242,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
                 # Copy to GPU
                 if self.distributed_rank != 0 and offset < local_state_size:
-                    local_chunk_size = min(chunk_size, local_state_size-offset)
+                    local_chunk_size = min(chunk_size, local_state_size - offset)
                     chunk[:local_chunk_size].copy_(
                         torch.frombuffer(
                             state_bytes_view,
@@ -2149,7 +2261,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                 with torch.cuda.stream(main_stream):
                     if self.distributed_rank == 0:
                         if self._gather_no_copy:
-                            no_copy_kwarg = { 'no_copy': True }
+                            no_copy_kwarg = {"no_copy": True}
                         else:
                             no_copy_kwarg = {}
                         torch.distributed.gather(
@@ -2175,7 +2287,9 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                         rank_chunk_size = rank_chunk_end - rank_chunk_start
                         if rank_chunk_size > 0:
                             src = gathered_chunks[rank][:rank_chunk_size]
-                            dst = gathered_state_bytes[rank][rank_chunk_start:rank_chunk_end]
+                            dst = gathered_state_bytes[rank][
+                                rank_chunk_start:rank_chunk_end
+                            ]
                             dst.copy_(src, non_blocking=True)
 
         # Synchronize GPU
@@ -2185,7 +2299,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
         # Return gathered state data on root rank
         if self.distributed_rank == 0:
-            return {'gathered_states': gathered_state_bytes}
+            return {"gathered_states": gathered_state_bytes}
         else:
             return None
 
@@ -2193,15 +2307,14 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         """Load optimizer state"""
 
         # State dict contains state for all ranks
-        if 'gathered_states' in state_dict:
-
+        if "gathered_states" in state_dict:
             # Deallocate distributed optimizer state to reduce GPU
             # memory usage
-            if 'buckets' in self.state:
-                del self.state['buckets']
+            if "buckets" in self.state:
+                del self.state["buckets"]
 
             # Get state for current rank and parse byte string
-            state_bytes = state_dict['gathered_states'][self.distributed_rank]
+            state_bytes = state_dict["gathered_states"][self.distributed_rank]
             state_bytes = io.BytesIO(state_bytes.numpy())
             state_dict = torch.load(state_bytes)
 


### PR DESCRIPTION
This PR makes some minor stylistic changes to the distributed Adam optimizer:
- Add type hints for functions and member variables.
- Remove unused functions, mainly the deprecated synchronization logic for async collectives in `GradientBucket.sync_wait` and `ParameterBucket.sync_wait`,
- Make the `ParameterFragment` class a dataclass.

None of these changes should affect functionality.