### PR TITLE
Support scaled optimizer state in distributed Adam optimizer

### DIFF
--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -1047,10 +1047,16 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                     f"into a buffer view with device={param_buffer_view.device}"
                 )
             if param_buffer_view.dtype != param.dtype:
-                raise RuntimeError(
-                    f"Attempted to change a parameter with dtype={param.dtype} "
-                    f"into a buffer view with dtype={param_buffer_view.dtype}"
-                )
+                if (
+                    not torch.is_floating_point(param_buffer_view)
+                    and param_buffer_view.element_size() == param.element_size()
+                ):
+                    param_buffer_view = param_buffer_view.view(dtype=param.dtype)
+                else:
+                    raise RuntimeError(
+                        f"Attempted to change a parameter with dtype={param.dtype} "
+                        f"into a buffer view with dtype={param_buffer_view.dtype}"
+                    )
             param_flat_views.append(param.detach().view(-1))
             param_buffer_views.append(param_buffer_view)
 

--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -662,7 +662,8 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         self.store_param_remainders: bool = store_param_remainders
 
         # Whether to scale optimizer state
-        if with_scaled_states:
+        self.with_scaled_states: bool = with_scaled_states
+        if self.with_scaled_states:
             if not self.store_params:
                 raise RuntimeError(
                     "Attempted to construct DistributedFusedAdam "
@@ -673,7 +674,12 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                     "Attempted to construct DistributedFusedAdam "
                     "with with_scaled_state=True and store_params_remainders=True"
                 )
-        self.with_scaled_states: bool = with_scaled_states
+            if self.dtype not in (torch.float16, torch.bfloat16):
+                raise RuntimeError(
+                    "Attempted to construct DistributedFusedAdam "
+                    f"with with_scaled_state=True and dtype={self.dtype} "
+                    "(only fp16 and bf16 are supported)"
+                )
         # Scaling factors for optimizer state
         self._state_scales: dict = {}
 

--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -691,7 +691,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                     "Attempted to construct DistributedFusedAdam "
                     f"with with_scaled_state=True and param_sync_dtype={self.param_sync_dtype}"
                 )
-        # Scaling factors for optimizer state
+        # Scaling factors to apply to recover unscaled optimizer state
         self._state_scales: dict = {}
 
         # Determine bucket sizes

--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -2297,12 +2297,8 @@ class DistributedFusedAdam(torch.optim.Optimizer):
 
             # Initialize param shard buffer
             if self.with_scaled_states:
-                # Use FP32 buffer if using scaled optimizer state
-                params_bucket.params_shard = torch.empty(
-                    [shard_size],
-                    dtype=torch.float32,
-                    device=self.device,
-                )
+                # Use FP32 workspace buffer with scaled optimizer state
+                params_bucket.params_shard = None
             elif not param_sync_dtype.is_floating_point:
                 # Make sure param shard buffer is floating-point
                 if (

--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -3079,7 +3079,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                     shard_range = slice(*fragment.shard_range)
                     torch.mul(
                         self._state_scales[(param_group_id, param_id)][state_key],
-                        scaled_shard[shard_range],
+                        shard[shard_range],
                         out=out[shard_range],
                     )
             return out
@@ -3370,17 +3370,17 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                 if self.with_scaled_states:
                     torch.mul(
                         param_rscale,
-                        param_state[param_range],
+                        param_state[param_range].to(device=self.device),
                         out=bucket.params_shard[shard_range],
                     )
                     torch.mul(
                         exp_avg_rscale,
-                        exp_avg[param_range],
+                        exp_avg[param_range].to(device=self.device),
                         out=bucket.exp_avg_shard[shard_range],
                     )
                     torch.mul(
                         exp_avg_sq_rscale,
-                        exp_avg_sq[param_range],
+                        exp_avg_sq[param_range].to(device=self.device),
                         out=bucket.exp_avg_sq_shard[shard_range],
                     )
                 else:

--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -766,6 +766,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         if self.overlap_param_sync:
             self._register_pre_forward_hooks()
 
+    @torch.no_grad()
     def _broadcast_params(self) -> None:
         """Broadcast parameter values from root rank"""
         process_group = self.process_group

--- a/apex/contrib/test/optimizers/test_dist_adam.py
+++ b/apex/contrib/test/optimizers/test_dist_adam.py
@@ -41,7 +41,7 @@ def make_models(
         param_sync_dtype: Optional[torch.dtype] = None,
         device: torch.device = 'cuda',
         process_group: Optional[torch.distributed.ProcessGroup] = None,
-        average_grad_sync: bool =True,
+        average_grad_sync: bool = True,
         overlap_communication: bool = True,
         bucket_cap_mb: float = 71/(4*1024*1024),
         contiguous_buffers: bool = False,
@@ -513,6 +513,7 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
                 lr=0.1,
                 process_group=save_group,
                 average_grad_sync=False,
+                overlap_communication=False,
                 **save_model_kwargs,
             )
             optim_save.init_params(reversed(list(model_save.parameters())))
@@ -526,6 +527,7 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
                 lr=1234.,
                 process_group=load_group,
                 average_grad_sync=False,
+                overlap_communication=False,
                 **load_model_kwargs,
             )
             optim_load.init_params(list(model_load.parameters()))
@@ -770,8 +772,8 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
             self.test_matches_pytorch(
                 num_layers=num_layers,
                 layer_size=layer_size,
+                overlap_communication=False,
                 bucket_cap_mb=fairish_bucket_cap_mb * 2,
-                contiguous_buffers=True,
             )
 
         # Check that warning is not raised when bucket utilization is high
