### PR TITLE
Avoid unnecessary param write in distributed Adam kernel

### DIFF
--- a/apex/contrib/csrc/optimizers/multi_tensor_distopt_adam_kernel.cu
+++ b/apex/contrib/csrc/optimizers/multi_tensor_distopt_adam_kernel.cu
@@ -178,7 +178,9 @@ struct DistAdamFunctor
         load_store(p_in + i_start, local_p);
         load_store(m + i_start, local_m);
         load_store(v + i_start, local_v);
-        load_store(p_out + i_start, local_p_out);
+        if (static_cast<void*>(p_out) != static_cast<void*>(p_in)) {
+          load_store(p_out + i_start, local_p_out);
+        }
       } else {
 #pragma unroll
         for (int ii = 0, i = i_start; ii < ILP; ii++, i++) {
@@ -186,7 +188,9 @@ struct DistAdamFunctor
             p_in[i] = local_p[ii];
             m[i] = local_m[ii];
             v[i] = local_v[ii];
-	    p_out[i] = local_p_out[ii];
+            if (static_cast<void*>(p_out) != static_cast<void*>(p_in)) {
+              p_out[i] = local_p_out[ii];
+            }
           }
         }
       }


### PR DESCRIPTION
The distributed Adam kernel is implemented to simultaneously output to the master param buffer (usually FP32) and to the param all-gather buffer (usually BF16). This saves the cost of doing an extra cast before the param all-gather. However, in some cases the distributed optimizer will use the same buffer for the master params and the param all-gather, e.g. when the all-gather dtype matches the master params or when doing FP8 all-gathers.

This PR adds a check to avoid writing to the same buffer twice. I'm not sure how much this issue is already mitigated by caching, so performance evaluations are in progress.