### PR TITLE
Distributed optimizer support for contiguous param buffer with FP8 params

### DIFF
--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -1007,7 +1007,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             if param_buffer_view.dtype != param.dtype:
                 raise RuntimeError(
                     f"Attempted to change a parameter with dtype={param.dtype} "
-                    f"into a buffer view with dtype={param_view_buffer.dtype}"
+                    f"into a buffer view with dtype={param_buffer_view.dtype}"
                 )
             param_flat_views.append(param.detach().view(-1))
             param_buffer_views.append(param_buffer_view)

--- a/apex/contrib/test/optimizers/test_dist_adam.py
+++ b/apex/contrib/test/optimizers/test_dist_adam.py
@@ -296,6 +296,12 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
             param_sync_dtype=torch.int64,
         )
 
+    def test_matches_pytorch_int64_param_sync_contiguous_buffers(self):
+        self.test_matches_pytorch(
+            param_sync_dtype=torch.int64,
+            contiguous_buffers=True,
+        )
+
     def test_matches_pytorch_uint8_param_sync(self):
         self.test_matches_pytorch(
             rtol=0.5,


### PR DESCRIPTION
https://github.com/NVIDIA/apex/pull/1723 added distopt infrastructure to support FP8 parameters in NeMo, but I found a bug with `contiguous_param_buffer=True`. In the non-FP8 case, the local shards of the updated params are views into the contiguous buffer. The Adam kernel outputs to the buffer, we do in-place all-gathers, and the params are ready for fprop. However, the FP8 case should use a temporary buffer since the Adam kernel doesn't support FP8. The Adam kernel outputs to a temporary FP32 buffer and we cast to FP8 in the contiguous param buffer.