### PR TITLE
Add nccl_allocator for zero-copy user buffer

### DIFF
--- a/apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp
+++ b/apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp
@@ -155,7 +155,7 @@ c10::DataPtr NCCLAllocator::allocate(size_t size) {
       r,
       raw_deleter(),
       c10::Device(
-          c10::DeviceType::CUDA, static_cast<int>(device))};
+          c10::DeviceType::CUDA, device)};
   return data_ptr;
 }
 
@@ -167,7 +167,7 @@ void* NCCLAllocator::raw_alloc(size_t nbytes) {
   c10::DeviceIndex device = -1;
   C10_CUDA_CHECK(c10::cuda::GetDevice(&device));
   cudaStream_t stream =
-      c10::cuda::getCurrentCUDAStream(static_cast<int>(device));
+      c10::cuda::getCurrentCUDAStream(device);
   return malloc(nbytes, device, stream);
 }
 
@@ -192,10 +192,8 @@ void NCCLAllocator::raw_delete(void* ptr) {
       stream = metadata.stream;
       cuda_rt_allocation_metadata_.erase(ptr);
       cuda_rt_cache_metadata_.emplace(size, metadata);
-      // C10_CUDA_CHECK(cudaFree(ptr));
     } else if (nccl_allocation_metadata_.count(ptr)) {
       nccl_allocation_metadata_[ptr].is_free = true;
-      // C10_NCCL_CHECK(ncclMemFree(ptr));
     } else {
       TORCH_CHECK(false, "Trying to free a pointer not allocated here");
     }

