### PR TITLE
Avoid importing apex transformer automatically 

### DIFF
--- a/apex/__init__.py
+++ b/apex/__init__.py
@@ -24,7 +24,6 @@ from . import fp16_utils
 # load time) the error message is timely and visible.
 from . import optimizers
 from . import normalization
-from . import transformer
 
 
 # Logging utilities for apex.transformer module

--- a/apex/transformer/utils.py
+++ b/apex/transformer/utils.py
@@ -8,6 +8,7 @@ from apex.transformer import parallel_state
 # The following 4 lines are for backward comparability with
 # older PyTorch.
 if "all_gather_into_tensor" not in dir(torch.distributed):
+    assert torch.distributed.is_available(), "PyTorch Distributed is Not available or Disabled."
     torch.distributed.all_gather_into_tensor = torch.distributed._all_gather_base
 
 def ensure_divisibility(numerator, denominator):


### PR DESCRIPTION
and make error message more clear when apex.transformer is explicitly called on unsupported platform

In some configurations, pytorch may not be built with distributed support. 
So we avoid the auto import of transformer, which calls torch.distributed api explicitly. 
