### PR TITLE
fixup concats for grouped convolution

### DIFF
--- a/apex/contrib/sparsity/permutation_lib.py
+++ b/apex/contrib/sparsity/permutation_lib.py
@@ -1200,6 +1200,7 @@ class Permutation:
                     fx_graph[child]['C_param'] = children_GCD_param
                     
                 old_children_GCD = cls.__group_data['sibling_group_C_params'][sibling_group_id]
+                children_GCD_param = str(np.gcd.reduce([int(children_GCD_param), int(old_children_GCD)]))
                 cls.__group_data['sibling_group_C_params'][sibling_group_id] = children_GCD_param
 
                 # fixup this node's dimensions


### PR DESCRIPTION
The function "fixup_concats" in file "apex\contrib\sparsity\permutation_lib.py " does not take grouped convolution into account, it will get a wrong  "sibling_group_C_params" for a node which is grouped convolution or which has grouped convolution siblings.  So this pull request adds a line code to deal with above issue.