--- a/apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp
+++ b/apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp
@@ -1,0 +1,437 @@
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/util/ApproximateClock.h>
+#include <iostream>
+#include <mutex>
+#include <nccl.h>
+
+#include "NCCLAllocator.h"
+
+#if defined(NCCL_MAJOR) && \
+    ((NCCL_MAJOR > 2) || (NCCL_MAJOR == 2) && (NCCL_MINOR >= 19))
+#define NCCL_SUPPORTS_UB
+#endif
+
+#define C10_NCCL_CHECK(cmd)                                               \
+  do {                                                                    \
+    ncclResult_t result = cmd;                                            \
+    if (result != ncclSuccess) {                                          \
+      std::string err = "NCCL error in: " + std::string(__FILE__) + ":" + \
+          std::to_string(__LINE__) + ", " +                               \
+          std::string(ncclGetErrorString(result));                        \
+      TORCH_CHECK(false, err);                                            \
+    }                                                                     \
+  } while (0)
+
+namespace nccl_allocator::cuda {
+
+extern int device_count;
+
+extern thread_local bool _use_nccl_mem;
+
+std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>
+createNCCLAllocator() {
+  auto allocator = std::make_shared<NCCLAllocator>();
+  allocator->init(device_count);
+  return allocator;
+}
+
+void custom_raw_deleter(void* ptr);
+
+_AllocationMetadata::_AllocationMetadata()
+    : size(0), device_idx(-1), stream{}, ptr(nullptr), is_free(false) {}
+
+_AllocationMetadata::_AllocationMetadata(
+    size_t size,
+    c10::DeviceIndex device_idx,
+    cudaStream_t stream,
+    void* ptr)
+    : size(size), device_idx(device_idx), stream(stream), ptr(ptr), is_free(false) {}
+
+NCCLAllocator::NCCLAllocator(NCCLAllocator& other)
+    : init_fn_(other.init_fn_),
+      memory_fraction_fn_(other.memory_fraction_fn_),
+      base_alloc_fn_(other.base_alloc_fn_),
+      record_stream_fn_(other.record_stream_fn_),
+      begin_allocate_to_pool_fn_(other.begin_allocate_to_pool_fn_),
+      end_allocate_to_pool_fn_(other.end_allocate_to_pool_fn_),
+      relase_pool_fn_(other.relase_pool_fn_) {}
+
+void* NCCLAllocator::malloc(size_t size, c10::DeviceIndex device, cudaStream_t stream) {
+  void* r = nullptr;
+#ifdef NCCL_SUPPORTS_UB
+  if (_use_nccl_mem) {
+    for (
+      auto md = nccl_allocation_metadata_.begin();
+           md != nccl_allocation_metadata_.end();
+	   md++
+    ) {
+      // compare stream?
+      if(md->second.is_free && md->second.size == size && md->second.device_idx == device) {
+        md->second.is_free = false;
+	r = md->second.ptr;
+	return r;
+      }
+    }
+
+    C10_NCCL_CHECK(ncclMemAlloc(&r, size));
+    {
+      const std::lock_guard<std::mutex> lock(allocator_mutex_);
+      nccl_allocation_metadata_.emplace(r, _AllocationMetadata(size, device, stream, r));
+
+      auto te = c10::cuda::CUDACachingAllocator::TraceEntry(
+        c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_ALLOC,
+        device,
+        (int64_t)r,
+        size,
+        stream,
+        c10::getApproximateTime(),
+        nullptr);
+      for (const auto& cb : trace_trackers_) {
+        cb(te);
+      }
+    }
+  }
+#else
+  if (_use_nccl_mem) {
+    TORCH_WARN_ONCE("ncclMemAlloc is not supported. ",
+                    "NCCL v2.19 and newer is required,",
+                    "but found NCCL v", NCCL_MAJOR, ".", NCCL_MINOR, ". ",
+                    "Falling back to cudaMalloc.");
+  }
+  if (false) {
+    // goto cudaMalloc
+  }
+#endif
+  else {
+    if (r == nullptr) {
+      // find allocation of the same size or slightly better
+      // What is the best upper bound?
+      auto start = cuda_rt_cache_metadata_.lower_bound(size);
+      auto end = cuda_rt_cache_metadata_.upper_bound(size + 1024);
+      for (auto md = start; md != end; ) {
+        _AllocationMetadata metadata = md->second;
+        // Should we check for stream?
+        if (metadata.device_idx == device) {
+          r = metadata.ptr;
+          cuda_rt_cache_metadata_.erase(md++);
+          break;
+        }
+        ++md;
+      }
+    }
+    if (r == nullptr) {
+      cudaError_t err = cudaMalloc(&r, size);
+      if (cudaSuccess != err) {
+        size_t freed = 0;
+        for (auto md = cuda_rt_cache_metadata_.rbegin(); md != cuda_rt_cache_metadata_.rend(); ++md) {
+          _AllocationMetadata metadata = md->second;
+          freed = freed + metadata.size;
+          cuda_rt_cache_metadata_.erase(--(md.base()));
+	  C10_CUDA_CHECK(cudaFree(metadata.ptr));
+          if (freed >= size) {
+            break;
+          }
+        }
+        C10_CUDA_CHECK(cudaMalloc(&r, size));
+      }
+    }
+    {
+      const std::lock_guard<std::mutex> lock(allocator_mutex_);
+      cuda_rt_allocation_metadata_.emplace(r, _AllocationMetadata(size, device, stream, r));
+    }
+  }
+  return r;
+}
+
+c10::DataPtr NCCLAllocator::allocate(size_t size) {
+  c10::DeviceIndex device = -1;
+  C10_CUDA_CHECK(c10::cuda::GetDevice(&device));
+  cudaStream_t stream =
+      c10::cuda::getCurrentCUDAStream(static_cast<int>(device));
+  void* r = this->malloc(size, device, stream);
+  c10::DataPtr data_ptr = {
+      r,
+      r,
+      raw_deleter(),
+      c10::Device(
+          c10::DeviceType::CUDA, static_cast<int>(device))};
+  return data_ptr;
+}
+
+c10::DeleterFnPtr NCCLAllocator::raw_deleter() const {
+  return &custom_raw_deleter;
+}
+
+void* NCCLAllocator::raw_alloc(size_t nbytes) {
+  c10::DeviceIndex device = -1;
+  C10_CUDA_CHECK(c10::cuda::GetDevice(&device));
+  cudaStream_t stream =
+      c10::cuda::getCurrentCUDAStream(static_cast<int>(device));
+  return malloc(nbytes, device, stream);
+}
+
+void* NCCLAllocator::raw_alloc_with_stream(
+    size_t nbytes,
+    cudaStream_t stream) {
+  c10::DeviceIndex device = -1;
+  C10_CUDA_CHECK(c10::cuda::GetDevice(&device));
+  return malloc(nbytes, device, stream);
+}
+
+void NCCLAllocator::raw_delete(void* ptr) {
+  cudaStream_t stream{};
+  c10::DeviceIndex device_idx = -1;
+  size_t size = 0;
+  {
+    const std::lock_guard<std::mutex> lock(allocator_mutex_);
+    if (cuda_rt_allocation_metadata_.count(ptr)) {
+      _AllocationMetadata& metadata = cuda_rt_allocation_metadata_[ptr];
+      size = metadata.size;
+      device_idx = metadata.device_idx;
+      stream = metadata.stream;
+      cuda_rt_allocation_metadata_.erase(ptr);
+      cuda_rt_cache_metadata_.emplace(size, metadata);
+      // C10_CUDA_CHECK(cudaFree(ptr));
+    } else if (nccl_allocation_metadata_.count(ptr)) {
+      nccl_allocation_metadata_[ptr].is_free = true;
+      // C10_NCCL_CHECK(ncclMemFree(ptr));
+    } else {
+      TORCH_CHECK(false, "Trying to free a pointer not allocated here");
+    }
+  }
+}
+
+void NCCLAllocator::init(int device_count) {
+  if (init_fn_) {
+    init_fn_(device_count);
+  }
+  initialized_ = true;
+}
+
+bool NCCLAllocator::initialized() {
+  return initialized_;
+}
+
+void NCCLAllocator::setMemoryFraction(double fraction, c10::DeviceIndex device) {
+  if (memory_fraction_fn_) {
+    memory_fraction_fn_(fraction, device);
+  }
+}
+
+void NCCLAllocator::emptyCache() {
+  void *ptr;
+  cudaStream_t stream{};
+  int device_idx = -1;
+  size_t size = 0;
+  for (
+    auto md = cuda_rt_cache_metadata_.cbegin();
+         md != cuda_rt_cache_metadata_.cend();
+  ) {
+    C10_CUDA_CHECK(cudaFree(md->second.ptr));
+    cuda_rt_cache_metadata_.erase(md++);
+  }
+  for (
+    auto md = nccl_allocation_metadata_.cbegin();
+         md != nccl_allocation_metadata_.cend();
+  ) {
+    if (md->second.is_free) {
+      ptr = md->second.ptr;
+      size = md->second.size;
+      device_idx = md->second.device_idx;
+      stream = md->second.stream;
+      nccl_allocation_metadata_.erase(md++);
+      auto te = c10::cuda::CUDACachingAllocator::TraceEntry(
+        c10::cuda::CUDACachingAllocator::TraceEntry::Action::SEGMENT_FREE,
+        device_idx,
+        (int64_t)ptr,
+        size,
+        stream,
+        c10::getApproximateTime(),
+        nullptr);
+      for (const auto& cb : trace_trackers_) {
+        cb(te);
+      }
+      C10_NCCL_CHECK(ncclMemFree(ptr));
+    }
+    else {
+      ++md;
+    }
+  }
+}
+
+void NCCLAllocator::cacheInfo(c10::DeviceIndex dev_id, size_t* largestBlock) {
+  TORCH_CHECK(
+      false,
+      "NCCLAllocator does not yet support cacheInfo. "
+      "If you need it, please file an issue describing your use case.");
+}
+
+void* NCCLAllocator::getBaseAllocation(void* ptr, size_t* size) {
+  if (base_alloc_fn_) {
+    return base_alloc_fn_(ptr, size);
+  } else {
+    return ptr;
+  }
+}
+
+void NCCLAllocator::recordStream(
+    const c10::DataPtr& ptr,
+    c10::cuda::CUDAStream stream) {
+  if (record_stream_fn_) {
+    record_stream_fn_(ptr.get(), stream);
+  }
+}
+
+c10::cuda::CUDACachingAllocator::DeviceStats NCCLAllocator::getDeviceStats(
+    c10::DeviceIndex device) {
+  TORCH_CHECK(
+      false,
+      "NCCLAllocator does not yet support getDeviceStats. "
+      "If you need it, please file an issue describing your use case.");
+}
+
+void NCCLAllocator::resetAccumulatedStats(c10::DeviceIndex device) {
+  TORCH_CHECK(
+      false,
+      "NCCLAllocator does not yet support resetAccumulatedStats. "
+      "If you need it, please file an issue describing your use case.");
+}
+
+void NCCLAllocator::resetPeakStats(c10::DeviceIndex device) {
+  TORCH_CHECK(
+      false,
+      "NCCLAllocator does not yet support resetPeakStats. "
+      "If you need it, please file an issue describing your use case.");
+}
+
+c10::cuda::CUDACachingAllocator::SnapshotInfo NCCLAllocator::snapshot() {
+  c10::cuda::CUDACachingAllocator::SnapshotInfo result;
+  result.segments.reserve(nccl_allocation_metadata_.size());
+  for (auto& da : nccl_allocation_metadata_) {
+    c10::cuda::CUDACachingAllocator::SegmentInfo seg;
+
+    seg.device = da.second.device_idx;
+    seg.address = (int64_t)da.first;
+    seg.total_size = da.second.size;
+    seg.requested_size = da.second.size;
+    seg.allocated_size = da.second.size;
+    seg.active_size = da.second.size;
+    seg.stream = da.second.stream;
+    seg.is_large = true;
+    seg.is_expandable = false;
+
+    result.segments.push_back(seg);
+  }
+  return result;
+}
+
+std::shared_ptr<void> NCCLAllocator::getIpcDevPtr(std::string handle) {
+  TORCH_CHECK(
+      false,
+      "NCCLAllocator does not yet support getIpcDevPtr. "
+      "If you need it, please file an issue describing your use case.");
+}
+
+// CUDAGraph interactions
+void NCCLAllocator::beginAllocateToPool(
+    c10::DeviceIndex device,
+    c10::cuda::MempoolId_t mempool_id,
+    std::function<bool(cudaStream_t)> filter) {
+  if (begin_allocate_to_pool_fn_) {
+    begin_allocate_to_pool_fn_(device, mempool_id, std::move(filter));
+  }
+}
+
+void NCCLAllocator::endAllocateToPool(
+    c10::DeviceIndex device,
+    c10::cuda::MempoolId_t mempool_id) {
+  if (end_allocate_to_pool_fn_) {
+    end_allocate_to_pool_fn_(device, mempool_id);
+  }
+}
+
+void NCCLAllocator::releasePool(
+    c10::DeviceIndex device,
+    c10::cuda::MempoolId_t mempool_id) {
+  if (relase_pool_fn_) {
+    relase_pool_fn_(device, mempool_id);
+  }
+}
+
+void NCCLAllocator::recordHistory(
+    bool enabled,
+    c10::cuda::CUDACachingAllocator::CreateContextFn context_recorder,
+    size_t alloc_trace_max_entries,
+    c10::cuda::CUDACachingAllocator::RecordContext when) {
+  TORCH_CHECK(
+      false,
+      "NCCLAllocator does not yet support recordHistory. "
+      "If you need it, please file an issue describing your use case.");
+}
+
+void NCCLAllocator::attachOutOfMemoryObserver(
+    c10::cuda::CUDACachingAllocator::OutOfMemoryObserver observer) {
+  TORCH_CHECK(
+      false,
+      "NCCLAllocator does not yet support attachOutOfMemoryObserver. "
+      "If you need it, please file an issue describing your use case.");
+}
+
+void NCCLAllocator::attachAllocatorTraceTracker(
+    c10::cuda::CUDACachingAllocator::AllocatorTraceTracker tracker) {
+  const std::lock_guard<std::mutex> lock(allocator_mutex_);
+  trace_trackers_.emplace_back(std::move(tracker));
+}
+
+std::shared_ptr<c10::cuda::CUDACachingAllocator::AllocatorState>
+NCCLAllocator::getCheckpointState(c10::DeviceIndex device, at::cuda::MempoolId_t id) {
+  TORCH_CHECK(
+      false,
+      "NCCLAllocator does not yet support getCheckpointState. "
+      "If you need it, please file an issue describing your use case.");
+}
+
+c10::cuda::CUDACachingAllocator::CheckpointDelta NCCLAllocator::
+    setCheckpointPoolState(
+        c10::DeviceIndex device,
+        std::shared_ptr<c10::cuda::CUDACachingAllocator::AllocatorState> pps) {
+  TORCH_CHECK(
+      false,
+      "NCCLAllocator does not yet support setCheckpointPoolState. "
+      "If you need it, please file an issue describing your use case.");
+}
+
+void NCCLAllocator::enablePeerAccess(c10::DeviceIndex dev, c10::DeviceIndex dev_to_access) {
+  c10::cuda::CUDAGuard device_guard(static_cast<int>(dev));
+  cudaError_t err = cudaDeviceEnablePeerAccess(dev_to_access, 0);
+  if (err == cudaErrorPeerAccessAlreadyEnabled) {
+    // ignore and clear the error if access was already enabled
+    (void)cudaGetLastError();
+  } else {
+    C10_CUDA_CHECK(err);
+  }
+}
+
+cudaError_t NCCLAllocator::memcpyAsync(
+    void* dst,
+    int dstDevice,
+    const void* src,
+    int srcDevice,
+    size_t count,
+    cudaStream_t stream,
+    bool p2p_enabled) {
+  return cudaMemcpyAsync(dst, src, count, cudaMemcpyDeviceToDevice, stream);
+}
+
+std::string NCCLAllocator::name() {
+  return "pluggable";
+}
+
+void NCCLAllocator::copy_data(void* dest, const void* src, std::size_t count)
+    const {
+  C10_CUDA_CHECK(
+      cudaMemcpy(dest, src, count, cudaMemcpyKind::cudaMemcpyDeviceToDevice));
+}
+
+} // namespace nccl_allocator::cuda

