### PR TITLE
Skip the p2p test on single GPU platforms

### DIFF
--- a/apex/contrib/test/bottleneck/test_bottleneck_module.py
+++ b/apex/contrib/test/bottleneck/test_bottleneck_module.py
@@ -296,7 +296,7 @@ class TestBottleneck(NcclDistributedTestBase):
         bt = apply_to_different_bottleneck(gt, spatial_bottleneck)
         self.assertEqual(gt, bt, **self.fp16_tolerance)
 
-    @unittest.skipIf(not torch.cuda.can_device_access_peer(0,1), "peer memory access not supported")
+    @unittest.skipIf(torch.cuda.device_count() < 2 or not torch.cuda.can_device_access_peer(0,1), "peer memory access not supported")
     def test_bottleneck_with_peer_memory(self) -> None:
 
         explicit_nhwc: bool = True


### PR DESCRIPTION
This PR fixes the errors that would show up if the test_bottleneck_module.py is run on a single GPU platform, where running torch.cuda.can_device_access_peer(0,1) would produce "invalid peer device id".  

 