### PR TITLE
Move to the correct device for v1 state dict

### DIFF
--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -3296,6 +3296,13 @@ class DistributedFusedAdam(torch.optim.Optimizer):
             if getattr(bucket, "param_sync_dtype", None) is None:
                 bucket.param_sync_dtype = self.param_sync_dtype
 
+            if bucket.params_shard is not None:
+                bucket.params_shard = bucket.params_shard.to(self.device)
+            if bucket.param_remainders_shard is not None:
+                bucket.param_remainders_shard = bucket.param_remainders_shard.to(self.device)
+            bucket.exp_avg_shard = bucket.exp_avg_shard.to(self.device)
+            bucket.exp_avg_sq_shard = bucket.exp_avg_sq_shard.to(self.device)
+
     @torch.no_grad()
     def _load_state_dict_v2(self, state_dict: dict) -> None:
         """Load optimizer state (default v2 format)


### PR DESCRIPTION
This PRs aims to move the attributes of `DistributedFusedAdam` to the correct device for v1 state dict.

After loading V1 state dict, tensors in `DistributedFusedAdam.["buckets"]` will be on CPU device when using default checkpoint_io in NeMo.  Although NeMo considers to move the optimizer state to the target CUDA device by the [_optimizer_to_device](https://github.com/Lightning-AI/pytorch-lightning/blob/2.0.7/src/lightning/fabric/utilities/optimizer.py#L31) in `pytorch_lightning`. However, it fails to do what it meant to do for DistributedFusedAdam because tensors like `DistributedFusedAdam.["buckets"][0].param_remainders_shard` would not be moved to the correct device when using the V1 format.

This PR aims to fix it.