--- a/apex/contrib/csrc/nccl_allocator/NCCLAllocator.h
+++ b/apex/contrib/csrc/nccl_allocator/NCCLAllocator.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <c10/core/Allocator.h>
+#include <c10/cuda/CUDAMacros.h>
+#include <c10/cuda/CUDAStream.h>
+#include <c10/cuda/CUDACachingAllocator.h>
+
+#include <map>
+#include <mutex>
+
+namespace nccl_allocator::cuda {
+
+std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>
+createNCCLAllocator();
+
+struct _AllocationMetadata {
+  _AllocationMetadata();
+  _AllocationMetadata(size_t size, c10::DeviceIndex device_idx, cudaStream_t stream, void* ptr);
+  size_t size;
+  int device_idx;
+  cudaStream_t stream;
+  void* ptr;
+  bool is_free;
+};
+
+struct NCCLAllocator
+    : public c10::cuda::CUDACachingAllocator::CUDAAllocator {
+  NCCLAllocator() = default;
+
+  NCCLAllocator(NCCLAllocator& other);
+
+  void* malloc(size_t size, c10::DeviceIndex device, cudaStream_t stream);
+
+  c10::DataPtr allocate(size_t size) override;
+  c10::DeleterFnPtr raw_deleter() const override;
+
+  void* raw_alloc(size_t nbytes) override;
+  void* raw_alloc_with_stream(size_t nbytes, cudaStream_t stream) override;
+  void raw_delete(void* ptr) override;
+  void init(int device_count) override;
+  bool initialized() override;
+  void setMemoryFraction(double fraction, c10::DeviceIndex device) override;
+  void emptyCache() override;
+  void cacheInfo(c10::DeviceIndex dev_id, size_t* largestBlock) override;
+  void* getBaseAllocation(void* ptr, size_t* size) override;
+
+  void recordStream(const c10::DataPtr&, c10::cuda::CUDAStream stream) override;
+
+  c10::cuda::CUDACachingAllocator::DeviceStats getDeviceStats(
+      c10::DeviceIndex device) override;
+  void resetAccumulatedStats(c10::DeviceIndex device) override;
+  void resetPeakStats(c10::DeviceIndex device) override;
+  c10::cuda::CUDACachingAllocator::SnapshotInfo snapshot() override;
+  void beginAllocateToPool(
+      c10::DeviceIndex device,
+      c10::cuda::MempoolId_t mempool_id,
+      std::function<bool(cudaStream_t)>) override;
+  void endAllocateToPool(c10::DeviceIndex device, c10::cuda::MempoolId_t mempool_id)
+      override;
+  void releasePool(c10::DeviceIndex device, c10::cuda::MempoolId_t mempool_id) override;
+  std::shared_ptr<void> getIpcDevPtr(std::string handle) override;
+  void recordHistory(
+      bool enabled,
+      c10::cuda::CUDACachingAllocator::CreateContextFn context_recorder,
+      size_t alloc_trace_max_entries,
+      c10::cuda::CUDACachingAllocator::RecordContext when) override;
+  void attachOutOfMemoryObserver(
+      c10::cuda::CUDACachingAllocator::OutOfMemoryObserver observer) override;
+  void attachAllocatorTraceTracker(
+      c10::cuda::CUDACachingAllocator::AllocatorTraceTracker tracker) override;
+  std::shared_ptr<c10::cuda::CUDACachingAllocator::AllocatorState>
+  getCheckpointState(c10::DeviceIndex device, at::cuda::MempoolId_t id) override;
+  c10::cuda::CUDACachingAllocator::CheckpointDelta setCheckpointPoolState(
+      c10::DeviceIndex device,
+      std::shared_ptr<c10::cuda::CUDACachingAllocator::AllocatorState> pps)
+      override;
+  void enablePeerAccess(c10::DeviceIndex dev, c10::DeviceIndex dev_to_access) override;
+  cudaError_t memcpyAsync(
+      void* dst,
+      int dstDevice,
+      const void* src,
+      int srcDevice,
+      size_t count,
+      cudaStream_t stream,
+      bool p2p_enabled) override;
+  std::string name() override;
+  void copy_data(void* dest, const void* src, std::size_t count) const;
+
+ protected:
+  std::function<void(int)> init_fn_;
+  std::function<void(double, int)> memory_fraction_fn_;
+  std::function<void*(void*, size_t*)> base_alloc_fn_;
+  std::function<void(void* ptr, cudaStream_t stream)> record_stream_fn_;
+  std::function<
+      void(int, c10::cuda::MempoolId_t, std::function<bool(cudaStream_t)>)>
+      begin_allocate_to_pool_fn_;
+  std::function<void(int, c10::cuda::MempoolId_t)> end_allocate_to_pool_fn_;
+  std::function<void(int, c10::cuda::MempoolId_t)> relase_pool_fn_;
+  std::mutex allocator_mutex_;
+  // We do the bookeeping here in order to simplify custom allocators
+  std::unordered_map<void*, _AllocationMetadata> cuda_rt_allocation_metadata_;
+  std::multimap<size_t, _AllocationMetadata> cuda_rt_cache_metadata_;
+  std::unordered_map<void*, _AllocationMetadata> nccl_allocation_metadata_;
+
+  bool initialized_ = false;
+  std::vector<c10::cuda::CUDACachingAllocator::AllocatorTraceTracker> trace_trackers_;
+}; // NCCLAllocator
+} // namespace nccl_allocator::cuda

