### PR TITLE
[Transformer][Test] Skip UccP2PCommTest on single GPU

### DIFF
--- a/tests/L0/run_transformer/test_p2p_comm.py
+++ b/tests/L0/run_transformer/test_p2p_comm.py
@@ -115,6 +115,7 @@ class P2PCommTestBase:
 
 
 # n.b.(mkozuki): Intentionally skip NCCL backend tests as I trust pytorch/pytorch repo.
+@unittest.skipIf(torch.cuda.device_count() < 2, "Requires >= 2 GPUs")
 class UccP2PCommTest(P2PCommTestBase, UccDistributedTestBase): pass
 
 


### PR DESCRIPTION
Running pipeline parallel test on single GPU does not make sense, why not just skip it?