### PR TITLE
Cleanup usage of `self.assertTrue(torch.allclose(...`

### DIFF
--- a/apex/contrib/test/fmha/test_fmha.py
+++ b/apex/contrib/test/fmha/test_fmha.py
@@ -96,7 +96,7 @@ class TestFMHA(unittest.TestCase):
         ctx = ctx.view(b,s,h,d)
 
         ctx_ref = py_mha(qkv, amask, b,s,h,d)
-        self.assertTrue(torch.allclose(ctx_ref.float(), ctx.float(), atol=1e-3))
+        torch.testing.assert_close(ctx_ref.float(), ctx.float(), atol=1e-3)
 
         labels = torch.randn_like(ctx_ref)
         diff = ctx_ref - labels
@@ -114,7 +114,7 @@ class TestFMHA(unittest.TestCase):
 
         dqkv2 = dqkv2.permute(0,2,1,3).view(b,s, h,3,d)
 
-        self.assertTrue(torch.allclose(qkv.grad.float(), dqkv2.float(), atol=1e-3))
+        torch.testing.assert_close(qkv.grad.float(), dqkv2.float(), atol=1e-3)
 
     def test_128(self):
         self.run_test(128, 32, False)

--- a/apex/contrib/test/transducer/test_transducer_joint.py
+++ b/apex/contrib/test/transducer/test_transducer_joint.py
@@ -118,9 +118,9 @@ class TransducerJointTest(unittest.TestCase):
         f_grad_tst = self.f_tst.grad
         g_grad_tst = self.g_tst.grad
 