--- a/apex/contrib/csrc/nccl_allocator/python_bindings.cpp
+++ b/apex/contrib/csrc/nccl_allocator/python_bindings.cpp
@@ -1,0 +1,47 @@
+#include <c10/cuda/CUDACachingAllocator.h>
+#include <torch/extension.h>
+#include "NCCLAllocator.h"
+
+namespace nccl_allocator::cuda {
+
+int device_count = 1;
+thread_local bool _use_nccl_mem;
+std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator> current_custom_allocator;
+
+std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator> getCurrentAllocator() {
+  return current_custom_allocator;
+}
+
+void use_nccl_mem(bool flag) {
+  _use_nccl_mem = flag;
+}
+
+void changeCurrentAllocator(std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator> allocator) {
+  TORCH_CHECK(
+      !c10::cuda::CUDACachingAllocator::allocator.load()->initialized(),
+      "Can't swap an already initialized allocator");
+  c10::cuda::CUDACachingAllocator::allocator.store(allocator.get());
+  current_custom_allocator = allocator;
+}
+
+void custom_raw_deleter(void* ptr) {
+  current_custom_allocator->raw_delete(ptr);
+}
+
+} // namespace nccl_allocator::cuda
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("_use_nccl_mem", [](bool flag) { nccl_allocator::cuda::use_nccl_mem(flag); });
+  m.def(
+      "_cuda_change_current_allocator",
+      [](std::shared_ptr<c10::cuda::CUDACachingAllocator::CUDAAllocator>
+             allocator) { nccl_allocator::cuda::changeCurrentAllocator(allocator); });
+  py::class_<
+      nccl_allocator::cuda::NCCLAllocator,
+      c10::cuda::CUDACachingAllocator::CUDAAllocator,
+      std::shared_ptr<nccl_allocator::cuda::NCCLAllocator>>(
+      m, "_NCCLAllocator");
+  m.def("_cuda_create_managed_allocator", []() {
+    return nccl_allocator::cuda::createNCCLAllocator();
+  });
+};

