### PR TITLE
Make fused normalization functions backward-compatible

### DIFF
--- a/apex/contrib/layer_norm/layer_norm.py
+++ b/apex/contrib/layer_norm/layer_norm.py
@@ -7,7 +7,7 @@ import fast_layer_norm
 
 class FastLayerNormFN(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x, gamma, beta, epsilon, memory_efficient):
+    def forward(ctx, x, gamma, beta, epsilon, memory_efficient=False):
         ctx.x_shape = x.shape
         ctx.memory_efficient = memory_efficient
 

--- a/apex/normalization/fused_layer_norm.py
+++ b/apex/normalization/fused_layer_norm.py
@@ -31,7 +31,7 @@ def manual_rms_norm(input, normalized_shape, weight, eps):
 
 class FusedLayerNormAffineFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input, weight, bias, normalized_shape, eps, memory_efficient):
+    def forward(ctx, input, weight, bias, normalized_shape, eps, memory_efficient=False):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
@@ -55,7 +55,7 @@ class FusedLayerNormAffineFunction(torch.autograd.Function):
         input_or_output, weight_, bias_, mean, invvar = ctx.saved_tensors
         grad_input = grad_weight = grad_bias = None
         grad_input, grad_weight, grad_bias = fused_layer_norm_cuda.backward_affine(
-            grad_output.contiguous(), mean, invvar, input_or_output, 
+            grad_output.contiguous(), mean, invvar, input_or_output,
             ctx.normalized_shape, weight_, bias_, ctx.eps, ctx.memory_efficient
         )
         return grad_input, grad_weight, grad_bias, None, None, None
@@ -63,7 +63,7 @@ class FusedLayerNormAffineFunction(torch.autograd.Function):
 
 class FusedRMSNormAffineFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input, weight, normalized_shape, eps, memory_efficient):
+    def forward(ctx, input, weight, normalized_shape, eps, memory_efficient=False):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
@@ -85,7 +85,7 @@ class FusedRMSNormAffineFunction(torch.autograd.Function):
         input_or_output, weight_, invvar = ctx.saved_tensors
         grad_input = grad_weight = None
         grad_input, grad_weight = fused_layer_norm_cuda.rms_backward_affine(
-           grad_output.contiguous(), invvar, input_or_output, 
+           grad_output.contiguous(), invvar, input_or_output,
            ctx.normalized_shape, weight_, ctx.eps, ctx.memory_efficient
         )
         return grad_input, grad_weight, None, None, None
@@ -94,7 +94,7 @@ class FusedRMSNormAffineFunction(torch.autograd.Function):
 class FusedLayerNormAffineMixedDtypesFunction(FusedLayerNormAffineFunction):
 
     @staticmethod
-    def forward(ctx, input, weight, bias, normalized_shape, eps, memory_efficient):
+    def forward(ctx, input, weight, bias, normalized_shape, eps, memory_efficient=False):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
@@ -117,7 +117,7 @@ class FusedLayerNormAffineMixedDtypesFunction(FusedLayerNormAffineFunction):
 class FusedRMSNormAffineMixedDtypesFunction(FusedRMSNormAffineFunction):
 
     @staticmethod
-    def forward(ctx, input, weight, normalized_shape, eps, memory_efficient):
+    def forward(ctx, input, weight, normalized_shape, eps, memory_efficient=False):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
@@ -138,7 +138,7 @@ class FusedRMSNormAffineMixedDtypesFunction(FusedRMSNormAffineFunction):
 
 class FusedLayerNormFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input, normalized_shape, eps, memory_efficient):
+    def forward(ctx, input, normalized_shape, eps, memory_efficient=False):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
@@ -165,7 +165,7 @@ class FusedLayerNormFunction(torch.autograd.Function):
 
 class FusedRMSNormFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input, normalized_shape, eps, memory_efficient):
+    def forward(ctx, input, normalized_shape, eps, memory_efficient=False):
         global fused_layer_norm_cuda
         if fused_layer_norm_cuda is None:
             fused_layer_norm_cuda = importlib.import_module("fused_layer_norm_cuda")
@@ -185,7 +185,7 @@ class FusedRMSNormFunction(torch.autograd.Function):
         input_or_output, invvar = ctx.saved_tensors
         grad_input = None
         grad_input = fused_layer_norm_cuda.rms_backward(
-            grad_output.contiguous(), invvar, input_or_output, 
+            grad_output.contiguous(), invvar, input_or_output,
             ctx.normalized_shape, ctx.eps, ctx.memory_efficient
         )
         return grad_input, None, None, None


### PR DESCRIPTION
https://github.com/NVIDIA/apex/pull/1715 makes breaking API changes to some fused normalization functions, in particular adding `memory_efficient` as a positional argument. This PR makes `memory_efficient` a keyword argument to ensure backward compatibility.

This change is motivated by the fact that Megatron-LM uses the old API:
https://github.com/NVIDIA/Megatron-LM/blob/2bc6cd307a11423928c675f741e79e03df23e721/megatron/core/fusions/fused_layer_norm.py#L147
This prevents NeMo from upgrading from the 23.09 to 23.11 PyTorch container. See https://github.com/NVIDIA/NeMo/pull/7909#issuecomment-1863754027.

Feedback would be appreciated. An alternative approach is to update Megatron-LM, but this seems simpler. Pinging @RuiWang1998.