### PR TITLE
Return distributed optimizer checkpoint on all ranks

### DIFF
--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -2199,12 +2199,13 @@ class DistributedFusedAdam(torch.optim.Optimizer):
     ) -> Optional[dict]:
         """Get dictionary containing optimizer state
 
-        Gathers optimizer state on the process group's root rank and
-        returns None on non-root ranks.
+        All ranks in the process group must call this function since
+        it performs communication. The same optimizer state is
+        returned on all ranks.
 
         Arguments:
-            state_dict_format (optional): Tag for custom or deprecated
-                state dict format.
+            state_dict_format (int, optional): Tag for custom or
+                deprecated state dict format.
             gather_on_root (bool, optional): Option for deprecated v1
                 format.
 
@@ -2398,8 +2399,9 @@ class DistributedFusedAdam(torch.optim.Optimizer):
     def _state_dict_v2(self) -> Optional[dict]:
         """Get dictionary containing optimizer state (default v2 format)
 
-        Gathers optimizer state on the process group's root rank and
-        returns None on non-root ranks.
+        All ranks in the process group must call this function since
+        it performs communication. The same optimizer state is
+        returned on all ranks.
 
         """
 


### PR DESCRIPTION
This PR addresses an issue introduced in the NeMo distributed checkpoint format (see https://github.com/NVIDIA/NeMo/pull/7116 and https://github.com/NVIDIA/NeMo/pull/7281). When we load a distributed checkpoint, we first create a state dict, replace its values with checkpoint data, and then load the state dict. The current distributed optimizer state dict function gathers all the data on rank 0 and returns `None`s on other ranks, so we were getting errors on non-root ranks. This PR changes the state dict behavior so it all-gathers the data and returns identical state dicts on all ranks.