-        self.assertTrue(torch.allclose(h_ref, h_tst, atol=1e-5, rtol=1e-5))
-        self.assertTrue(torch.allclose(f_grad_ref, f_grad_tst, atol=1e-5, rtol=1e-5))
-        self.assertTrue(torch.allclose(g_grad_ref, g_grad_tst, atol=1e-4, rtol=1e-4))
+        torch.testing.assert_close(h_ref, h_tst, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(f_grad_ref, f_grad_tst, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(g_grad_ref, g_grad_tst, atol=1e-4, rtol=1e-4)
 
     def test_transducer_joint(self):
         self.run_transducer_joint(for_vector_kernel=True, pack_output=True, relu=False, dropout=False)

--- a/apex/contrib/test/transducer/test_transducer_loss.py
+++ b/apex/contrib/test/transducer/test_transducer_loss.py
@@ -99,40 +99,40 @@ class TransducerLossTest(unittest.TestCase):
                                                         fuse_softmax_backward=False,
                                                         packed_input=False,
                                                         for_vector_kernel=False)
-        self.assertTrue(torch.allclose(self.loss_ref, loss_tst, atol=1e-5, rtol=1e-5))
-        self.assertTrue(torch.allclose(self.grad_ref, grad_tst, atol=1e-5, rtol=1e-5))
+        torch.testing.assert_close(self.loss_ref, loss_tst, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(self.grad_ref, grad_tst, atol=1e-5, rtol=1e-5)
 
     def test_transducer_loss_fp16(self):
         loss_tst, grad_tst = self.run_transducer_loss(  scalar_t=torch.float16,
                                                         fuse_softmax_backward=False,
                                                         packed_input=False,
                                                         for_vector_kernel=False)
-        self.assertTrue(torch.allclose(self.loss_ref, loss_tst, atol=1e-5, rtol=1e-5))
-        self.assertTrue(torch.allclose(self.grad_ref, grad_tst, atol=1e-4, rtol=1e-3))
+        torch.testing.assert_close(self.loss_ref, loss_tst, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(self.grad_ref, grad_tst, atol=1e-4, rtol=1e-3)
 
     def test_transducer_loss_fp16_backward_fusion(self):
         loss_tst, grad_tst = self.run_transducer_loss(  scalar_t=torch.float16,
                                                         fuse_softmax_backward=True,
                                                         packed_input=False,
                                                         for_vector_kernel=False)
-        self.assertTrue(torch.allclose(self.loss_ref, loss_tst, atol=1e-5, rtol=1e-5))
-        self.assertTrue(torch.allclose(self.grad_ref, grad_tst, atol=1e-4, rtol=1e-3))
+        torch.testing.assert_close(self.loss_ref, loss_tst, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(self.grad_ref, grad_tst, atol=1e-4, rtol=1e-3)
 
     def test_transducer_loss_fp16_backward_fusion_packed(self):
         loss_tst, grad_tst = self.run_transducer_loss(  scalar_t=torch.float16,
                                                         fuse_softmax_backward=True,
                                                         packed_input=True,
                                                         for_vector_kernel=False)
-        self.assertTrue(torch.allclose(self.loss_ref, loss_tst, atol=1e-5, rtol=1e-5))
-        self.assertTrue(torch.allclose(self.grad_ref, grad_tst, atol=1e-4, rtol=1e-3))
+        torch.testing.assert_close(self.loss_ref, loss_tst, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(self.grad_ref, grad_tst, atol=1e-4, rtol=1e-3)
 
     def test_transducer_loss_fp16_backward_fusion_packed_vec(self):
         loss_tst, grad_tst = self.run_transducer_loss(  scalar_t=torch.float16,
                                                         fuse_softmax_backward=True,
                                                         packed_input=True,
                                                         for_vector_kernel=True)
-        self.assertTrue(torch.allclose(self.loss_ref, loss_tst, atol=1e-5, rtol=1e-5))
-        self.assertTrue(torch.allclose(self.grad_ref, grad_tst, atol=1e-4, rtol=1e-3))
+        torch.testing.assert_close(self.loss_ref, loss_tst, atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(self.grad_ref, grad_tst, atol=1e-4, rtol=1e-3)
 
 
 if __name__ == '__main__':

--- a/tests/L0/run_amp/test_add_param_group.py
+++ b/tests/L0/run_amp/test_add_param_group.py
@@ -139,8 +139,8 @@ class TestAddParamGroup(unittest.TestCase):
                                  [param.data.clone() for param in model1.parameters()]
 
                   for reference, final in zip(reference_params, final_params):
-                      self.assertTrue(torch.allclose(reference.to(final.dtype), final),
-                                      "opt_level = {}, how_to_zero = {}, zero_before_add = {}".format(
+                      torch.testing.assert_close(reference.to(final.dtype), final,
+                                      msg="opt_level = {}, how_to_zero = {}, zero_before_add = {}".format(
                                       opt_level, how_to_zero, zero_before_add))
 
 

--- a/tests/L0/run_amp/test_cache.py
+++ b/tests/L0/run_amp/test_cache.py
@@ -92,9 +92,9 @@ class TestCache(unittest.TestCase):
             # Currently there's no difference in the allclose calls, so no need for branching,
             # but I'm keeping this in case we want different tolerances for fp16 and fp32 checks. 
             if model.weight.grad.type() == "torch.cuda.HalfTensor":
-                self.assertTrue(torch.allclose(model.weight.grad.float(), reference_grad))
+                torch.testing.assert_close(model.weight.grad.float(), reference_grad)
             elif model.weight.grad.type() == "torch.cuda.FloatTensor":
-                self.assertTrue(torch.allclose(model.weight.grad.float(), reference_grad))
+                torch.testing.assert_close(model.weight.grad.float(), reference_grad)
             else:
                 raise RuntimeError("model.weight.grad.type = {}".format(model.weight.grad.type()))
 

--- a/tests/L0/run_amp/test_fused_sgd.py
+++ b/tests/L0/run_amp/test_fused_sgd.py
@@ -168,8 +168,8 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                                     if opt_level == "O2" and not materialize_master_grads:
                                         continue
                                     else:
-                                        self.assertTrue(torch.allclose(param.grad.float(), reference_grad.float()),
-                                                        "opt_level {} i {} inject_inf {} which_backward {} inject_inf_loc {} use_multiple_loss_scalers {}".format(opt_level, i, inject_inf, which_backward, inject_inf_loc, use_multiple_loss_scalers))
+                                        torch.testing.assert_close(param.grad.float(), reference_grad.float(),
+                                                        msg="opt_level {} i {} inject_inf {} which_backward {} inject_inf_loc {} use_multiple_loss_scalers {}".format(opt_level, i, inject_inf, which_backward, inject_inf_loc, use_multiple_loss_scalers))
                                 unskipped += 1
                             optimizer.step()
 
@@ -178,8 +178,8 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                                 model_params,
                                 amp.master_params(optimizer),
                                 final_params):
-                            self.assertTrue(torch.allclose(model, reference))
-                            self.assertTrue(torch.allclose(model, master.to(model.dtype)))
+                            torch.testing.assert_close(model, reference)
+                            torch.testing.assert_close(model, master.to(model.dtype))
 
                         if opt_level == "O1":
                             _amp_state.handle._deactivate()
@@ -326,8 +326,8 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                                       if opt_level == "O2" and not materialize_master_grads:
                                           continue
                                       else:
-                                          self.assertTrue(torch.allclose(param.grad.float(), reference_grad.float()),
-                                          "opt_level {} i {} inject_inf {} which_backward {} inject_inf_loc {} which_model {} use_multiple_loss_scalers {}".format(opt_level, i, inject_inf, which_backward, inject_inf_loc, which_model, use_multiple_loss_scalers))
+                                          torch.testing.assert_close(param.grad.float(), reference_grad.float(),
+                                          msg="opt_level {} i {} inject_inf {} which_backward {} inject_inf_loc {} which_model {} use_multiple_loss_scalers {}".format(opt_level, i, inject_inf, which_backward, inject_inf_loc, which_model, use_multiple_loss_scalers))
                                   unskipped += 1
 
                               optimizer.step()
@@ -339,8 +339,8 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                                   model_params,
                                   amp.master_params(optimizer),
                                   final_params):
-                              self.assertTrue(torch.allclose(model, reference))
-                              self.assertTrue(torch.allclose(model, master.to(model.dtype)))
+                              torch.testing.assert_close(model, reference)
+                              torch.testing.assert_close(model, master.to(model.dtype))
 
                           if opt_level == "O1":
                               _amp_state.handle._deactivate()
@@ -521,7 +521,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                                     if opt_level == "O2" and not materialize_master_grads:
                                         continue
                                     else:
-                                        self.assertTrue(torch.allclose(param.grad.float(), reference_grad.float()))
+                                        torch.testing.assert_close(param.grad.float(), reference_grad.float())
                                 unskipped += 1
 
                             optimizer0.step()
@@ -534,8 +534,8 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                                 model_params,
                                 master_params,
                                 final_params[what_got_skipped(inject_inf, which_backward)]):
-                            self.assertTrue(torch.allclose(model, reference))
-                            self.assertTrue(torch.allclose(model, master.to(model.dtype)))
+                            torch.testing.assert_close(model, reference)
+                            torch.testing.assert_close(model, master.to(model.dtype))
 
                         if opt_level == "O1":
                             _amp_state.handle._deactivate()
@@ -766,7 +766,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                                       if opt_level == "O2" and not materialize_master_grads:
                                           continue
                                       else:
-                                          self.assertTrue(torch.allclose(param.grad.float(), reference_grad.float()))
+                                          torch.testing.assert_close(param.grad.float(), reference_grad.float())
                                   unskipped += 1
 
                               optimizer0.step()
@@ -784,8 +784,8 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                                   model_params,
                                   master_params,
                                   final_params[what_got_skipped(inject_inf, which_backward, which_model)]):
-                              self.assertTrue(torch.allclose(model, reference))
-                              self.assertTrue(torch.allclose(model, master.to(model.dtype)))
+                              torch.testing.assert_close(model, reference)
+                              torch.testing.assert_close(model, master.to(model.dtype))
 
                           if opt_level == "O1":
                               _amp_state.handle._deactivate()

--- a/tests/L0/run_amp/test_multi_tensor_l2norm.py
+++ b/tests/L0/run_amp/test_multi_tensor_l2norm.py
@@ -50,9 +50,9 @@ class TestMultiTensorL2Norm(unittest.TestCase):
 
         reference = torch.cuda.FloatTensor((sizea + sizeb)*repeat_tensors).fill_(self.val).norm()
 
-        self.assertTrue(torch.allclose(norm, reference))
+        torch.testing.assert_close(norm, reference.broadcast_to(norm.shape))
         if per_tensor:
-          self.assertTrue(torch.allclose(norm_per_tensor, normab))
+          torch.testing.assert_close(norm_per_tensor, normab.broadcast_to(norm_per_tensor.shape))
         self.assertTrue(self.overflow_buf.item() == 0)
 
     @unittest.skipIf(disabled, "amp_C is unavailable")

--- a/tests/L0/run_amp/test_multi_tensor_unscale_l2norm.py
+++ b/tests/L0/run_amp/test_multi_tensor_unscale_l2norm.py
@@ -52,9 +52,9 @@ class TestMultiTensorUnscaleL2Norm(unittest.TestCase):
 
         reference = torch.full([(sizea + sizeb)*repeat_tensors], self.val * self.inv_scale, dtype=torch.float32, device='cuda').norm()
 
-        self.assertTrue(torch.allclose(norm, reference))
+        torch.testing.assert_close(norm, reference)
         if per_tensor:
-            self.assertTrue(torch.allclose(norm_per_tensor, normab))
+            torch.testing.assert_close(norm_per_tensor, normab)
         self.assertTrue(self.overflow_buf.item() == 0)
 
     @unittest.skipIf(disabled, "amp_C is unavailable")

--- a/tests/L0/run_amp/test_multiple_models_optimizers_losses.py
+++ b/tests/L0/run_amp/test_multiple_models_optimizers_losses.py
@@ -152,7 +152,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                           if i != inject_inf:
                               for param, reference_grad in zip(amp.master_params(optimizer),
                                                                reference_grads[unskipped]):
-                                  self.assertTrue(torch.allclose(param.grad.float(), reference_grad.float()))
+                                  torch.testing.assert_close(param.grad.float(), reference_grad.float())
                               unskipped += 1
                           optimizer.step()
 
@@ -161,8 +161,8 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                               model_params,
                               amp.master_params(optimizer),
                               final_params):
-                          self.assertTrue(torch.allclose(model, reference))
-                          self.assertTrue(torch.allclose(model, master.to(model.dtype)))
+                          torch.testing.assert_close(model, reference)
+                          torch.testing.assert_close(model, master.to(model.dtype))
 
                       if opt_level == "O1":
                           _amp_state.handle._deactivate()
@@ -305,7 +305,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                             if i != inject_inf:
                                 for param, reference_grad in zip(amp.master_params(optimizer),
                                                                  reference_grads[unskipped]):
-                                    self.assertTrue(torch.allclose(param.grad.float(), reference_grad.float()))
+                                    torch.testing.assert_close(param.grad.float(), reference_grad.float())
                                 unskipped += 1
 
                             optimizer.step()
@@ -317,8 +317,8 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                                 model_params,
                                 amp.master_params(optimizer),
                                 final_params):
-                            self.assertTrue(torch.allclose(model, reference))
-                            self.assertTrue(torch.allclose(model, master.to(model.dtype)))
+                            torch.testing.assert_close(model, reference)
+                            torch.testing.assert_close(model, master.to(model.dtype))
 
                         if opt_level == "O1":
                             _amp_state.handle._deactivate()
@@ -494,7 +494,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                                               list(amp.master_params(optimizer1))
                               for param, reference_grad in zip(master_params,
                                       reference_grads[what_got_skipped(inject_inf, which_backward)][unskipped]):
-                                  self.assertTrue(torch.allclose(param.grad.float(), reference_grad.float()))
+                                  torch.testing.assert_close(param.grad.float(), reference_grad.float())
                               unskipped += 1
 
                           optimizer0.step()
@@ -507,8 +507,8 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                               model_params,
                               master_params,
                               final_params[what_got_skipped(inject_inf, which_backward)]):
-                          self.assertTrue(torch.allclose(model, reference))
-                          self.assertTrue(torch.allclose(model, master.to(model.dtype)))
+                          torch.testing.assert_close(model, reference)
+                          torch.testing.assert_close(model, master.to(model.dtype))
 
                       if opt_level == "O1":
                           _amp_state.handle._deactivate()
@@ -734,7 +734,7 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                                 for param, reference_grad in zip(master_params,
                                       reference_grads[what_got_skipped(inject_inf,
                                           which_backward, which_model)][unskipped]):
-                                    self.assertTrue(torch.allclose(param.grad.float(), reference_grad.float()))
+                                    torch.testing.assert_close(param.grad.float(), reference_grad.float())
                                 unskipped += 1
 
                             optimizer0.step()
@@ -752,8 +752,8 @@ class TestMultipleModelsOptimizersLosses(unittest.TestCase):
                                 model_params,
                                 master_params,
                                 final_params[what_got_skipped(inject_inf, which_backward, which_model)]):
-                            self.assertTrue(torch.allclose(model, reference))
-                            self.assertTrue(torch.allclose(model, master.to(model.dtype)))
+                            torch.testing.assert_close(model, reference)
+                            torch.testing.assert_close(model, master.to(model.dtype))
 
                         if opt_level == "O1":
                             _amp_state.handle._deactivate()


### PR DESCRIPTION
Cleanup so that we have better signal (i.e., are numerical mismatches small or large?) in logs of failing tests.

Some files appear to be mangled because they were in Windows? format somehow? I've converted them to unix in this PR.

CC @crcrpar @Fuzzkatt 