@@ -779,8 +781,8 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
             self.test_matches_pytorch(
                 num_layers=num_layers,
                 layer_size=layer_size,
+                overlap_communication=False,
                 bucket_cap_mb=fairish_bucket_cap_mb,
-                contiguous_buffers=True,
             )
             for w in warns:
                 self.assertNotRegex(str(w.message), ".*Consider decreasing the bucket_cap_mb argument.")

--- a/apex/contrib/test/optimizers/test_dist_adam.py
+++ b/apex/contrib/test/optimizers/test_dist_adam.py
@@ -45,7 +45,7 @@ def make_models(
         contiguous_buffers: bool = False,
         store_params: bool = False,
         store_param_remainders: bool = False,
-        with_scaled_state: bool = False,
+        with_scaled_states: bool = False,
 ):
 
     # Construct models with same parameters
@@ -95,7 +95,7 @@ def make_models(
         contiguous_grad_buffer=contiguous_buffers,
         store_params=store_params,
         store_param_remainders=store_param_remainders,
-        with_scaled_state=with_scaled_state,
+        with_scaled_states=with_scaled_states,
         **optim_args,
     )
 
@@ -136,7 +136,7 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
             contiguous_buffers: bool = False,
             store_params: bool = False,
             store_param_remainders: bool = False,
-            with_scaled_state: bool = False,
+            with_scaled_states: bool = False,
             init_optim_func: Optional[Callable[[DistributedFusedAdam], None]] = None,
     ):
 
@@ -157,7 +157,7 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
             contiguous_buffers=contiguous_buffers,
             store_params=store_params,
             store_param_remainders=store_param_remainders,
-            with_scaled_state=with_scaled_state,
+            with_scaled_states=with_scaled_states,
         )
 
         # Initialize distributed optimizer
@@ -325,7 +325,7 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
             optim_dtype=torch.float16,
             param_sync_dtype=torch.int,
             store_params=True,
-            with_scaled_state=True,
+            with_scaled_states=True,
         )
 
     def test_raises_on_mismatch(self):
@@ -744,14 +744,14 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
                 optim_dtype=torch.float16,
                 param_sync_dtype=torch.int,
                 store_params=True,
-                with_scaled_state=True,
+                with_scaled_states=True,
             ),
             load_model_kwargs=dict(
                 model_dtype=torch.bfloat16,
                 optim_dtype=torch.float16,
                 param_sync_dtype=torch.int,
                 store_params=True,
-                with_scaled_state=True,
+                with_scaled_states=True,
             ),
         )
 

--- a/apex/contrib/test/optimizers/test_dist_adam.py
+++ b/apex/contrib/test/optimizers/test_dist_adam.py
@@ -323,7 +323,7 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
             micro_batch_steps=1,
             model_dtype=torch.bfloat16,
             optim_dtype=torch.float16,
-            #param_sync_dtype=torch.int,
+            param_sync_dtype=torch.int,
             store_params=True,
             with_scaled_state=True,
         )
@@ -731,6 +731,27 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
                 param_sync_dtype=torch.bfloat16,
                 store_params=False,
                 store_param_remainders=True,
+            ),
+        )
+
+    def test_checkpoint_scaled_state(self):
+        """Test checkpoint with scaled FP16 state"""
+        self.test_checkpoint(
+            rtol=5e-2,
+            atol=1e-5,
+            save_model_kwargs=dict(
+                model_dtype=torch.bfloat16,
+                optim_dtype=torch.float16,
+                param_sync_dtype=torch.int,
+                store_params=True,
+                with_scaled_state=True,
+            ),
+            load_model_kwargs=dict(
+                model_dtype=torch.bfloat16,
+                optim_dtype=torch.float16,
+                param_sync_dtype=torch.int,
+                store_params=True,
+                with_scaled_state=True,
             ),
         )
 

--- a/apex/contrib/test/optimizers/test_dist_adam.py
+++ b/apex/contrib/test/optimizers/test_dist_adam.py
@@ -302,9 +302,9 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
             param_sync_dtype=torch.int64,
         )
 
-    def test_matches_pytorch_int64_param_sync_contiguous_buffers(self):
+    def test_matches_pytorch_int32_param_sync_contiguous_buffers(self):
         self.test_matches_pytorch(
-            param_sync_dtype=torch.int64,
+            param_sync_dtype=torch.int32,
             contiguous_buffers=True,
         )
 


### PR DESCRIPTION
This PR adds basic support for scaled optimizer state as discussed in [the MS-AMP paper](https://arxiv.org/pdf/2310.18313.pdf). The idea is that per-tensor scaling factors along with FP16/FP8 optimizer state results in lower memory usage than FP32 optimizer state with no degradation in convergence. This implementation is not quite the same as the MS-AMP FP8 optimizer since it only uses FP16 optimizer state and uses per-parameter-fragment scaling factors rather than per-parameter. It is a preliminary implementation and its performance could be improved with custom kernels (e.g. kernel to compute scaling factors, fused kernel with FP16-FP32 casts and Adam step).

In the process of debugging, I've also made some other performance optimizations and bugfixes:
- Generalize support for overlapping first grad sync with optimizer step (to be used for NeMo FP8 support)
- Fix bug where loading checkpoint does not load parameter group configs
- Fix bug where test from https://github.com/NVIDIA/apex/pull/1749 was not doing anything