--- a/apex/contrib/examples/nccl_allocator/allreduce.py
+++ b/apex/contrib/examples/nccl_allocator/allreduce.py
@@ -1,0 +1,22 @@
+import os
+import torch
+import torch.distributed as dist
+import apex.contrib.nccl_allocator as nccl_allocator
+
+assert os.getenv("WORLD_SIZE") is not None, "Please use: torchrun --nproc-per-node=8 allreduce.py"
+
+rank = int(os.getenv("RANK"))
+local_rank = int(os.getenv("LOCAL_RANK"))
+world_size = int(os.getenv("WORLD_SIZE"))
+
+nccl_allocator.init()
+
+torch.cuda.set_device(local_rank)
+dist.init_process_group(backend="nccl")
+
+with nccl_allocator.nccl_mem():
+    a = torch.ones(1024 * 1024 * 2, device="cuda")
+dist.all_reduce(a)
+
+torch.cuda.synchronize()
+

--- a/apex/contrib/examples/nccl_allocator/cache.py
+++ b/apex/contrib/examples/nccl_allocator/cache.py
@@ -1,0 +1,54 @@
+import os
+import torch
+import apex.contrib.nccl_allocator as nccl_allocator
+from pynvml.smi import nvidia_smi
+
+def set_device(dev):
+    import ctypes
+    handle = ctypes.CDLL("libcudart.so")
+    result = handle.cudaSetDevice(ctypes.c_int(dev))
+    assert result == 0
+
+def print_used_mem(string, nvsmi, device_id = 0):
+    print(f"{string}:", nvsmi.DeviceQuery('memory.used')['gpu'][device_id])
+
+nccl_allocator.init()
+nrep = 6
+nccl_mem = []
+
+set_device(0)
+nvsmi = nvidia_smi.getInstance()
+
+print_used_mem("", nvsmi)
+
+with nccl_allocator.nccl_mem():
+    for i in range(nrep):
+      out = torch.randn(1024 * 1024 * 100).cuda() # >= 400 MB
+      nccl_mem.append(out)
+
+print_used_mem("after nccl alloc (+>=2400)", nvsmi) # + 2400+ MB
+
+cudart_mem = []
+for i in range(nrep):
+  out = torch.randn(1024 * 1024 * 50 ).cuda() # == 200 MB
+  cudart_mem.append(out)
+
+print_used_mem("after cudart alloc (+1200)", nvsmi)
+
+del cudart_mem
+torch.cuda.empty_cache()
+torch.cuda.empty_cache()
+print_used_mem("release cudart mem (-1200)", nvsmi) # - 1200 MB
+
+del nccl_mem
+nccl_mem2 = []
+with nccl_allocator.nccl_mem():
+    for i in range(nrep):
+      out = torch.randn(1024 * 1024 * 100).cuda() # >= 400 MB
+      nccl_mem2.append(out)
+print_used_mem("reuse nccl cache (same)", nvsmi) # + 0 MB
+del nccl_mem2
+torch.cuda.empty_cache()
+print_used_mem("release nccl_mem (-2400)", nvsmi) # - 2400 MB
+
+torch.cuda.empty_cache()

