### PR TITLE
[contrib.xentropy] bfloat16 support

### DIFF
--- a/apex/contrib/csrc/xentropy/interface.cpp
+++ b/apex/contrib/csrc/xentropy/interface.cpp
@@ -1,5 +1,7 @@
 #include <torch/extension.h>
 
+#include <string>
+
 // CUDA forward declarations
 
 std::vector<at::Tensor> softmax_xentropy_cuda(
@@ -49,4 +51,13 @@ at::Tensor softmax_xentropy_backward(
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("forward", &softmax_xentropy_forward, "Softmax cross entropy loss with label smoothing forward (CUDA)");
     m.def("backward", &softmax_xentropy_backward, "Softmax cross entropy loss with label smoothing backward (CUDA)");
+    // ref: https://pybind11.readthedocs.io/en/stable/basics.html#exporting-variables
+    py::object version = py::cast(
+#ifdef XENTROPY_VER
+        XENTROPY_VER
+#else
+        std::string{}
+#endif
+        );
+    m.attr("__version__") = version;
 }

--- a/apex/contrib/csrc/xentropy/xentropy_kernel.cu
+++ b/apex/contrib/csrc/xentropy/xentropy_kernel.cu
@@ -605,7 +605,7 @@ std::vector<Tensor> host_softmax_xentropy(
   dim3 grid(outer_size);
 
   using namespace at;
-  DISPATCH_FLOAT_AND_HALF(input.scalar_type(), 0, "host_softmax_xentropy",
+  DISPATCH_FLOAT_HALF_AND_BFLOAT(input.scalar_type(), 0, "host_softmax_xentropy",
     using accscalar_t = at::acc_type<scalar_t_0, true>;
     const int ILP = sizeof(float4)/sizeof(scalar_t_0);
     dim3 block = SoftMax_getBlockSize(ILP, dim_size);
@@ -673,7 +673,7 @@ Tensor host_softmax_xentropy_backward(
 
   dim3 grid(outer_size);
 
-  DISPATCH_FLOAT_AND_HALF(gI.scalar_type(), 0, "host_softmax_xentropy_backward",
+  DISPATCH_FLOAT_HALF_AND_BFLOAT(gI.scalar_type(), 0, "host_softmax_xentropy_backward",
     using accscalar_t = acc_type<scalar_t_0, true>;
     const int ILP = sizeof(float4)/sizeof(scalar_t_0);
     dim3 block = SoftMax_getBlockSize(ILP, dim_size);

--- a/apex/contrib/test/xentropy/test_label_smoothing.py
+++ b/apex/contrib/test/xentropy/test_label_smoothing.py
@@ -95,8 +95,6 @@ class LabelSmoothingTest(unittest.TestCase):
             self.print_max_diff_elem(ref_grad, val_grad)
             torch.testing.assert_close(val_loss, ref_loss)
             torch.testing.assert_close(val_grad, ref_grad)
-            # self.assertTrue(torch.allclose(ref_loss, val_loss, atol=1e-5, rtol=1e-5))
-            # self.assertTrue(torch.allclose(ref_grad, val_grad, atol=1e-5, rtol=1e-5))
 
     def test_label_smoothing_function_fp16(self):
         self._test_label_smoothing_function(torch.half)

--- a/apex/contrib/test/xentropy/test_label_smoothing.py
+++ b/apex/contrib/test/xentropy/test_label_smoothing.py
@@ -45,8 +45,8 @@ class LabelSmoothingTest(unittest.TestCase):
         # Set pytorch print precision
         torch.set_printoptions(precision=10)
 
-    def gen_test_inputs(self, N, T, H, smoothing, padding_idx):
-        logits = torch.randn((N*T, H), dtype=torch.half, device='cuda',
+    def gen_test_inputs(self, N, T, H, smoothing, padding_idx, dtype=torch.half):
+        logits = torch.randn((N*T, H), dtype=dtype, device='cuda',
             requires_grad=True)
         labels = torch.randint(0, H, [N*T], device='cuda')
         for i in random.sample(range(N*T), N*T//6):
@@ -62,7 +62,7 @@ class LabelSmoothingTest(unittest.TestCase):
         print("Max atol idx: {}, diff: {:.6f}, ref: {:.6f}, tst: {:.6f}".format(
             idx, diff, ref[idx], tst[idx]))
 
-    def test_label_smoothing_function(self):
+    def _test_label_smoothing_function(self, dtype):
         # Set label smoothing configuration
         smoothing, padding_idx = 0.1, 0
         N, T, H = 128, 74, 32320
@@ -93,8 +93,16 @@ class LabelSmoothingTest(unittest.TestCase):
 
             # Validate
             self.print_max_diff_elem(ref_grad, val_grad)
-            self.assertTrue(torch.allclose(ref_loss, val_loss, atol=1e-5, rtol=1e-5))
-            self.assertTrue(torch.allclose(ref_grad, val_grad, atol=1e-5, rtol=1e-5))
+            torch.testing.assert_close(val_loss, ref_loss)
+            torch.testing.assert_close(val_grad, ref_grad)
+            # self.assertTrue(torch.allclose(ref_loss, val_loss, atol=1e-5, rtol=1e-5))
+            # self.assertTrue(torch.allclose(ref_grad, val_grad, atol=1e-5, rtol=1e-5))
+
+    def test_label_smoothing_function_fp16(self):
+        self._test_label_smoothing_function(torch.half)
+
+    def test_label_smoothing_function_bf16(self):
+        self._test_label_smoothing_function(torch.bfloat16)
 
     def test_label_smoothing_perf(self):
         # Set label smoothing configuration
@@ -131,6 +139,6 @@ class LabelSmoothingTest(unittest.TestCase):
         print("Opt time {:.2f} s elapsed for {} iterations, norm {:.4f}".format(
             time.time() - ts, iters, logits.grad.norm()))
 
+
 if __name__ == '__main__':
     unittest.main()
-

--- a/setup.py
+++ b/setup.py
@@ -405,15 +405,18 @@ if "--bnp" in sys.argv:
     )
 
 if "--xentropy" in sys.argv:
+    from datetime import datetime
     sys.argv.remove("--xentropy")
     raise_if_cuda_home_none("--xentropy")
+    xentropy_ver = datetime.today().strftime("%y.%m.%d")
+    print(f"`--xentropy` setting version of {xentropy_ver}")
     ext_modules.append(
         CUDAExtension(
             name="xentropy_cuda",
             sources=["apex/contrib/csrc/xentropy/interface.cpp", "apex/contrib/csrc/xentropy/xentropy_kernel.cu"],
             include_dirs=[os.path.join(this_dir, "csrc")],
             extra_compile_args={
-                "cxx": ["-O3"] + version_dependent_macros,
+                "cxx": ["-O3"] + version_dependent_macros + [f'-DXENTROPY_VER="{xentropy_ver}"'],
                 "nvcc": ["-O3"] + version_dependent_macros,
             },
         )


### PR DESCRIPTION
`xentropy.__version__` returns `YY.MM.DD` based off of when it's compiled