### PR TITLE
Massively reduce LayerNorm/RMSNorm GPU memory usage in modern networks by tricking torch autograd

### DIFF
--- a/apex/contrib/csrc/layer_norm/ln.h
+++ b/apex/contrib/csrc/layer_norm/ln.h
@@ -10,7 +10,7 @@ namespace layer_norm {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template<typename Params> 
+template<typename Params>
 struct LaunchParams{
 
     size_t workspace_bytes;
@@ -26,17 +26,20 @@ struct LaunchParams{
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-struct ParamsBase {
-    ParamsBase()
+struct FwdParams{
+    FwdParams()
         : ctas_per_col(0)
         , rows(0)
         , cols(0)
         , x(nullptr)
+        , z(nullptr)
         , mu(nullptr)
         , rs(nullptr)
         , gamma(nullptr)
+        , beta(nullptr)
         , workspace(nullptr)
         , barrier(nullptr)
+        , epsilon(0.f)
     {
     }
 
@@ -49,9 +52,11 @@ struct ParamsBase {
 
     // Common data pointers.
     void *x;
+    void *z;
     void *mu;
     void *rs;
     void *gamma;
+    void *beta;
 
     // Multi-CTA workspace in gmem.
     void *workspace;
@@ -59,31 +64,15 @@ struct ParamsBase {
     // Multi-CTA sync barriers in gmem.
     int *barrier;
 
-};
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-struct FwdParams : public ParamsBase {
-    FwdParams()
-        : ParamsBase()
-        , z(nullptr)
-        , beta(nullptr)
-        , epsilon(0.f)
-    {
-    }
-
     // Output of LN FWD.
-    void *z;
-    void *beta;
     float epsilon;
-
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-struct BwdParams : public ParamsBase {
+struct BwdParams : public  FwdParams{
     BwdParams()
-        : ParamsBase()
+        : FwdParams()
         , dz(nullptr)
         , dbeta_part(nullptr)
         , dgamma_part(nullptr)
@@ -92,7 +81,6 @@ struct BwdParams : public ParamsBase {
         , dgamma(nullptr)
     {
     }
-
     // Input: gradient wrt. LN FWD output.
     void *dz;
 
@@ -200,3 +188,4 @@ struct BwdRegistrar{
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 }  // namespace layer_norm
+

--- a/apex/contrib/csrc/layer_norm/ln_bwd_kernels.cuh
+++ b/apex/contrib/csrc/layer_norm/ln_bwd_kernels.cuh
@@ -57,10 +57,14 @@ void ln_bwd_kernel(layer_norm::BwdParams params) {
 
     constexpr float rn = 1.f / float(COLS);
     Wvec gamma[LDGS];
+    Wvec beta[LDGS];
     index_t idx = c;
     #pragma unroll
     for( int it = 0; it < LDGS; it++ ) {
         gamma[it].load_from(params.gamma, idx);
+        if (params.z != nullptr) {
+            beta[it].load_from(params.beta, idx);
+        }
         idx += Ktraits::VEC_COLS_PER_LDG;
     }
     // TODO if ROWS_PER_CTA does not divide rows, we might get divergence in the
@@ -68,15 +72,19 @@ void ln_bwd_kernel(layer_norm::BwdParams params) {
     // grid stride over rows
     #pragma unroll 1
     for( int row = r; row < params.rows; row += params.ctas_per_col * ROWS_PER_CTA ) {
-        const compute_t mu_r = static_cast<const compute_t *>(params.mu)[row];
+        const compute_t mu_r = params.z == nullptr ? static_cast<const compute_t *>(params.mu)[row] : 0.f;
         const compute_t rs_r = static_cast<const compute_t *>(params.rs)[row];
-        Ivec x[LDGS];
+        Ivec x_or_z[LDGS];
         Ovec dz[LDGS];
         index_t idx = row * Ktraits::VEC_COLS + c;
         #pragma unroll
         for( int it = 0; it < LDGS; it++ ) {
             dz[it].load_from(params.dz, idx);
-            x[it].load_from(params.x, idx);
+            if (params.z != nullptr) {
+              x_or_z[it].load_from(params.z, idx);
+            } else {
+              x_or_z[it].load_from(params.x, idx);
+            }
             idx += Ktraits::VEC_COLS_PER_LDG;
         }
 
@@ -89,10 +97,11 @@ void ln_bwd_kernel(layer_norm::BwdParams params) {
         for( int it = 0; it < LDGS; it++ ) {
             #pragma unroll
             for( int jt = 0; jt < NUM_ELTS; jt++ ) {
-                compute_t x_tmp = x[it].data.elt[jt];
-                compute_t y_tmp = rs_r * (x_tmp - mu_r);
-                compute_t dy_tmp = compute_t(gamma[it].data.elt[jt]);
-                dy_tmp *= compute_t(dz[it].data.elt[jt]);
+                compute_t gamma_tmp = compute_t(gamma[it].data.elt[jt]);
+                compute_t beta_tmp = compute_t(beta[it].data.elt[jt]);
+                compute_t x_or_z_tmp = compute_t(x_or_z[it].data.elt[jt]);
+                compute_t y_tmp = params.z != nullptr ? (x_or_z_tmp - beta_tmp) / gamma_tmp : rs_r * (x_or_z_tmp - mu_r);
+                compute_t dy_tmp = compute_t(dz[it].data.elt[jt]) * gamma_tmp;
                 compute_t dz_tmp = dz[it].data.elt[jt];
 
                 mdy_local += dy_tmp;

--- a/apex/contrib/layer_norm/layer_norm.py
+++ b/apex/contrib/layer_norm/layer_norm.py
@@ -29,9 +29,9 @@ class FastLayerNormFN(torch.autograd.Function):
         dy = dy.contiguous()  # this happens!
         x_or_y_mat, gamma, mu, rsigma, beta = ctx.saved_tensors
         dymat = dy.view(x_or_y_mat.shape)
-        dxmat, dgamma, dbeta, _, _ = fast_layer_norm.ln_bwd(dymat, x_or_y_mat, mu, rsigma, gamma, beta)
+        dxmat, dgamma, dbeta, _, _ = fast_layer_norm.ln_bwd(dymat, x_or_y_mat, mu, rsigma, gamma, beta, ctx.memory_efficient)
         dx = dxmat.view(ctx.x_shape)
-        return dx, dgamma, dbeta, None
+        return dx, dgamma, dbeta, None, None
 
 
 def _fast_layer_norm(x, weight, bias, epsilon, memory_efficient):

--- a/apex/contrib/layer_norm/layer_norm.py
+++ b/apex/contrib/layer_norm/layer_norm.py
@@ -7,40 +7,44 @@ import fast_layer_norm
 
 class FastLayerNormFN(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x, gamma, beta, epsilon):
+    def forward(ctx, x, gamma, beta, epsilon, memory_efficient):
+        ctx.x_shape = x.shape
+        ctx.memory_efficient = memory_efficient
+
         x = x.contiguous()
         gamma = gamma.contiguous()
         beta = beta.contiguous()
         hidden_size = gamma.numel()
         xmat = x.view((-1, hidden_size))
         ymat, mu, rsigma = fast_layer_norm.ln_fwd(xmat, gamma, beta, epsilon)
-        ctx.save_for_backward(x, gamma, mu, rsigma)
+        if ctx.memory_efficient:
+            ctx.save_for_backward(ymat, gamma, None, rsigma, beta)
+        else:
+            ctx.save_for_backward(xmat, gamma, mu, rsigma, None)
         return ymat.view(x.shape)
 
     @staticmethod
     def backward(ctx, dy):
         # assert dy.is_contiguous()
         dy = dy.contiguous()  # this happens!
-        x, gamma, mu, rsigma = ctx.saved_tensors
-
-        hidden_size = gamma.numel()
-        xmat = x.view((-1, hidden_size))
-        dymat = dy.view(xmat.shape)
-        dxmat, dgamma, dbeta, _, _ = fast_layer_norm.ln_bwd(dymat, xmat, mu, rsigma, gamma)
-        dx = dxmat.view(x.shape)
+        x_or_y_mat, gamma, mu, rsigma, beta = ctx.saved_tensors
+        dymat = dy.view(x_or_y_mat.shape)
+        dxmat, dgamma, dbeta, _, _ = fast_layer_norm.ln_bwd(dymat, x_or_y_mat, mu, rsigma, gamma, beta)
+        dx = dxmat.view(ctx.x_shape)
         return dx, dgamma, dbeta, None
 
 
-def _fast_layer_norm(x, weight, bias, epsilon):
-    args = _cast_if_autocast_enabled(x, weight, bias, epsilon)
+def _fast_layer_norm(x, weight, bias, epsilon, memory_efficient):
+    args = _cast_if_autocast_enabled(x, weight, bias, epsilon, memory_efficient)
     with torch.cuda.amp.autocast(enabled=False):
         return FastLayerNormFN.apply(*args)
 
 
 class FastLayerNorm(torch.nn.Module):
-    def __init__(self, hidden_size, eps=1e-5):
+    def __init__(self, hidden_size, eps=1e-5, memory_efficient=False):
         super().__init__()
         self.epsilon = eps
+        self.memory_efficient = memory_efficient
         self.weight = torch.nn.Parameter(torch.empty(hidden_size))
         self.bias = torch.nn.Parameter(torch.empty(hidden_size))
         self.reset_parameters()
@@ -50,4 +54,4 @@ class FastLayerNorm(torch.nn.Module):
         init.zeros_(self.bias)
 
     def forward(self, x):
-        return _fast_layer_norm(x, self.weight, self.bias, self.epsilon)
+        return _fast_layer_norm(x, self.weight, self.bias, self.epsilon, self.memory_efficient)

--- a/apex/normalization/fused_layer_norm.py
+++ b/apex/normalization/fused_layer_norm.py
@@ -31,172 +31,198 @@ def manual_rms_norm(input, normalized_shape, weight, eps):
 
 class FusedLayerNormAffineFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input, weight, bias, normalized_shape, eps):
+    def forward(ctx, input, weight, bias, normalized_shape, eps, memory_efficient):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
         ctx.normalized_shape = normalized_shape
         ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
         input_ = input.contiguous()
         weight_ = weight.contiguous()
         bias_ = bias.contiguous()
         output, mean, invvar = fused_layer_norm_cuda.forward_affine(
             input_, ctx.normalized_shape, weight_, bias_, ctx.eps
         )
-        ctx.save_for_backward(output, weight_, bias_, invvar)
+        if ctx.memory_efficient:
+            ctx.save_for_backward(output, weight_, bias_, None, invvar)
+        else:
+            ctx.save_for_backward(input_, weight_, bias_, mean, invvar)
         return output
 
     @staticmethod
     def backward(ctx, grad_output):
-        output, weight_, bias_, invvar = ctx.saved_tensors
+        input_or_output, weight_, bias_, mean, invvar = ctx.saved_tensors
         grad_input = grad_weight = grad_bias = None
         grad_input, grad_weight, grad_bias = fused_layer_norm_cuda.backward_affine(
-            grad_output.contiguous(), invvar, output, ctx.normalized_shape, weight_, bias_, ctx.eps
+            grad_output.contiguous(), mean, invvar, input_or_output, 
+            ctx.normalized_shape, weight_, bias_, ctx.eps, ctx.memory_efficient
         )
-        return grad_input, grad_weight, grad_bias, None, None
+        return grad_input, grad_weight, grad_bias, None, None, None
 
 
 class FusedRMSNormAffineFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input, weight, normalized_shape, eps):
+    def forward(ctx, input, weight, normalized_shape, eps, memory_efficient):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
         ctx.normalized_shape = normalized_shape
         ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
         input_ = input.contiguous()
         weight_ = weight.contiguous()
         output, invvar = fused_layer_norm_cuda.rms_forward_affine(
             input_, ctx.normalized_shape, weight_, ctx.eps)
-        ctx.save_for_backward(output, weight_, invvar)
+        if ctx.memory_efficient:
+            ctx.save_for_backward(output, weight_, invvar)
+        else:
+            ctx.save_for_backward(input_, weight_, invvar)
         return output
 
     @staticmethod
     def backward(ctx, grad_output):
-        output, weight_, invvar = ctx.saved_tensors
+        input_or_output, weight_, invvar = ctx.saved_tensors
         grad_input = grad_weight = None
         grad_input, grad_weight = fused_layer_norm_cuda.rms_backward_affine(
-           grad_output.contiguous(), invvar, output, ctx.normalized_shape, weight_, ctx.eps
+           grad_output.contiguous(), invvar, input_or_output, 
+           ctx.normalized_shape, weight_, ctx.eps, ctx.memory_efficient
         )
-        return grad_input, grad_weight, None, None
+        return grad_input, grad_weight, None, None, None
 
 
 class FusedLayerNormAffineMixedDtypesFunction(FusedLayerNormAffineFunction):
 
     @staticmethod
-    def forward(ctx, input, weight, bias, normalized_shape, eps):
+    def forward(ctx, input, weight, bias, normalized_shape, eps, memory_efficient):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
         ctx.normalized_shape = normalized_shape
         ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
         input_ = input.contiguous()
         weight_ = weight.contiguous()
         bias_ = bias.contiguous()
         output, mean, invvar = fused_layer_norm_cuda.forward_affine_mixed_dtypes(
             input_, ctx.normalized_shape, weight_, bias_, ctx.eps
         )
-        ctx.save_for_backward(output, weight_, bias_, invvar)
+        if ctx.memory_efficient:
+            ctx.save_for_backward(output, weight_, bias_, None, invvar)
+        else:
+            ctx.save_for_backward(input_, weight_, bias_, mean, invvar)
         return output
 
 
 class FusedRMSNormAffineMixedDtypesFunction(FusedRMSNormAffineFunction):
 
     @staticmethod
-    def forward(ctx, input, weight, normalized_shape, eps):
+    def forward(ctx, input, weight, normalized_shape, eps, memory_efficient):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
         ctx.normalized_shape = normalized_shape
         ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
         input_ = input.contiguous()
         weight_ = weight.contiguous()
         output, invvar = fused_layer_norm_cuda.rms_forward_affine_mixed_dtypes(
             input_, ctx.normalized_shape, weight_, ctx.eps
         )
-
-        ctx.save_for_backward(output, weight_, invvar)
+        if ctx.memory_efficient:
+            ctx.save_for_backward(output, weight_, invvar)
+        else:
+            ctx.save_for_backward(input_, weight_, invvar)
         return output
 
 
 class FusedLayerNormFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input, normalized_shape, eps):
+    def forward(ctx, input, normalized_shape, eps, memory_efficient):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
         ctx.normalized_shape = normalized_shape
         ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
         input_ = input.contiguous()
         output, mean, invvar = fused_layer_norm_cuda.forward(input_, ctx.normalized_shape, ctx.eps)
-        ctx.save_for_backward(output, invvar)
+        if ctx.memory_efficient:
+            ctx.save_for_backward(output, None, invvar)
+        else:
+            ctx.save_for_backward(input_, mean, invvar)
         return output
 
     @staticmethod
     def backward(ctx, grad_output):
-        output, invvar = ctx.saved_tensors
-        grad_input = None
+        input_or_output, mean, invvar = ctx.saved_tensors
         grad_input = fused_layer_norm_cuda.backward(
-            grad_output.contiguous(), invvar, output, ctx.normalized_shape, ctx.eps
+            grad_output.contiguous(), mean, invvar, input_or_output,
+            ctx.normalized_shape, ctx.eps, ctx.memory_efficient
         )
-        return grad_input, None, None
+        return grad_input, None, None, None
 
 
 class FusedRMSNormFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input, normalized_shape, eps):
+    def forward(ctx, input, normalized_shape, eps, memory_efficient):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
         ctx.normalized_shape = normalized_shape
         ctx.eps = eps
+        ctx.memory_efficient = memory_efficient
         input_ = input.contiguous()
         output, invvar = fused_layer_norm_cuda.rms_forward(input_, ctx.normalized_shape, ctx.eps)
-        ctx.save_for_backward(output, invvar)
+        if ctx.memory_efficient:
+            ctx.save_for_backward(output, invvar)
+        else:
+            ctx.save_for_backward(input_, invvar)
         return output
 
     @staticmethod
     def backward(ctx, grad_output):
-        output, invvar = ctx.saved_tensors
+        input_or_output, invvar = ctx.saved_tensors
         grad_input = None
         grad_input = fused_layer_norm_cuda.rms_backward(
-            grad_output.contiguous(), invvar, output, ctx.normalized_shape, ctx.eps
+            grad_output.contiguous(), invvar, input_or_output, 
+            ctx.normalized_shape, ctx.eps, ctx.memory_efficient
         )
-        return grad_input, None, None
+        return grad_input, None, None, None
 
 
-def fused_layer_norm_affine(input, weight, bias, normalized_shape, eps=1e-6):
-    args = _cast_if_autocast_enabled(input, weight, bias, normalized_shape, eps)
+def fused_layer_norm_affine(input, weight, bias, normalized_shape, eps=1e-6, memory_efficient=False):
+    args = _cast_if_autocast_enabled(input, weight, bias, normalized_shape, eps, memory_efficient)
     with torch.cuda.amp.autocast(enabled=False):
         return FusedLayerNormAffineFunction.apply(*args)
 
 
-def fused_layer_norm(input, normalized_shape, eps=1e-6):
-    args = _cast_if_autocast_enabled(input, normalized_shape, eps)
+def fused_layer_norm(input, normalized_shape, eps=1e-6, memory_efficient=False):
+    args = _cast_if_autocast_enabled(input, normalized_shape, eps, memory_efficient)
     with torch.cuda.amp.autocast(enabled=False):
         return FusedLayerNormFunction.apply(*args)
 
 
-def mixed_dtype_fused_layer_norm_affine(input, weight, bias, normalized_shape, eps=1e-6):
-    args = _cast_if_autocast_enabled(input, weight, bias, normalized_shape, eps)
+def mixed_dtype_fused_layer_norm_affine(input, weight, bias, normalized_shape, eps=1e-6, memory_efficient=False):
+    args = _cast_if_autocast_enabled(input, weight, bias, normalized_shape, eps, memory_efficient)
     with torch.cuda.amp.autocast(enabled=False):
         return FusedLayerNormAffineMixedDtypesFunction.apply(*args)
 
 
-def fused_rms_norm_affine(input, weight, normalized_shape, eps=1e-6):
-    args = _cast_if_autocast_enabled(input, weight, normalized_shape, eps)
+def fused_rms_norm_affine(input, weight, normalized_shape, eps=1e-6, memory_efficient=False):
+    args = _cast_if_autocast_enabled(input, weight, normalized_shape, eps, memory_efficient)
     with torch.cuda.amp.autocast(enabled=False):
         return FusedRMSNormAffineFunction.apply(*args)
 
 
-def fused_rms_norm(input, normalized_shape, eps=1e-6):
-    args = _cast_if_autocast_enabled(input, normalized_shape, eps)
+def fused_rms_norm(input, normalized_shape, eps=1e-6, memory_efficient=False):
+    args = _cast_if_autocast_enabled(input, normalized_shape, eps, memory_efficient)
     with torch.cuda.amp.autocast(enabled=False):
         return FusedRMSNormFunction.apply(*args)
 
 
-def mixed_dtype_fused_rms_norm_affine(input, weight, normalized_shape, eps=1e-6):
-    args = _cast_if_autocast_enabled(input, weight, normalized_shape, eps)
+def mixed_dtype_fused_rms_norm_affine(input, weight, normalized_shape, eps=1e-6, memory_efficient=False):
+    args = _cast_if_autocast_enabled(input, weight, normalized_shape, eps, memory_efficient)
     with torch.cuda.amp.autocast(enabled=False):
         return FusedRMSNormAffineMixedDtypesFunction.apply(*args)
 
@@ -261,7 +287,7 @@ class FusedLayerNorm(torch.nn.Module):
     .. _`Layer Normalization`: https://arxiv.org/abs/1607.06450
     """
 
-    def __init__(self, normalized_shape, eps=1e-5, elementwise_affine=True):
+    def __init__(self, normalized_shape, eps=1e-5, elementwise_affine=True, memory_efficient=False):
         super().__init__()
 
         global fused_layer_norm_cuda
@@ -272,6 +298,7 @@ class FusedLayerNorm(torch.nn.Module):
         self.normalized_shape = torch.Size(normalized_shape)
         self.eps = eps
         self.elementwise_affine = elementwise_affine
+        self.memory_efficient = memory_efficient
         if self.elementwise_affine:
             self.weight = Parameter(torch.empty(*normalized_shape))
             self.bias = Parameter(torch.empty(*normalized_shape))
@@ -289,9 +316,11 @@ class FusedLayerNorm(torch.nn.Module):
         if torch.jit.is_tracing() or torch.jit.is_scripting() or not input.is_cuda:
             return F.layer_norm(input, self.normalized_shape, self.weight, self.bias, self.eps)
         if self.elementwise_affine:
-            return fused_layer_norm_affine(input, self.weight, self.bias, self.normalized_shape, self.eps)
+            return fused_layer_norm_affine(
+                input, self.weight, self.bias, self.normalized_shape, self.eps, self.memory_efficient
+            )
         else:
-            return fused_layer_norm(input, self.normalized_shape, self.eps)
+            return fused_layer_norm(input, self.normalized_shape, self.eps, self.memory_efficient)
 
     def extra_repr(self):
         return "{normalized_shape}, eps={eps}, " "elementwise_affine={elementwise_affine}".format(**self.__dict__)
@@ -357,7 +386,7 @@ class FusedRMSNorm(torch.nn.Module):
     .. _`Root Mean Square Layer Normalization`: https://arxiv.org/pdf/1910.07467.pdf
     """
 
-    def __init__(self, normalized_shape, eps=1e-5, elementwise_affine=True):
+    def __init__(self, normalized_shape, eps=1e-5, elementwise_affine=True, memory_efficient=False):
         super().__init__()
 
         global fused_layer_norm_cuda
@@ -368,6 +397,7 @@ class FusedRMSNorm(torch.nn.Module):
         self.normalized_shape = torch.Size(normalized_shape)
         self.eps = eps
         self.elementwise_affine = elementwise_affine
+        self.memory_efficient = memory_efficient
         if self.elementwise_affine:
             self.weight = Parameter(torch.empty(*normalized_shape))
         else:
@@ -383,9 +413,11 @@ class FusedRMSNorm(torch.nn.Module):
             return manual_rms_norm(input, self.normalized_shape, self.weight, self.eps)
 
         if self.elementwise_affine:
-            return fused_rms_norm_affine(input, self.weight, self.normalized_shape, self.eps)
+            return fused_rms_norm_affine(
+                input, self.weight, self.normalized_shape, self.eps, self.memory_efficient
+            )
         else:
-            return fused_rms_norm(input, self.normalized_shape, self.eps)
+            return fused_rms_norm(input, self.normalized_shape, self.eps, self.memory_efficient)
 
     def extra_repr(self):
         return "{normalized_shape}, eps={eps}, " "elementwise_affine={elementwise_affine}".format(**self.__dict__)
@@ -397,7 +429,7 @@ class FusedRMSNorm(torch.nn.Module):
 # See: `layer_norm_affine` and `layer_norm_affine_mixed_dtypes` in "csrc/layer_norm_cuda.cpp"
 class MixedFusedLayerNorm(FusedLayerNorm):
 
-    def __init__(self, normalized_shape, eps=1e-5, **kwargs):
+    def __init__(self, normalized_shape, eps=1e-5, *, memory_efficient=False, **kwargs):
         if "elementwise_affine" in kwargs:
             import warnings
             warnings.warn("MixedFusedLayerNorm does not support `elementwise_affine` argument")
@@ -405,13 +437,16 @@ class MixedFusedLayerNorm(FusedLayerNorm):
             if not elementwise_affine:
                 raise RuntimeError("MixedFusedLayerNorm does not support `elementwise_affine = False`")
 
-        super().__init__(normalized_shape=normalized_shape, eps=eps, elementwise_affine=True)
-
+        super().__init__(
+            normalized_shape=normalized_shape, eps=eps, elementwise_affine=True, memory_efficient=memory_efficient
+        )
     def forward(self, input: torch.Tensor):
         # NOTE (mkozuki): CPU path is here mainly for unittest sake.
         if torch.jit.is_tracing() or torch.jit.is_scripting() or not input.is_cuda:
             return F.layer_norm(input, self.normalized_shape, self.weight, self.bias, self.eps)
-        return mixed_dtype_fused_layer_norm_affine(input, self.weight, self.bias, self.normalized_shape, self.eps)
+        return mixed_dtype_fused_layer_norm_affine(
+            input, self.weight, self.bias, self.normalized_shape, self.eps, self.memory_efficient
+        )
 
 
 # MixedFusedLayerNorm differs from FusedLayerNorm in that this layer norm uses parameter's dtype
@@ -419,7 +454,7 @@ class MixedFusedLayerNorm(FusedLayerNorm):
 # See: `layer_norm_affine` and `layer_norm_affine_mixed_dtypes` in "csrc/layer_norm_cuda.cpp"
 class MixedFusedRMSNorm(FusedRMSNorm):
 
-    def __init__(self, normalized_shape, eps=1e-5, **kwargs):
+    def __init__(self, normalized_shape, eps=1e-5, *, memory_efficient=False, **kwargs):
         if "elementwise_affine" in kwargs:
             import warnings
             warnings.warn("MixedFusedRMSNorm does not support `elementwise_affine` argument")
@@ -427,11 +462,14 @@ class MixedFusedRMSNorm(FusedRMSNorm):
             if not elementwise_affine:
                 raise RuntimeError("MixedFusedRMSNorm does not support `elementwise_affine = False`")
 
-        super().__init__(normalized_shape=normalized_shape, eps=eps, elementwise_affine=True)
-
+        super().__init__(
+            normalized_shape=normalized_shape, eps=eps, elementwise_affine=True, memory_efficient=memory_efficient
+        )
     def forward(self, input: torch.Tensor):
         # NOTE (mkozuki): CPU path is here mainly for unittest sake.
         # TODO Manual RMS Norm Implementation Here
         if torch.jit.is_tracing() or torch.jit.is_scripting() or not input.is_cuda:
             return manual_rms_norm(input, self.normalized_shape, self.weight, self.eps)
-        return mixed_dtype_fused_rms_norm_affine(input, self.weight, self.normalized_shape, self.eps)
+        return mixed_dtype_fused_rms_norm_affine(
+            input, self.weight, self.normalized_shape, self.eps, self.memory_efficient
+        )

--- a/csrc/layer_norm_cuda.cpp
+++ b/csrc/layer_norm_cuda.cpp
@@ -212,9 +212,8 @@ std::vector<at::Tensor> layer_norm_affine_mixed_dtypes(
 
 void cuda_layer_norm_gradient(
     at::Tensor* dout,
-    at::Tensor* mean,
     at::Tensor* invvar,
-    at::Tensor* input,
+    at::Tensor* output,
     int n1,
     int n2,
     #ifdef VERSION_GE_1_1
@@ -232,9 +231,8 @@ void cuda_layer_norm_gradient(
 
 at::Tensor layer_norm_gradient(
     at::Tensor dout,
-    at::Tensor mean,
     at::Tensor invvar,
-    at::Tensor input,
+    at::Tensor output,
     #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
     #else
@@ -242,13 +240,12 @@ at::Tensor layer_norm_gradient(
     #endif
     double epsilon) {
   CHECK_INPUT(dout);
-  CHECK_INPUT(mean);
   CHECK_INPUT(invvar);
-  CHECK_INPUT(input);
+  CHECK_INPUT(output);
   int n1,n2;
-  check_args(input,normalized_shape,n1,n2);
-  at::Tensor grad_input = at::empty_like(input);
-  cuda_layer_norm_gradient(&dout,&mean,&invvar,&input,n1,n2,
+  check_args(output,normalized_shape,n1,n2);
+  at::Tensor grad_input = at::empty_like(output);
+  cuda_layer_norm_gradient(&dout,&invvar,&output,n1,n2,
       normalized_shape,NULL,NULL,epsilon,
       &grad_input,NULL,NULL);
   return grad_input;
@@ -256,9 +253,8 @@ at::Tensor layer_norm_gradient(
 
 std::vector<at::Tensor> layer_norm_gradient_affine(
     at::Tensor dout,
-    at::Tensor mean,
     at::Tensor invvar,
-    at::Tensor input,
+    at::Tensor output,
     #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
     #else
@@ -268,17 +264,16 @@ std::vector<at::Tensor> layer_norm_gradient_affine(
     at::Tensor beta,
     double epsilon) {
   CHECK_INPUT(dout);
-  CHECK_INPUT(mean);
   CHECK_INPUT(invvar);
-  CHECK_INPUT(input);
+  CHECK_INPUT(output);
   CHECK_INPUT(gamma);
   CHECK_INPUT(beta);
   int n1,n2;
-  check_args(input,normalized_shape,gamma,beta,n1,n2);
-  at::Tensor grad_input = at::empty_like(input);
+  check_args(output,normalized_shape,gamma,beta,n1,n2);
+  at::Tensor grad_input = at::empty_like(output);
   at::Tensor grad_gamma = at::empty_like(gamma);
   at::Tensor grad_beta = at::empty_like(beta);
-  cuda_layer_norm_gradient(&dout,&mean,&invvar,&input,n1,n2,
+  cuda_layer_norm_gradient(&dout,&invvar,&output,n1,n2,
       normalized_shape,&gamma,&beta,epsilon,
       &grad_input,&grad_gamma,&grad_beta);
   return {grad_input, grad_gamma, grad_beta};
@@ -364,7 +359,7 @@ std::vector<at::Tensor> rms_norm_affine_mixed_dtypes(
 void cuda_rms_norm_gradient(
     at::Tensor* dout,
     at::Tensor* invvar,
-    at::Tensor* input,
+    at::Tensor* output,
     int n1,
     int n2,
     #ifdef VERSION_GE_1_1
@@ -380,7 +375,7 @@ void cuda_rms_norm_gradient(
 at::Tensor rms_norm_gradient(
     at::Tensor dout,
     at::Tensor invvar,
-    at::Tensor input,
+    at::Tensor output,
     #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
     #else
@@ -389,11 +384,11 @@ at::Tensor rms_norm_gradient(
     double epsilon) {
   CHECK_INPUT(dout);
   CHECK_INPUT(invvar);
-  CHECK_INPUT(input);
+  CHECK_INPUT(output);
   int n1,n2;
-  check_args(input,normalized_shape,n1,n2);
-  at::Tensor grad_input = at::empty_like(input);
-  cuda_rms_norm_gradient(&dout,&invvar,&input,n1,n2,
+  check_args(output,normalized_shape,n1,n2);
+  at::Tensor grad_input = at::empty_like(output);
+  cuda_rms_norm_gradient(&dout,&invvar,&output,n1,n2,
       normalized_shape,NULL,epsilon,
       &grad_input,NULL);
   return grad_input;
@@ -402,7 +397,7 @@ at::Tensor rms_norm_gradient(
 std::vector<at::Tensor> rms_norm_gradient_affine(
     at::Tensor dout,
     at::Tensor invvar,
-    at::Tensor input,
+    at::Tensor output,
     #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
     #else
@@ -412,13 +407,13 @@ std::vector<at::Tensor> rms_norm_gradient_affine(
     double epsilon) {
   CHECK_INPUT(dout);
   CHECK_INPUT(invvar);
-  CHECK_INPUT(input);
+  CHECK_INPUT(output);
   CHECK_INPUT(gamma);
   int n1,n2;
-  check_args(input,normalized_shape,gamma,n1,n2);
-  at::Tensor grad_input = at::empty_like(input);
+  check_args(output,normalized_shape,gamma,n1,n2);
+  at::Tensor grad_input = at::empty_like(output);
   at::Tensor grad_gamma = at::empty_like(gamma);
-  cuda_rms_norm_gradient(&dout,&invvar,&input,n1,n2,
+  cuda_rms_norm_gradient(&dout,&invvar,&output,n1,n2,
       normalized_shape,&gamma,epsilon,
       &grad_input,&grad_gamma);
   return {grad_input, grad_gamma};

--- a/csrc/layer_norm_cuda.cpp
+++ b/csrc/layer_norm_cuda.cpp
@@ -212,8 +212,9 @@ std::vector<at::Tensor> layer_norm_affine_mixed_dtypes(
 
 void cuda_layer_norm_gradient(
     at::Tensor* dout,
+    at::Tensor* mean,
     at::Tensor* invvar,
-    at::Tensor* output,
+    at::Tensor* input_or_output,
     int n1,
     int n2,
     #ifdef VERSION_GE_1_1
@@ -226,35 +227,45 @@ void cuda_layer_norm_gradient(
     double epsilon,
     at::Tensor* grad_input,
     at::Tensor* grad_gamma,
-    at::Tensor* grad_beta
+    at::Tensor* grad_beta,
+    bool memory_efficient
     );
 
 at::Tensor layer_norm_gradient(
     at::Tensor dout,
+    c10::optional<at::Tensor> mean_,
     at::Tensor invvar,
-    at::Tensor output,
+    at::Tensor input_or_output,
     #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
     #else
     at::IntList normalized_shape,
     #endif
-    double epsilon) {
+    double epsilon,
+    bool memory_efficient) {
   CHECK_INPUT(dout);
   CHECK_INPUT(invvar);
-  CHECK_INPUT(output);
+  CHECK_INPUT(input_or_output);
   int n1,n2;
-  check_args(output,normalized_shape,n1,n2);
-  at::Tensor grad_input = at::empty_like(output);
-  cuda_layer_norm_gradient(&dout,&invvar,&output,n1,n2,
-      normalized_shape,NULL,NULL,epsilon,
-      &grad_input,NULL,NULL);
+  check_args(input_or_output,normalized_shape,n1,n2);
+  at::Tensor grad_input = at::empty_like(input_or_output);
+  if (mean_.has_value()) {
+    cuda_layer_norm_gradient(&dout,&mean_.value(),&invvar,&input_or_output,n1,n2,
+        normalized_shape,NULL,NULL,epsilon,
+        &grad_input,NULL,NULL,memory_efficient);
+  } else {
+    cuda_layer_norm_gradient(&dout,NULL,&invvar,&input_or_output,n1,n2,
+        normalized_shape,NULL,NULL,epsilon,
+        &grad_input,NULL,NULL,memory_efficient);
+  }
   return grad_input;
 }
 
 std::vector<at::Tensor> layer_norm_gradient_affine(
     at::Tensor dout,
+    c10::optional<at::Tensor> mean_,
     at::Tensor invvar,
-    at::Tensor output,
+    at::Tensor input_or_output,
     #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
     #else
@@ -262,20 +273,28 @@ std::vector<at::Tensor> layer_norm_gradient_affine(
     #endif
     at::Tensor gamma,
     at::Tensor beta,
-    double epsilon) {
+    double epsilon,
+    bool memory_efficient) {
   CHECK_INPUT(dout);
   CHECK_INPUT(invvar);
-  CHECK_INPUT(output);
+  CHECK_INPUT(input_or_output);
   CHECK_INPUT(gamma);
   CHECK_INPUT(beta);
   int n1,n2;
-  check_args(output,normalized_shape,gamma,beta,n1,n2);
-  at::Tensor grad_input = at::empty_like(output);
+  check_args(input_or_output,normalized_shape,gamma,beta,n1,n2);
+  at::Tensor grad_input = at::empty_like(input_or_output);
   at::Tensor grad_gamma = at::empty_like(gamma);
   at::Tensor grad_beta = at::empty_like(beta);
-  cuda_layer_norm_gradient(&dout,&invvar,&output,n1,n2,
-      normalized_shape,&gamma,&beta,epsilon,
-      &grad_input,&grad_gamma,&grad_beta);
+//   at::Tensor *mean = mean_.has_value() ? &mean_.value() : NULL;
+  if (mean_.has_value()) {
+    cuda_layer_norm_gradient(&dout,&mean_.value(),&invvar,&input_or_output,n1,n2,
+        normalized_shape,&gamma,&beta,epsilon,
+        &grad_input,&grad_gamma,&grad_beta,memory_efficient);
+  } else {
+    cuda_layer_norm_gradient(&dout,NULL,&invvar,&input_or_output,n1,n2,
+        normalized_shape,&gamma,&beta,epsilon,
+        &grad_input,&grad_gamma,&grad_beta,memory_efficient);
+  }
   return {grad_input, grad_gamma, grad_beta};
 }
 
@@ -359,7 +378,7 @@ std::vector<at::Tensor> rms_norm_affine_mixed_dtypes(
 void cuda_rms_norm_gradient(
     at::Tensor* dout,
     at::Tensor* invvar,
-    at::Tensor* output,
+    at::Tensor* input_or_output,
     int n1,
     int n2,
     #ifdef VERSION_GE_1_1
@@ -370,52 +389,55 @@ void cuda_rms_norm_gradient(
     at::Tensor* gamma,
     double epsilon,
     at::Tensor* grad_input,
-    at::Tensor* grad_gamma);
+    at::Tensor* grad_gamma,
+    bool memory_efficient);
 
 at::Tensor rms_norm_gradient(
     at::Tensor dout,
     at::Tensor invvar,
-    at::Tensor output,
+    at::Tensor input_or_output,
     #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
     #else
     at::IntList normalized_shape,
     #endif
-    double epsilon) {
+    double epsilon,
+    bool memory_efficient) {
   CHECK_INPUT(dout);
   CHECK_INPUT(invvar);
-  CHECK_INPUT(output);
+  CHECK_INPUT(input_or_output);
   int n1,n2;
-  check_args(output,normalized_shape,n1,n2);
-  at::Tensor grad_input = at::empty_like(output);
-  cuda_rms_norm_gradient(&dout,&invvar,&output,n1,n2,
+  check_args(input_or_output,normalized_shape,n1,n2);
+  at::Tensor grad_input = at::empty_like(input_or_output);
+  cuda_rms_norm_gradient(&dout,&invvar,&input_or_output,n1,n2,
       normalized_shape,NULL,epsilon,
-      &grad_input,NULL);
+      &grad_input,NULL,memory_efficient);
   return grad_input;
 }
 
 std::vector<at::Tensor> rms_norm_gradient_affine(
     at::Tensor dout,
     at::Tensor invvar,
-    at::Tensor output,
+    at::Tensor input_or_output,
     #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
     #else
     at::IntList normalized_shape,
     #endif
     at::Tensor gamma,
-    double epsilon) {
+    double epsilon,
+    bool memory_efficient) {
   CHECK_INPUT(dout);
   CHECK_INPUT(invvar);
-  CHECK_INPUT(output);
+  CHECK_INPUT(input_or_output);
   CHECK_INPUT(gamma);
   int n1,n2;
-  check_args(output,normalized_shape,gamma,n1,n2);
-  at::Tensor grad_input = at::empty_like(output);
+  check_args(input_or_output,normalized_shape,gamma,n1,n2);
+  at::Tensor grad_input = at::empty_like(input_or_output);
   at::Tensor grad_gamma = at::empty_like(gamma);
-  cuda_rms_norm_gradient(&dout,&invvar,&output,n1,n2,
+  cuda_rms_norm_gradient(&dout,&invvar,&input_or_output,n1,n2,
       normalized_shape,&gamma,epsilon,
-      &grad_input,&grad_gamma);
+      &grad_input,&grad_gamma,memory_efficient);
   return {grad_input, grad_gamma};
 }
 

--- a/csrc/layer_norm_cuda_kernel.cu
+++ b/csrc/layer_norm_cuda_kernel.cu
@@ -467,14 +467,17 @@ void cuLoadWriteStridedInputs(
     const int row_stride,
     U* warp_buf1,
     U* warp_buf2,
-    const T* output,
+    const T* input_or_output,
     const V* dout,
     const int i1_end,
     const int n2,
+    const U* __restrict__ mean,
+    const U* __restrict__ invvar,
     const V* __restrict__ gamma,
     const V* __restrict__ beta,
     const double eps,
-    bool rms_only
+    bool rms_only,
+    bool memory_efficient
     )
 {
   int i1 = i1_block+thr_load_row_off;
@@ -484,15 +487,22 @@ void cuLoadWriteStridedInputs(
       int load_idx = i1*n2+i2;
       int write_idx = thr_load_row_off*row_stride+thr_load_col_off+k;
       if (i2<n2) {
-        U curr_output = static_cast<U>(output[load_idx]);
+        U c_h = static_cast<U>(input_or_output[load_idx]);
         U curr_dout = static_cast<U>(dout[load_idx]);
-        U curr_gamma = static_cast<U>(clamp_by_magnitude(gamma[i2], eps));
         if (!rms_only) {
-          U curr_beta = static_cast<U>(beta[i2]);
           warp_buf1[write_idx] = curr_dout;
-          warp_buf2[write_idx] = curr_dout * (curr_output - curr_beta) / curr_gamma;
+          if (memory_efficient) {
+            U curr_beta = static_cast<U>(beta[i2]);
+            warp_buf2[write_idx] = curr_dout * (c_h - curr_beta) / static_cast<U>(clamp_by_magnitude(gamma[i2], eps));
+          } else {
+            warp_buf2[write_idx] = curr_dout * (c_h - mean[i1]) * invvar[i1];
+          }
         } else {
-          warp_buf2[write_idx] = curr_dout * curr_output / curr_gamma;
+          if (memory_efficient) {
+            warp_buf2[write_idx] = curr_dout * (c_h) / static_cast<U>(clamp_by_magnitude(gamma[i2], eps));
+          } else {
+            warp_buf2[write_idx] = curr_dout * (c_h) * invvar[i1];
+          }
         }
       } else {
         if (!rms_only) {
@@ -521,14 +531,17 @@ void cuLoadAddStridedInputs(
     const int row_stride,
     U* warp_buf1,
     U* warp_buf2,
-    const T* output,
+    const T* input_or_output,
     const V* dout,
     const int i1_end,
     const int n2,
+    const U* __restrict__ mean,
+    const U* __restrict__ invvar,
     const V* __restrict__ gamma,
     const V* __restrict__ beta,
     const double eps,
-    bool rms_only
+    bool rms_only,
+    bool memory_efficient
     )
 {
   int i1 = i1_block+thr_load_row_off;
@@ -538,15 +551,22 @@ void cuLoadAddStridedInputs(
       int load_idx = i1*n2+i2;
       int write_idx = thr_load_row_off*row_stride+thr_load_col_off+k;
       if (i2<n2) {
-        U curr_output = static_cast<U>(output[load_idx]);
+        U c_h = static_cast<U>(input_or_output[load_idx]);
         U curr_dout = static_cast<U>(dout[load_idx]);
-        U curr_gamma = static_cast<U>(clamp_by_magnitude(gamma[i2], eps));
         if (!rms_only) {
           U curr_beta = static_cast<U>(beta[i2]);
           warp_buf1[write_idx] += curr_dout;
-          warp_buf2[write_idx] += curr_dout * (curr_output - curr_beta) / curr_gamma;
+          if (memory_efficient) {
+            warp_buf2[write_idx] += curr_dout * (c_h - curr_beta) / static_cast<U>(clamp_by_magnitude(gamma[i2], eps));
+          } else {
+            warp_buf2[write_idx] += curr_dout * (c_h - mean[i1]) * invvar[i1];
+          }
         } else {
-          warp_buf2[write_idx] += curr_dout * (curr_output) / curr_gamma;
+          if (memory_efficient) {
+            warp_buf2[write_idx] += curr_dout * (c_h) / static_cast<U>(clamp_by_magnitude(gamma[i2], eps));
+          } else {
+            warp_buf2[write_idx] += curr_dout * (c_h) * invvar[i1];
+          }
         }
       }
     }
@@ -557,16 +577,19 @@ void cuLoadAddStridedInputs(
 template<typename T, typename U, typename V> __global__
 void cuComputePartGradGammaBeta(
     const V* __restrict__ dout,
-    const T* __restrict__ output,
+    const T* __restrict__ input_or_output,
     const int n1,
     const int n2,
+    const U* __restrict__ mean,
+    const U* __restrict__ invvar,
     U epsilon,
     const V* __restrict__ gamma,
     const V* __restrict__ beta,
     U* part_grad_gamma,
     U* part_grad_beta,
     const double eps,
-    bool rms_only)
+    bool rms_only,
+    bool memory_efficient)
 {
     const int numsegs_n1 = (n1+blockDim.y*blockDim.y-1) / (blockDim.y*blockDim.y);
     const int segs_per_block = (numsegs_n1 + gridDim.y - 1) / gridDim.y;
@@ -583,9 +606,9 @@ void cuComputePartGradGammaBeta(
     U* warp_buf2 = warp_buf1 + blockDim.y * blockDim.y * row_stride;
     // compute partial sums from strided inputs
     // do this to increase number of loads in flight
-    cuLoadWriteStridedInputs(i1_beg,thr_load_row_off,thr_load_col_off,i2_off,row_stride,warp_buf1,warp_buf2,output,dout,i1_end,n2,gamma,beta,eps, rms_only);
+    cuLoadWriteStridedInputs(i1_beg,thr_load_row_off,thr_load_col_off,i2_off,row_stride,warp_buf1,warp_buf2,input_or_output,dout,i1_end,n2,mean,invvar,gamma,beta,eps, rms_only,memory_efficient);
     for (int i1_block = i1_beg+blockDim.y*blockDim.y;  i1_block < i1_end;  i1_block+=blockDim.y*blockDim.y) {
-      cuLoadAddStridedInputs(i1_block,thr_load_row_off,thr_load_col_off,i2_off,row_stride,warp_buf1,warp_buf2,output,dout,i1_end,n2,gamma,beta,eps, rms_only);
+      cuLoadAddStridedInputs(i1_block,thr_load_row_off,thr_load_col_off,i2_off,row_stride,warp_buf1,warp_buf2,input_or_output,dout,i1_end,n2,mean,invvar,gamma,beta,eps, rms_only,memory_efficient);
     }
     __syncthreads();
     // inter-warp reductions
@@ -696,72 +719,106 @@ void cuComputeGradGammaBeta(
 template<typename T, typename U, typename V> __global__
 void cuComputeGradInput(
     const V* __restrict__ dout,
-    const T* __restrict__ output,
+    const T* __restrict__ input_or_output,
     const int n1,
     const int n2,
+    const U* __restrict__ mean,
     const U* __restrict__ invvar,
     U epsilon,
     const V* gamma,
     const V* beta,
     T* grad_input,
     const double eps,
-    bool rms_only)
+    bool rms_only,
+    bool memory_efficient)
 {
   for (auto i1=blockIdx.y; i1 < n1; i1 += gridDim.y) {
     U sum_loss1 = U(0);
     U sum_loss2 = U(0);
-    const T* k_output = output + i1*n2;
+    const T* k_h = input_or_output + i1*n2;
     const V* k_dout = dout + i1*n2;
     const U c_invvar = invvar[i1];
+    const U c_mean = !memory_efficient ? mean[i1] : 0.;
     const int numx = blockDim.x * blockDim.y;
     const int thrx = threadIdx.x + threadIdx.y * blockDim.x;
     if (gamma != NULL) {
       int l = 4*thrx;
       for (;  l+3 < n2;  l+=4*numx) {
         for (int k = 0;  k < 4;  ++k) {
-          const U c_h = static_cast<U>(k_output[l+k]);
+          const U c_h = static_cast<U>(k_h[l+k]);
           const U c_loss = static_cast<U>(k_dout[l+k]);
           if (!rms_only) {
             sum_loss1 += c_loss * gamma[l+k];
-            sum_loss2 += c_loss * (c_h - beta[l+k]);
+            if (memory_efficient) {
+              sum_loss2 += c_loss * (c_h - beta[l+k]);
+            } else {
+              sum_loss2 += c_loss * gamma[l+k] * (c_h - c_mean) * c_invvar;
+            }
           } else {
-            sum_loss2 += c_loss * c_h;
+            if (memory_efficient) {
+              sum_loss2 += c_loss * c_h;
+            } else {
+              sum_loss2 += c_loss * gamma[l+k] * (c_h) * c_invvar;
+            }
           }
         }
       }
       for (;  l < n2;  ++l) {
-        const U c_h = static_cast<U>(k_output[l]);
+        const U c_h = static_cast<U>(k_h[l]);
         const U c_loss = static_cast<U>(k_dout[l]);
         if (!rms_only) {
           sum_loss1 += c_loss * gamma[l];
-          sum_loss2 += c_loss * (c_h - beta[l]);
+          if (memory_efficient) {
+            sum_loss2 += c_loss * (c_h - beta[l]);
+          } else {
+            sum_loss2 += c_loss * gamma[l] * (c_h - c_mean) * c_invvar;
+          }
         } else {
-          sum_loss2 += c_loss * c_h;
+          if (memory_efficient) {
+            sum_loss2 += c_loss * c_h;
+          } else {
+            sum_loss2 += c_loss * gamma[l] * (c_h) * c_invvar;
+          }
         }
-
       }
     } else {
       int l = 4*thrx;
       for (;  l+3 < n2;  l+=4*numx) {
         for (int k = 0;  k < 4;  ++k) {
-          const U c_h = static_cast<U>(k_output[l+k]);
+          const U c_h = static_cast<U>(k_h[l+k]);
           const U c_loss = static_cast<U>(k_dout[l+k]);
           if (!rms_only) {
             sum_loss1 += c_loss;
-            sum_loss2 += c_loss * c_h;
+            if (memory_efficient) {
+              sum_loss2 += c_loss * c_h;
+            } else {
+              sum_loss2 += c_loss * (c_h - c_mean) * c_invvar;
+            }
           } else {
-            sum_loss2 += c_loss * c_h;
+            if (memory_efficient) {
+              sum_loss2 += c_loss * c_h;
+            } else {
+              sum_loss2 += c_loss * (c_h) * c_invvar;
+            }
           }
         }
       }
       for (;  l < n2;  ++l) {
-        const U c_h = static_cast<U>(k_output[l]);
+        const U c_h = static_cast<U>(k_h[l]);
         const U c_loss = static_cast<U>(k_dout[l]);
         if (!rms_only) {
           sum_loss1 += c_loss;
-          sum_loss2 += c_loss * c_h;
+          if (memory_efficient) {
+            sum_loss2 += c_loss * c_h;
+          } else {
+            sum_loss2 += c_loss * (c_h - c_mean) * c_invvar;
+          }
         } else {
-          sum_loss2 += c_loss * c_h;
+          if (memory_efficient) {
+            sum_loss2 += c_loss * c_h;
+          } else {
+            sum_loss2 += c_loss * (c_h) * c_invvar;
+          }
         }
       }
     }
@@ -816,30 +873,46 @@ void cuComputeGradInput(
     T* k_grad_input = grad_input + i1*n2;
     if (gamma != NULL) {
       for (int l = thrx;  l < n2;  l+=numx) {
-        const U c_h = static_cast<U>(k_output[l]);
+        const U c_h = static_cast<U>(k_h[l]);
         const U c_loss = static_cast<U>(k_dout[l]);
         const U k_gamma = static_cast<U>(clamp_by_magnitude(gamma[l], eps));
         U f_grad_input = fH * c_loss * k_gamma;
         if (!rms_only) {
           const U k_beta = beta[l];
           f_grad_input -= sum_loss1;
-          f_grad_input -= (c_h - k_beta) / k_gamma * sum_loss2;
+          if (memory_efficient) {
+            f_grad_input -= (c_h - k_beta) / k_gamma * sum_loss2;
+          } else {
+            f_grad_input -= (c_h - c_mean) * c_invvar * sum_loss2;
+          }
         } else {
-          f_grad_input -= c_h / k_gamma * sum_loss2;
+          if (memory_efficient) {
+            f_grad_input -= c_h / k_gamma * sum_loss2;
+          } else {
+            f_grad_input -= c_h * c_invvar * sum_loss2;
+          }
         }
         f_grad_input *= term1;
         k_grad_input[l] = static_cast<T>(f_grad_input);
       }
     } else {
       for (int l = thrx;  l < n2;  l+=numx) {
-        const U c_h = static_cast<U>(k_output[l]);
+        const U c_h = static_cast<U>(k_h[l]);
         const U c_loss = static_cast<U>(k_dout[l]);
         U f_grad_input = fH * c_loss;
         if (!rms_only) {
           f_grad_input -= sum_loss1;
-          f_grad_input -= c_h * sum_loss2;
+          if (memory_efficient) {
+            f_grad_input -= c_h * sum_loss2;
+          } else {
+            f_grad_input -= (c_h - c_mean) * c_invvar * sum_loss2;
+          }
         } else {
-          f_grad_input -= c_h * sum_loss2;
+          if (memory_efficient) {
+            f_grad_input -= c_h * sum_loss2;
+          } else {
+            f_grad_input -= c_h * c_invvar * sum_loss2;
+          }
         }
         f_grad_input *= term1;
         k_grad_input[l] = static_cast<T>(f_grad_input);
@@ -962,8 +1035,9 @@ void cuda_rms_norm(
 template<typename T, typename U=float, typename V=T>
 void HostLayerNormGradient(
     const V* dout,
+    const U* mean,
     const U* invvar,
-    at::Tensor* output,
+    at::Tensor* input_or_output,
     int n1,
     int n2,
     const V* gamma,
@@ -971,7 +1045,8 @@ void HostLayerNormGradient(
     double epsilon,
     T* grad_input,
     V* grad_gamma,
-    V* grad_beta
+    V* grad_beta,
+    bool memory_efficient
     )
 {
     auto stream = at::cuda::getCurrentCUDAStream().stream();
@@ -987,22 +1062,25 @@ void HostLayerNormGradient(
       // note (mkozuki): I can hard code part_grad_gamma's dtype as float given that
       // the `cuda_layer_norm_gradient` doesn't support double.
       const auto part_grad_dtype =
-        (output->scalar_type() == at::ScalarType::Half || output->scalar_type() == at::ScalarType::BFloat16) ?
+        (input_or_output->scalar_type() == at::ScalarType::Half || input_or_output->scalar_type() == at::ScalarType::BFloat16) ?
         at::ScalarType::Float :
-        output->scalar_type();
-      at::Tensor part_grad_gamma = at::empty({part_size,n2}, output->options().dtype(part_grad_dtype));
+        input_or_output->scalar_type();
+      at::Tensor part_grad_gamma = at::empty({part_size,n2}, input_or_output->options().dtype(part_grad_dtype));
       at::Tensor part_grad_beta = at::empty_like(part_grad_gamma);
       cuComputePartGradGammaBeta<<<blocks2, threads2, nshared2, stream>>>(
                       dout,
-                      output->DATA_PTR<T>(),
+                      input_or_output->DATA_PTR<T>(),
                       n1,n2,
+                      mean,
+                      invvar,
                       U(epsilon),
                       gamma,
                       beta,
                       part_grad_gamma.DATA_PTR<U>(),
                       part_grad_beta.DATA_PTR<U>(),
                       epsilon,
-                      false);
+                      false,
+                      memory_efficient);
 
       const dim3 threads3(32,8,1);
       const dim3 blocks3((n2+threads2.x-1)/threads2.x,1,1);
@@ -1027,28 +1105,31 @@ void HostLayerNormGradient(
             0;
     cuComputeGradInput<<<blocks1, threads1, nshared, stream>>>(
             dout,
-            output->DATA_PTR<T>(),
+            input_or_output->DATA_PTR<T>(),
             n1,n2,
+            mean,
             invvar,
             U(epsilon),
             gamma,
             beta,
             grad_input,
             epsilon,
-            false);
+            false,
+            memory_efficient);
 }
 
 template<typename T, typename U=float, typename V=T>
 void HostRMSNormGradient(
     const V* dout,
     const U* invvar,
-    at::Tensor* output,
+    at::Tensor* input_or_output,
     int n1,
     int n2,
     const V* gamma,
     double epsilon,
     T* grad_input,
-    V* grad_gamma)
+    V* grad_gamma,
+    bool memory_efficient)
 {
     auto stream = at::cuda::getCurrentCUDAStream().stream();
 
@@ -1062,21 +1143,24 @@ void HostRMSNormGradient(
       // note (mkozuki): I can hard code part_grad_gamma's dtype as float given that
       // the `cuda_layer_norm_gradient` doesn't support double.
       const auto part_grad_dtype =
-        (output->scalar_type() == at::ScalarType::Half || output->scalar_type() == at::ScalarType::BFloat16) ?
+        (input_or_output->scalar_type() == at::ScalarType::Half || input_or_output->scalar_type() == at::ScalarType::BFloat16) ?
         at::ScalarType::Float :
-        output->scalar_type();
-      at::Tensor part_grad_gamma = at::empty({part_size,n2}, output->options().dtype(part_grad_dtype));
+        input_or_output->scalar_type();
+      at::Tensor part_grad_gamma = at::empty({part_size,n2}, input_or_output->options().dtype(part_grad_dtype));
       cuComputePartGradGammaBeta<<<blocks2, threads2, nshared2, stream>>>(
                       dout,
-                      output->DATA_PTR<T>(),
+                      input_or_output->DATA_PTR<T>(),
                       n1,n2,
+                      invvar, /* unused */
+                      invvar,
                       U(epsilon),
                       gamma,
                       gamma, /* unused */
                       part_grad_gamma.DATA_PTR<U>(),
                       part_grad_gamma.DATA_PTR<U>(), /* unused */
                       epsilon,
-                      true);
+                      true,
+                      memory_efficient);
 
       const dim3 threads3(32,8,1);
       const dim3 blocks3((n2+threads2.x-1)/threads2.x,1,1);
@@ -1101,21 +1185,24 @@ void HostRMSNormGradient(
             0;
     cuComputeGradInput<<<blocks1, threads1, nshared, stream>>>(
             dout,
-            output->DATA_PTR<T>(),
+            input_or_output->DATA_PTR<T>(),
             n1,n2,
+            invvar, /* unused */
             invvar,
             U(epsilon),
             gamma,
             gamma, /* unused */
             grad_input,
             epsilon,
-            true);
+            true,
+            memory_efficient);
 }
 
 void cuda_layer_norm_gradient(
     at::Tensor* dout,
+    at::Tensor* mean,
     at::Tensor* invvar,
-    at::Tensor* output,
+    at::Tensor* input_or_output,
     int n1,
     int n2,
     #ifdef VERSION_GE_1_1
@@ -1128,17 +1215,19 @@ void cuda_layer_norm_gradient(
     double epsilon,
     at::Tensor* grad_input,
     at::Tensor* grad_gamma,
-    at::Tensor* grad_beta)
+    at::Tensor* grad_beta,
+    bool memory_efficient)
 {
     using namespace at;
     // we can do away with `accscalar_t` as there're only three dtypes: fp32, fp16, bf16
     DISPATCH_FLOAT_HALF_AND_BFLOAT_INOUT_TYPES(
-      output->scalar_type(), gamma == NULL ? output->scalar_type() :  gamma->scalar_type(), "cuComputeGradInput",
+      input_or_output->scalar_type(), gamma == NULL ? input_or_output->scalar_type() :  gamma->scalar_type(), "cuComputeGradInput",
       using accscalar_t = at::acc_type<scalar_t_in, true>;
       HostLayerNormGradient(
         dout->DATA_PTR<scalar_t_out>(),
+        mean != NULL ? mean->DATA_PTR<accscalar_t>() : NULL,
         invvar->DATA_PTR<accscalar_t>(),
-        output,
+        input_or_output,
         n1,n2,
             // TMJ pass NULL argument for gamma, beta, grad_gamma and grad_beta
             // if gamma Tensor is NULL on input.
@@ -1147,14 +1236,15 @@ void cuda_layer_norm_gradient(
         epsilon,
         grad_input->DATA_PTR<scalar_t_in>(),
         gamma != NULL ? grad_gamma->DATA_PTR<scalar_t_out>() : NULL,
-        gamma != NULL ? grad_beta->DATA_PTR<scalar_t_out>() : NULL);
+        gamma != NULL ? grad_beta->DATA_PTR<scalar_t_out>() : NULL,
+        memory_efficient);
     )
 }
 
 void cuda_rms_norm_gradient(
     at::Tensor* dout,
     at::Tensor* invvar,
-    at::Tensor* output,
+    at::Tensor* input_or_output,
     int n1,
     int n2,
     #ifdef VERSION_GE_1_1
@@ -1165,24 +1255,26 @@ void cuda_rms_norm_gradient(
     at::Tensor* gamma,
     double epsilon,
     at::Tensor* grad_input,
-    at::Tensor* grad_gamma)
+    at::Tensor* grad_gamma,
+    bool memory_efficient)
 {
     using namespace at;
     // we can do away with `accscalar_t` as there're only three dtypes: fp32, fp16, bf16
     // DISPATCH_FLOAT_HALF_AND_BFLOAT_INOUT_TYPES(
     DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT_INOUT_TYPES(
-      output->scalar_type(), gamma == NULL ? output->scalar_type() :  gamma->scalar_type(), "cuComputeGradInputRMS",
+      input_or_output->scalar_type(), gamma == NULL ? input_or_output->scalar_type() :  gamma->scalar_type(), "cuComputeGradInputRMS",
       using accscalar_t = at::acc_type<scalar_t_in, true>;
       HostRMSNormGradient(
         dout->DATA_PTR<scalar_t_out>(),
         invvar->DATA_PTR<accscalar_t>(),
-        output,
+        input_or_output,
         n1,n2,
             // TMJ pass NULL argument for gamma, beta, grad_gamma and grad_beta
             // if gamma Tensor is NULL on input.
         gamma != NULL ? gamma->DATA_PTR<scalar_t_out>() : NULL,
         epsilon,
         grad_input->DATA_PTR<scalar_t_in>(),
-        gamma != NULL ? grad_gamma->DATA_PTR<scalar_t_out>() : NULL);
+        gamma != NULL ? grad_gamma->DATA_PTR<scalar_t_out>() : NULL,
+        memory_efficient);
     )
 }

--- a/csrc/static_switch.h
+++ b/csrc/static_switch.h
@@ -1,0 +1,25 @@
+// From
+// https://github.com/NVIDIA/DALI/blob/main/include/dali/core/static_switch.h
+
+#pragma once
+
+/// @param COND       - a boolean expression to switch by
+/// @param CONST_NAME - a name given for the constexpr bool variable.
+/// @param ...       - code to execute for true and false
+///
+/// Usage:
+/// ```
+/// BOOL_SWITCH(flag, BoolConst, [&] {
+///     some_function<BoolConst>(...);
+/// });
+/// ```
+#define BOOL_SWITCH(COND, CONST_NAME, ...)      \
+  [&] {                                         \
+    if (COND) {                                 \
+      constexpr static bool CONST_NAME = true;  \
+      return __VA_ARGS__();                     \
+    } else {                                    \
+      constexpr static bool CONST_NAME = false; \
+      return __VA_ARGS__();                     \
+    }                                           \
+  }()

--- a/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
+++ b/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
@@ -21,7 +21,7 @@ autocast_dtypes = (torch.half, torch.bfloat16) if torch.cuda.is_bf16_supported()
 class TestFusedLayerNorm(common_utils.TestCase):
 
     def _test_fused_layer_norm(
-        self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype,
+        self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient,
         fwd_thresholds=dict(rtol=None, atol=None), bwd_thresholds=dict(rtol=None, atol=None)
         ):
 
@@ -29,15 +29,19 @@ class TestFusedLayerNorm(common_utils.TestCase):
 
         if not mixed_fused:
             module_cpu_ = FusedLayerNorm(
-                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine).cpu()
+                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine, memory_efficient=memory_efficient
+            ).cpu()
             module_cuda_ = FusedLayerNorm(
-                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine).to(device="cuda", dtype=dtype)
+                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine, memory_efficient=memory_efficient
+            ).to(device="cuda", dtype=dtype)
         else:
             assert elementwise_affine
             module_cpu_ = MixedFusedLayerNorm(
-                normalized_shape=normalized_shape).cpu()
+                normalized_shape=normalized_shape, memory_efficient=memory_efficient
+            ).cpu()
             module_cuda_ = MixedFusedLayerNorm(
-                normalized_shape=normalized_shape).to(device="cuda", dtype=dtype)
+                normalized_shape=normalized_shape, memory_efficient=memory_efficient
+            ).to(device="cuda", dtype=dtype)
 
         torch.cuda.manual_seed(42)
         if contiguous:
@@ -70,7 +74,7 @@ class TestFusedLayerNorm(common_utils.TestCase):
             input_.grad.to(device="cuda", dtype=dtype), input_cuda_.grad, **bwd_thresholds)
 
     def _test_fused_rms_norm(
-        self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype,
+        self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient,
         fwd_thresholds=dict(rtol=None, atol=None), bwd_thresholds=dict(rtol=None, atol=None)
         ):
 
@@ -78,9 +82,11 @@ class TestFusedLayerNorm(common_utils.TestCase):
 
         if not mixed_fused:
             module_cpu_ = FusedRMSNorm(
-                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine).cpu()
+                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine, memory_efficient=memory_efficient
+            ).cpu()
             module_cuda_ = FusedRMSNorm(
-                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine).to(device="cuda", dtype=dtype)
+                normalized_shape=normalized_shape, elementwise_affine=elementwise_affine, memory_efficient=memory_efficient
+            ).to(device="cuda", dtype=dtype)
         else:
             assert elementwise_affine
             module_cpu_ = MixedFusedRMSNorm(
@@ -123,87 +129,87 @@ class TestFusedLayerNorm(common_utils.TestCase):
 
     # layer norm tests
     @common_utils.parametrize(
-        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
-        list(product((16, 65536), (True, False), (False,), (False,), (torch.float,)))
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16, 65536), (True, False), (False,), (False,), (torch.float,), (True, False)))
     )
-    def test_layer_norm_regular(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
-        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype)
+    def test_layer_norm_regular(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient)
     
     @common_utils.parametrize(
-        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
-        list(product((16, 65536), (True, False), (True,), (False,), (torch.float,)))
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16, 65536), (True, False), (True,), (False,), (torch.float,), (True, False)))
     )
-    def test_layer_norm_elemwise(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
-        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype)
+    def test_layer_norm_elemwise(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient)
 
     @common_utils.parametrize(
-        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
-        list(product((16, 65536), (True, False), (True,), (True,), (torch.float,)))
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16, 65536), (True, False), (True,), (True,), (torch.float,), (True, False)))
     )
-    def test_layer_norm_mixed(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
-        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype)
+    def test_layer_norm_mixed(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient)
     
     @common_utils.parametrize(
-        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
-        list(product((16,), (True, False), (True,), (False,), (torch.half,)))
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16,), (True, False), (True,), (False,), (torch.half,), (True, False)))
     )
-    def test_layer_norm_half(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
-        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype,
+    def test_layer_norm_half(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient,
                                 fwd_thresholds=dict(rtol=1e-3, atol=1e-3), bwd_thresholds=dict(rtol=1e-3, atol=1e-3))
     
     @common_utils.parametrize(
-        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
-        list(product((16,), (True, False), (True,), (False,), (torch.bfloat16,)))
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16,), (True, False), (True,), (False,), (torch.bfloat16,), (True, False)))
     )
-    def test_layer_norm_bfloat16(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
-        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, 
+    def test_layer_norm_bfloat16(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_layer_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient, 
                                 fwd_thresholds=dict(rtol=1.6e-2, atol=3e-4), bwd_thresholds=dict(rtol=1.6e-2, atol=3e-3))
 
     # rms norm tests
     @common_utils.parametrize(
-        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
-        list(product((16, 65536), (True, False), (False,), (False,), (torch.float,)))
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16, 65536), (True, False), (False,), (False,), (torch.float,), (True, False)))
     )
-    def test_rms_norm_regular(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
-        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype)
+    def test_rms_norm_regular(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient)
 
     @common_utils.parametrize(
-        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
-        list(product((16, 65536), (True, False), (True,), (False,), (torch.float,)))
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16, 65536), (True, False), (True,), (False,), (torch.float,), (True, False)))
     )
-    def test_rms_norm_elemwise(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
-        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype,
+    def test_rms_norm_elemwise(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient,
                                 bwd_thresholds=dict(rtol=2e-3, atol=2e-4))
 
     @common_utils.parametrize(
-        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
-        list(product((16, 65536), (True, False), (True,), (True,), (torch.float,)))
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16, 65536), (True, False), (True,), (True,), (torch.float,), (True, False)))
     )
-    def test_rms_norm_mixed(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
-        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype,
+    def test_rms_norm_mixed(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient,
                                 bwd_thresholds=dict(rtol=2e-3, atol=2e-4))
     
     @common_utils.parametrize(
-        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
-        list(product((16,), (True, False), (True,), (False,), (torch.half,)))
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16,), (True, False), (True,), (False,), (torch.half,), (True, False)))
     )
-    def test_rms_norm_half(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
-        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype,
+    def test_rms_norm_half(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient,
                                 bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3))
     
     @common_utils.parametrize(
-        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype",
-        list(product((16,), (True, False), (True,), (False,), (torch.bfloat16,)))
+        "batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient",
+        list(product((16,), (True, False), (True,), (False,), (torch.bfloat16,), (True, False)))
     )
-    def test_rms_norm_bfloat16(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype):
-        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, 
+    def test_rms_norm_bfloat16(self, batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient):
+        self._test_fused_rms_norm(batch_size, contiguous, elementwise_affine, mixed_fused, dtype, memory_efficient, 
                                 fwd_thresholds=dict(rtol=1.6e-2, atol=3e-4), bwd_thresholds=dict(rtol=1.6e-2, atol=3e-2))
 
     @common_utils.parametrize(
-        "dtype, elementwise_affine",
-        list(product(autocast_dtypes, (True, False)))
+        "dtype, elementwise_affine, memory_efficient",
+        list(product(autocast_dtypes, (True, False), (True, False)))
     )
-    def test_autocast_fused_layer_norm(self, dtype, elementwise_affine):
+    def test_autocast_fused_layer_norm(self, dtype, elementwise_affine, memory_efficient):
         bf16_fwd_thresholds = dict(rtol=1.6e-2, atol=3e-4)
         bf16_bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
         batch_size = 16
@@ -212,7 +218,7 @@ class TestFusedLayerNorm(common_utils.TestCase):
             normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
         ).to(device="cuda", dtype=dtype)
         fused = FusedLayerNorm(
-            normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
+            normalized_shape=normalized_shape, elementwise_affine=elementwise_affine, memory_efficient=memory_efficient
         ).cuda()
         native_x, fused_x = _prep_inputs(batch_size, normalized_shape, dtype)
 
@@ -233,19 +239,19 @@ class TestFusedLayerNorm(common_utils.TestCase):
         tols = {'rtol': None, 'atol': None} if dtype == torch.half else bf16_bwd_thresholds
         torch.testing.assert_close(native_x.grad, fused_x.grad, **tols, check_dtype=False)
     @common_utils.parametrize(
-        "dtype, elementwise_affine",
-        list(product(autocast_dtypes, (True, False)))
+        "dtype, elementwise_affine, memory_efficient",
+        list(product(autocast_dtypes, (True, False), (True, False)))
     )
-    def test_autocast_fused_rms_norm(self, dtype, elementwise_affine):
+    def test_autocast_fused_rms_norm(self, dtype, elementwise_affine, memory_efficient):
         bf16_fwd_thresholds = dict(rtol=1.6e-2, atol=3e-4)
         bf16_bwd_thresholds = dict(rtol=1.6e-2, atol=3e-3)
         batch_size = 16
         normalized_shape = [32, 16]
         native = FusedRMSNorm(
-            normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
+            normalized_shape=normalized_shape, elementwise_affine=elementwise_affine, memory_efficient=memory_efficient, 
         ).to(dtype=dtype)
         fused = FusedRMSNorm(
-            normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
+            normalized_shape=normalized_shape, elementwise_affine=elementwise_affine, memory_efficient=memory_efficient, 
         ).cuda()
         native_x, fused_x = _prep_inputs(batch_size, normalized_shape, dtype)
 

--- a/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
+++ b/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
@@ -236,7 +236,12 @@ class TestFusedLayerNorm(common_utils.TestCase):
         expected.backward(g_native)
         actual.backward(g_fused)
 
-        tols = {'rtol': None, 'atol': None} if dtype == torch.half else bf16_bwd_thresholds
+        if dtype != torch.half:
+            tols = bf16_bwd_thresholds
+        elif memory_efficient:
+            tols = {'rtol': 1e-3, 'atol': 1e-4}
+        else:
+            tols = {'rtol': None, 'atol': None}
         torch.testing.assert_close(native_x.grad, fused_x.grad, **tols, check_dtype=False)
     @common_utils.parametrize(
         "dtype, elementwise_affine, memory_efficient",


### PR DESCRIPTION
Hi,

# Content/motivation
This modifies the fused layernorm/rmsnorm implmentation s.t. the output tensor is saved and the input is supposedly freed. The motivation comes from the observation that the output is going to be saved somewhere anyway. For example, in pre-norm Transformers (GPT, Palm, T5, and many others), the normalization is directly followed by a linear projection either in attention or in mlp.  In post-norm models, the output is additionally used in residual connection directly. However, in both scenarios, the input of the normalization is left unused, making its original usage here pretty redundant as we can save the output tensor that is going to be saved anyway.

# Effect
We observe a substantial reduction in memory usage when training large transformer models: a 80GB-run on one A100 now only requires 70GB memory, which is 1/8 of a reduction in total memory cost. We use a configuration where fewer normalizations are applied and the benefits will be more pronounced in canonical models.

# Notes on numerical precision
Since we save the output instead of the input tensor, the _normalied_ tensor $\hat{x}$ needed in the backward is recomputed from output, i.e., $\hat{x}=(y-\beta)/\gamma$ instead of $\hat{x}=\frac{x-E(x)}{\sqrt{VAR(x)-E(x)}}$. As a result we are seeing numerical differences between the current implementation and the proposed change. However, note that the reduction part of the computation happens in the forward pass s.t. we would not have any stability issue whatsoever (we also clamp by magnitude of $\gamma$ for division).

Currently we are failing at two test runs due to numerical discrepancies when using `float16`:

```bash
======================================================================
FAIL: test_autocast_fused_layer_norm_float16_elementwise_affine_False_cuda_float16 (__main__.TestFusedLayerNormCUDA.test_autocast_fused_layer_norm_float16_elementwise_affine_False_cuda_float16)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rui/anaconda3/envs/layer-norm/lib/python3.11/site-packages/torch/testing/_internal/common_utils.py", line 2081, in wrapper
    method(*args, **kwargs)
  File "/home/rui/anaconda3/envs/layer-norm/lib/python3.11/site-packages/torch/testing/_internal/common_device_type.py", line 401, in instantiated_test
    result = test(self, **param_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rui/opensource/apex/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py", line 234, in test_autocast_fused_layer_norm
    torch.testing.assert_close(native_x.grad, fused_x.grad, **tols, check_dtype=False)
  File "/home/rui/anaconda3/envs/layer-norm/lib/python3.11/site-packages/torch/testing/_comparison.py", line 1511, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not close!

Mismatched elements: 20 / 8192 (0.2%)
Greatest absolute difference: 4.57763671875e-05 at index (1, 21, 12) (up to 1e-05 allowed)
Greatest relative difference: 0.01692047377326565 at index (7, 25, 8) (up to 0.001 allowed)

======================================================================
FAIL: test_autocast_fused_layer_norm_float16_elementwise_affine_True_cuda_float16 (__main__.TestFusedLayerNormCUDA.test_autocast_fused_layer_norm_float16_elementwise_affine_True_cuda_float16)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rui/anaconda3/envs/layer-norm/lib/python3.11/site-packages/torch/testing/_internal/common_utils.py", line 2081, in wrapper
    method(*args, **kwargs)
  File "/home/rui/anaconda3/envs/layer-norm/lib/python3.11/site-packages/torch/testing/_internal/common_device_type.py", line 401, in instantiated_test
    result = test(self, **param_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rui/opensource/apex/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py", line 234, in test_autocast_fused_layer_norm
    torch.testing.assert_close(native_x.grad, fused_x.grad, **tols, check_dtype=False)
  File "/home/rui/anaconda3/envs/layer-norm/lib/python3.11/site-packages/torch/testing/_comparison.py", line 1511, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: Tensor-likes are not close!

Mismatched elements: 20 / 8192 (0.2%)
Greatest absolute difference: 4.57763671875e-05 at index (1, 21, 12) (up to 1e-05 allowed)
Greatest relative difference: 0.01692047377326565 at index (7, 25, 8) (up to 0.001 allowed)
```