--- a/apex/contrib/examples/nccl_allocator/change_cuda_allocator.py
+++ b/apex/contrib/examples/nccl_allocator/change_cuda_allocator.py
@@ -1,0 +1,14 @@
+import torch
+import apex.contrib.nccl_allocator as nccl_allocator
+
+nccl_allocator.init()
+nrep = 6
+with nccl_allocator.nccl_mem():
+    for i in range(nrep):
+      out = torch.randn(1024).cuda()
+
+for i in range(nrep):
+  out = torch.randn(1024).cuda()
+
+torch.cuda.empty_cache()
+torch.cuda.empty_cache()

--- a/apex/contrib/examples/nccl_allocator/toy_ddp.py
+++ b/apex/contrib/examples/nccl_allocator/toy_ddp.py
@@ -1,0 +1,53 @@
+import os
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+import apex.contrib.nccl_allocator as nccl_allocator
+
+assert os.getenv("WORLD_SIZE") is not None, "Please use: torchrun --nproc-per-node=8 toy_ddp.py"
+
+class ToyModel(nn.Module):
+    def __init__(self):
+        super(ToyModel, self).__init__()
+        self.net1 = nn.Linear(10, 10)
+        self.relu = nn.ReLU()
+        self.net2 = nn.Linear(10, 5)
+
+    def forward(self, x):
+        return self.net2(self.relu(self.net1(x)))
+
+
+rank = int(os.getenv("RANK"))
+local_rank = int(os.getenv("LOCAL_RANK"))
+world_size = int(os.getenv("WORLD_SIZE"))
+
+nccl_allocator.init()
+
+torch.cuda.set_device(local_rank)
+dist.init_process_group(backend="nccl")
+
+device = torch.device("cuda", local_rank)
+model = ToyModel().to(device)
+ddp_model = DDP(model, device_ids=[rank])
+loss_fn = nn.MSELoss()
+optimizer = optim.SGD(ddp_model.parameters(), lr=0.001)
+
+data_ptrs = []
+with nccl_allocator.nccl_mem():
+    for param in ddp_model.parameters():
+        param.grad = torch.empty_like(param)
+        data_ptrs.append(param.grad.data_ptr())
+
+for _ in range(10):
+    optimizer.zero_grad(set_to_none=False)
+    outputs = ddp_model(torch.randn(20, 10))
+    labels = torch.randn(20, 5).to(rank)
+    loss_fn(outputs, labels).backward()
+    optimizer.step()
+
+for data_ptr, param in zip(data_ptrs, ddp_model.parameters()):
+    assert(data_ptr == param.grad.data_ptr())
+dist.destroy_process_group()

--- a/apex/contrib/nccl_allocator/README.md
+++ b/apex/contrib/nccl_allocator/README.md
@@ -1,0 +1,43 @@
+## General information
+
+`nccl_allocator` is a module that enables `ncclMemAlloc` to be used within PyTorch for faster NCCL NVLS collective communications.
+It is mainly based on `CUDAPluggableAllocator`.
+The context manager `nccl_allocator.nccl_mem(enabled=True)` is used as a switch between `cudaMalloc` and `ncclMemAlloc` (if `enabled=True` it will use `cudaMalloc`).
+
+
+### Example usage:
+
+Here is a minimalistic example:
+
+```
+import os
+import torch
+import torch.distributed as dist
+import apex.contrib.nccl_allocator as nccl_allocator
+
+rank = int(os.getenv("RANK"))
+local_rank = int(os.getenv("LOCAL_RANK"))
+world_size = int(os.getenv("WORLD_SIZE"))
+
+nccl_allocator.init()
+
+torch.cuda.set_device(local_rank)
+dist.init_process_group(backend="nccl")
+
+with nccl_allocator.nccl_mem():
+	a = torch.ones(1024 * 1024 * 2, device="cuda")
+dist.all_reduce(a)
+
+torch.cuda.synchronize()
+```
+
+Please visit `apex/contrib/examples/nccl_allocator` for more examples.
+
+
+### IMPORTANT
+
+There are several strict requirements:
+- PyTorch must include PR [#112850](https://github.com/pytorch/pytorch/pull/112850)
+- NCCL v2.19.4 and newer
+- NCCL NVLS requires CUDA Driver 530 and newer (tested on 535)
+

--- a/apex/contrib/nccl_allocator/README.md
+++ b/apex/contrib/nccl_allocator/README.md
@@ -1,9 +1,10 @@
 ## General information
 
-`nccl_allocator` is a module that enables `ncclMemAlloc` to be used within PyTorch for faster NCCL NVLS collective communications.
+`nccl_allocator` is a module that enables `ncclMemAlloc`[^1] to be used within PyTorch for faster NCCL NVLS collective communications.
 It is mainly based on `CUDAPluggableAllocator`.
 The context manager `nccl_allocator.nccl_mem(enabled=True)` is used as a switch between `cudaMalloc` and `ncclMemAlloc` (if `enabled=True` it will use `cudaMalloc`).
 
+[^1]: https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html
 
 ### Example usage:
 

--- a/apex/contrib/nccl_allocator/__init__.py
+++ b/apex/contrib/nccl_allocator/__init__.py
@@ -1,0 +1,1 @@
+from .nccl_allocator import *

--- a/apex/contrib/nccl_allocator/nccl_allocator.py
+++ b/apex/contrib/nccl_allocator/nccl_allocator.py
@@ -1,0 +1,27 @@
+import os
+import torch
+from torch.cuda.memory import _CUDAAllocator
+import nccl_allocator
+
+from contextlib import contextmanager
+
+__all__ = ["init", "nccl_mem"]
+
+class NCCLAllocator(_CUDAAllocator):
+    def __init__(self):
+        self._allocator = nccl_allocator._cuda_create_managed_allocator()
+
+def init():
+    os.environ["NCCL_NVLS_ENABLE"] = "1"
+    os.environ["TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK"] = "1"
+    allocator = NCCLAllocator()
+    nccl_allocator._cuda_change_current_allocator(allocator.allocator())
+
+def use_nccl_mem(flag: bool) -> None:
+    nccl_allocator._use_nccl_mem(flag)
+
+@contextmanager
+def nccl_mem(flag: bool = True) -> None:
+    use_nccl_mem(flag)
+    yield
+    use_nccl_mem(False)

--- a/setup.py
+++ b/setup.py
@@ -819,6 +819,33 @@ if "--fused_conv_bias_relu" in sys.argv:
         )
 
 
+if "--nccl_allocator" in sys.argv:
+    sys.argv.remove("--nccl_allocator")
+    raise_if_cuda_home_none("--nccl_allocator")
+    _nccl_version_getter = load(
+        name="_nccl_version_getter",
+        sources=["apex/contrib/csrc/nccl_p2p/nccl_version.cpp", "apex/contrib/csrc/nccl_p2p/nccl_version_check.cu"],
+    )
+    _available_nccl_version = _nccl_version_getter.get_nccl_version()
+    if _available_nccl_version >= (2, 19):
+        ext_modules.append(
+            CUDAExtension(
+                name="nccl_allocator",
+                sources=[
+                    "apex/contrib/csrc/nccl_allocator/python_bindings.cpp",
+                    "apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp",
+                ],
+                include_dirs=[os.path.join(this_dir, "apex/apex/contrib/csrc/nccl_allocator")],
+                libraries=["nccl"],
+                extra_compile_args={"cxx": ["-O3"] + version_dependent_macros + generator_flag},
+            )
+        )
+    else:
+        warnings.warn(
+            f"Skip `--nccl_allocator` as it requires NCCL 2.19 or later, but {_available_nccl_version[0]}.{_available_nccl_version[1]}"
+        )
+
+
 if "--gpu_direct_storage" in sys.argv:
     sys.argv.remove("--gpu_direct_storage")
     raise_if_cuda_home_none("--gpu_direct_storage")


### PR DESCRIPTION
This PR adds a custom pluggable allocator that conditionally utilizes `ncclMemAlloc` and `ncclMemFree` for memory allocations. The buffers allocated through `ncclMemAlloc` can later be registered in NCCL Process Group for a subsequent utilization in Zero-Copy collective communications.

cc @crcrpar @eqy 