### PR TITLE
deprecate uses of torch.cuda.amp

### DIFF
--- a/apex/contrib/conv_bias_relu/conv_bias_relu.py
+++ b/apex/contrib/conv_bias_relu/conv_bias_relu.py
@@ -11,7 +11,7 @@ check_cudnn_version_and_warn(__name__, 8400)
 
 class ConvBiasReLU_(torch.autograd.Function):
     @staticmethod
-    @torch.amp.custom_fwd('cuda', cast_inputs=torch.half)
+    @torch.amp.custom_fwd(cast_inputs=torch.half, device_type='cuda')
     def forward(ctx, x, weight, bias, padding, stride):
         outputs = fused_conv_bias_relu.forward([x, weight, bias], padding, stride)
         ctx.save_for_backward(x, weight, outputs[0])
@@ -21,7 +21,7 @@ class ConvBiasReLU_(torch.autograd.Function):
         return outputs[0]
 
     @staticmethod
-    @torch.amp.custom_bwd('cuda')
+    @torch.amp.custom_bwd(device_type='cuda')
     def backward(ctx, grad_output):
         bwd_args = [*ctx.saved_tensors, grad_output]
         padding = ctx.padding
@@ -33,7 +33,7 @@ class ConvBiasReLU_(torch.autograd.Function):
 
 class ConvBiasMaskReLU_(torch.autograd.Function):
     @staticmethod
-    @torch.amp.custom_fwd('cuda', cast_inputs=torch.half)
+    @torch.amp.custom_fwd(cast_inputs=torch.half, device_type='cuda')
     def forward(ctx, x, weight, bias, mask, padding, stride):
         outputs = fused_conv_bias_relu.forward_mask([x, weight, bias, mask], padding, stride)
         ctx.save_for_backward(x, weight, outputs[0])
@@ -43,7 +43,7 @@ class ConvBiasMaskReLU_(torch.autograd.Function):
         return outputs[0]
 
     @staticmethod
-    @torch.amp.custom_bwd('cuda')
+    @torch.amp.custom_bwd(device_type='cuda')
     def backward(ctx, grad_output):
         bwd_args = [*ctx.saved_tensors, grad_output]
         padding = ctx.padding
@@ -55,7 +55,7 @@ class ConvBiasMaskReLU_(torch.autograd.Function):
 
 class ConvBias_(torch.autograd.Function):
     @staticmethod
-    @torch.amp.custom_fwd('cuda', cast_inputs=torch.half)
+    @torch.amp.custom_fwd(cast_inputs=torch.half, device_type='cuda')
     def forward(ctx, x, weight, bias, padding, stride):
         outputs = fused_conv_bias_relu.forward_no_relu([x, weight, bias], padding, stride)
         ctx.save_for_backward(x, weight)
@@ -65,7 +65,7 @@ class ConvBias_(torch.autograd.Function):
         return outputs[0]
 
     @staticmethod
-    @torch.amp.custom_bwd('cuda')
+    @torch.amp.custom_bwd(device_type='cuda')
     def backward(ctx, grad_output):
         bwd_args = [*ctx.saved_tensors, grad_output]
         padding = ctx.padding
@@ -77,7 +77,7 @@ class ConvBias_(torch.autograd.Function):
 
 class ConvFrozenScaleBiasReLU_(torch.autograd.Function):
     @staticmethod
-    @torch.amp.custom_fwd('cuda', cast_inputs=torch.half)
+    @torch.amp.custom_fwd(cast_inputs=torch.half, device_type='cuda')
     def forward(ctx, x, weight, scale, bias, padding, stride):
         output = fused_conv_bias_relu.forward_cscale_cbias_relu([x, weight, scale, bias], padding, stride)
         ctx.save_for_backward(x, weight, scale, output)
@@ -87,7 +87,7 @@ class ConvFrozenScaleBiasReLU_(torch.autograd.Function):
         return output
 
     @staticmethod
-    @torch.amp.custom_bwd('cuda')
+    @torch.amp.custom_bwd(device_type='cuda')
     def backward(ctx, grad_output):
         bwd_args = [*ctx.saved_tensors, grad_output]
         padding = ctx.padding

--- a/apex/contrib/conv_bias_relu/conv_bias_relu.py
+++ b/apex/contrib/conv_bias_relu/conv_bias_relu.py
@@ -11,7 +11,7 @@ check_cudnn_version_and_warn(__name__, 8400)
 
 class ConvBiasReLU_(torch.autograd.Function):
     @staticmethod
-    @torch.cuda.amp.custom_fwd(cast_inputs=torch.half)
+    @torch.amp.custom_fwd('cuda', cast_inputs=torch.half)
     def forward(ctx, x, weight, bias, padding, stride):
         outputs = fused_conv_bias_relu.forward([x, weight, bias], padding, stride)
         ctx.save_for_backward(x, weight, outputs[0])
@@ -21,7 +21,7 @@ class ConvBiasReLU_(torch.autograd.Function):
         return outputs[0]
 
     @staticmethod
-    @torch.cuda.amp.custom_bwd
+    @torch.amp.custom_bwd('cuda')
     def backward(ctx, grad_output):
         bwd_args = [*ctx.saved_tensors, grad_output]
         padding = ctx.padding
@@ -33,7 +33,7 @@ class ConvBiasReLU_(torch.autograd.Function):
 
 class ConvBiasMaskReLU_(torch.autograd.Function):
     @staticmethod
-    @torch.cuda.amp.custom_fwd(cast_inputs=torch.half)
+    @torch.amp.custom_fwd('cuda', cast_inputs=torch.half)
     def forward(ctx, x, weight, bias, mask, padding, stride):
         outputs = fused_conv_bias_relu.forward_mask([x, weight, bias, mask], padding, stride)
         ctx.save_for_backward(x, weight, outputs[0])
@@ -43,7 +43,7 @@ class ConvBiasMaskReLU_(torch.autograd.Function):
         return outputs[0]
 
     @staticmethod
-    @torch.cuda.amp.custom_bwd
+    @torch.amp.custom_bwd('cuda')
     def backward(ctx, grad_output):
         bwd_args = [*ctx.saved_tensors, grad_output]
         padding = ctx.padding
@@ -55,7 +55,7 @@ class ConvBiasMaskReLU_(torch.autograd.Function):
 
 class ConvBias_(torch.autograd.Function):
     @staticmethod
-    @torch.cuda.amp.custom_fwd(cast_inputs=torch.half)
+    @torch.amp.custom_fwd('cuda', cast_inputs=torch.half)
     def forward(ctx, x, weight, bias, padding, stride):
         outputs = fused_conv_bias_relu.forward_no_relu([x, weight, bias], padding, stride)
         ctx.save_for_backward(x, weight)
@@ -65,7 +65,7 @@ class ConvBias_(torch.autograd.Function):
         return outputs[0]
 
     @staticmethod
-    @torch.cuda.amp.custom_bwd
+    @torch.amp.custom_bwd('cuda')
     def backward(ctx, grad_output):
         bwd_args = [*ctx.saved_tensors, grad_output]
         padding = ctx.padding
@@ -77,7 +77,7 @@ class ConvBias_(torch.autograd.Function):
 
 class ConvFrozenScaleBiasReLU_(torch.autograd.Function):
     @staticmethod
-    @torch.cuda.amp.custom_fwd(cast_inputs=torch.half)
+    @torch.amp.custom_fwd('cuda', cast_inputs=torch.half)
     def forward(ctx, x, weight, scale, bias, padding, stride):
         output = fused_conv_bias_relu.forward_cscale_cbias_relu([x, weight, scale, bias], padding, stride)
         ctx.save_for_backward(x, weight, scale, output)
@@ -87,7 +87,7 @@ class ConvFrozenScaleBiasReLU_(torch.autograd.Function):
         return output
 
     @staticmethod
-    @torch.cuda.amp.custom_bwd
+    @torch.amp.custom_bwd('cuda')
     def backward(ctx, grad_output):
         bwd_args = [*ctx.saved_tensors, grad_output]
         padding = ctx.padding

--- a/apex/contrib/layer_norm/layer_norm.py
+++ b/apex/contrib/layer_norm/layer_norm.py
@@ -36,7 +36,7 @@ class FastLayerNormFN(torch.autograd.Function):
 
 def _fast_layer_norm(x, weight, bias, epsilon, memory_efficient):
     args = _cast_if_autocast_enabled(x, weight, bias, epsilon, memory_efficient)
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         return FastLayerNormFN.apply(*args)
 
 

--- a/apex/contrib/test/conv_bias_relu/test_conv_bias_relu.py
+++ b/apex/contrib/test/conv_bias_relu/test_conv_bias_relu.py
@@ -64,11 +64,11 @@ class FusedDenseTest(unittest.TestCase):
 								    self.conv_stride, self.conv_pad))
 
     def test_conv_bias_relu(self):
-        with torch.cuda.amp.autocast(dtype=torch.half):
+        with torch.amp.autocast('cuda', dtype=torch.half):
             out = ConvBiasReLU(self.x, self.conv1.weight, self.conv1.bias.reshape(1, -1, 1, 1), self.conv_pad, self.conv_stride)
             loss = (out.float()**2).sum() / out.numel()
         loss.backward()
-        with torch.cuda.amp.autocast(dtype=torch.half):
+        with torch.amp.autocast('cuda', dtype=torch.half):
             out_ = F.relu(self.conv1_(self.x_))
             loss_ = (out_**2).sum() / out_.numel()
         loss_.backward()
@@ -79,12 +79,12 @@ class FusedDenseTest(unittest.TestCase):
         torch.testing.assert_close(self.x_.grad, self.x.grad, atol=1e-3, rtol=1e-3, equal_nan=True)
 
     def test_conv_bias(self):
-        with torch.cuda.amp.autocast(dtype=torch.half):
+        with torch.amp.autocast('cuda', dtype=torch.half):
             out = ConvBias(self.x, self.conv1.weight, self.conv1.bias.reshape(1, -1, 1, 1), self.conv_pad, self.conv_stride)
             loss = (out.float()**2).sum() / out.numel()
         loss.backward()
 
-        with torch.cuda.amp.autocast(dtype=torch.half):
+        with torch.amp.autocast('cuda', dtype=torch.half):
             out_ = self.conv1_(self.x_)
             loss_ = (out_**2).sum() / out_.numel()
         loss_.backward()
@@ -95,11 +95,11 @@ class FusedDenseTest(unittest.TestCase):
         torch.testing.assert_close(self.x_.grad, self.x.grad, atol=1e-3, rtol=1e-3, equal_nan=True)
 
     def test_conv_bias_mask_relu(self):
-        with torch.cuda.amp.autocast(dtype=torch.half):
+        with torch.amp.autocast('cuda', dtype=torch.half):
             out = ConvBiasMaskReLU(self.x, self.conv1.weight, self.conv1.bias.reshape(1, -1, 1, 1), self.mask, self.conv_pad, self.conv_stride)
             loss = (out.float()**2).sum() / out.numel()
         loss.backward()
-        with torch.cuda.amp.autocast(dtype=torch.half):
+        with torch.amp.autocast('cuda', dtype=torch.half):
             out_ = F.relu(self.conv1_(self.x_) * self.mask_)
             loss_ = (out_**2).sum() / out_.numel()
         loss_.backward()
@@ -110,11 +110,11 @@ class FusedDenseTest(unittest.TestCase):
         torch.testing.assert_close(self.x_.grad, self.x.grad, atol=1e-3, rtol=1e-3, equal_nan=True)
 
     def test_conv_frozen_scale_bias_relu(self):
-        with torch.cuda.amp.autocast(dtype=torch.half):
+        with torch.amp.autocast('cuda', dtype=torch.half):
             out = ConvFrozenScaleBiasReLU(self.x, self.conv2.weight, self.scale, self.bias, self.conv_pad, self.conv_stride)
             loss = (out.float()**2).sum() / out.numel()
         loss.backward()
-        with torch.cuda.amp.autocast(dtype=torch.half):
+        with torch.amp.autocast('cuda', dtype=torch.half):
             out_ = F.relu(self.conv2_(self.x_) * self.scale_ + self.bias_)
             loss_ = (out_**2).sum() / out_.numel()
         loss_.backward()

--- a/apex/contrib/test/cudnn_gbn/test_cudnn_gbn_with_two_gpus.py
+++ b/apex/contrib/test/cudnn_gbn/test_cudnn_gbn_with_two_gpus.py
@@ -115,7 +115,7 @@ class TestCudnnGBN(NcclDistributedTestBase):
             ref_grad_out = grad_out.half().clone().detach()
             grad_out = grad_out[self.rank : self.rank + 1, ...].half().clone().detach()
 
-        with torch.cuda.amp.autocast():
+        with torch.amp.autocast('cuda'):
             out = cudnn_gbn_model(input)
             ref_out = ref_model(ref_input.half())
         out.backward(grad_out)

--- a/apex/contrib/test/layer_norm/test_fast_layer_norm.py
+++ b/apex/contrib/test/layer_norm/test_fast_layer_norm.py
@@ -271,7 +271,7 @@ class TestFastLayerNorm(unittest.TestCase):
         for dtype in autocast_dtypes:
             layer_norm.zero_grad(set_to_none=True)
             with self.subTest(f"autocast_dtype={dtype}"):
-                with torch.cuda.amp.autocast(enabled=True, dtype=dtype):
+                with torch.amp.autocast('cuda', enabled=True, dtype=dtype):
                     out = layer_norm(input)
                     self.assertEqual(dtype, out.dtype)
                 grad = torch.randn_like(out)

--- a/apex/contrib/test/optimizers/test_dist_adam.py
+++ b/apex/contrib/test/optimizers/test_dist_adam.py
@@ -416,8 +416,8 @@ class TestDistributedFusedAdam(NcclDistributedTestBase):
             backoff_factor=0.876,
             growth_interval=1,
         )
-        ref_scaler =  torch.cuda.amp.GradScaler(**grad_scaler_args)
-        dist_scaler =  torch.cuda.amp.GradScaler(**grad_scaler_args)
+        ref_scaler =  torch.amp.GradScaler('cuda', **grad_scaler_args)
+        dist_scaler =  torch.amp.GradScaler('cuda', **grad_scaler_args)
 
         # Training steps with pre-determined gradients
         xs = [3, 1, 4, 1, 5, 9]

--- a/apex/fused_dense/fused_dense.py
+++ b/apex/fused_dense/fused_dense.py
@@ -48,17 +48,17 @@ class FusedDenseGeluDenseFunc(torch.autograd.Function):
 
 def _fused_dense(input, weight, bias):
     args = _cast_if_autocast_enabled(input, weight, bias)
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         return FusedDenseFunc.apply(*args)
 
 def _dense_no_bias(input, weight):
     args = _cast_if_autocast_enabled(input, weight)
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         return DenseNoBiasFunc.apply(*args)
 
 def _fused_dense_gelu_dense(input, weight1, bias1, weight2, bias2):
     args = _cast_if_autocast_enabled(input, weight1, bias1, weight2, bias2)
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         return FusedDenseGeluDenseFunc.apply(*args)
 
 class FusedDense(nn.Module):

--- a/apex/normalization/fused_layer_norm.py
+++ b/apex/normalization/fused_layer_norm.py
@@ -193,37 +193,37 @@ class FusedRMSNormFunction(torch.autograd.Function):
 
 def fused_layer_norm_affine(input, weight, bias, normalized_shape, eps=1e-6, memory_efficient=False):
     args = _cast_if_autocast_enabled(input, weight, bias, normalized_shape, eps, memory_efficient)
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         return FusedLayerNormAffineFunction.apply(*args)
 
 
 def fused_layer_norm(input, normalized_shape, eps=1e-6, memory_efficient=False):
     args = _cast_if_autocast_enabled(input, normalized_shape, eps, memory_efficient)
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         return FusedLayerNormFunction.apply(*args)
 
 
 def mixed_dtype_fused_layer_norm_affine(input, weight, bias, normalized_shape, eps=1e-6, memory_efficient=False):
     args = _cast_if_autocast_enabled(input, weight, bias, normalized_shape, eps, memory_efficient)
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         return FusedLayerNormAffineMixedDtypesFunction.apply(*args)
 
 
 def fused_rms_norm_affine(input, weight, normalized_shape, eps=1e-6, memory_efficient=False):
     args = _cast_if_autocast_enabled(input, weight, normalized_shape, eps, memory_efficient)
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         return FusedRMSNormAffineFunction.apply(*args)
 
 
 def fused_rms_norm(input, normalized_shape, eps=1e-6, memory_efficient=False):
     args = _cast_if_autocast_enabled(input, normalized_shape, eps, memory_efficient)
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         return FusedRMSNormFunction.apply(*args)
 
 
 def mixed_dtype_fused_rms_norm_affine(input, weight, normalized_shape, eps=1e-6, memory_efficient=False):
     args = _cast_if_autocast_enabled(input, weight, normalized_shape, eps, memory_efficient)
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         return FusedRMSNormAffineMixedDtypesFunction.apply(*args)
 
 

--- a/apex/transformer/functional/fused_softmax.py
+++ b/apex/transformer/functional/fused_softmax.py
@@ -56,7 +56,7 @@ def scaled_upper_triang_masked_softmax(inputs, _, scale):
     # Reshaping input to 3D tensor (attn_batches, sq, sk)
     inputs = inputs.view(-1, sq, sk)
     args = _cast_if_autocast_enabled(inputs, scale)
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         probs = ScaledUpperTriangMaskedSoftmax.apply(*args)
     return probs.view(b, np, sq, sk)
 
@@ -95,11 +95,11 @@ def scaled_masked_softmax(inputs, mask, scale):
     # input is 4D tensor (b, np, sq, sk)
     if mask is not None:
         args = _cast_if_autocast_enabled(inputs, mask, scale)
-        with torch.cuda.amp.autocast(enabled=False):
+        with torch.amp.autocast('cuda', enabled=False):
             return ScaledMaskedSoftmax.apply(*args)
     else:
         args = _cast_if_autocast_enabled(inputs, scale)
-        with torch.cuda.amp.autocast(enabled=False):
+        with torch.amp.autocast('cuda', enabled=False):
             return ScaledSoftmax.apply(*args)
 
 
@@ -126,7 +126,7 @@ class GenericScaledMaskedSoftmax(torch.autograd.Function):
 def generic_scaled_masked_softmax(inputs, mask, scale):
     # input is 4D tensor (b, np, sq, sk)
     args = _cast_if_autocast_enabled(inputs, mask, scale)
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         return GenericScaledMaskedSoftmax.apply(*args)
 
 

--- a/apex/transformer/pipeline_parallel/schedules/common.py
+++ b/apex/transformer/pipeline_parallel/schedules/common.py
@@ -294,7 +294,7 @@ def forward_step(
     input_tensor = [inp.get() if isinstance(inp, FutureTensor) else inp for inp in input_tensor]
 
     unwrapped_model.set_input_tensor(input_tensor)
-    with torch.cuda.amp.autocast(
+    with torch.amp.autocast('cuda', 
         enabled=not disable_autocast and dtype in (torch.half, torch.bfloat16),
         dtype=dtype,
     ):

--- a/apex/transformer/tensor_parallel/layers.py
+++ b/apex/transformer/tensor_parallel/layers.py
@@ -453,7 +453,7 @@ def linear_with_grad_accumulation_and_async_allreduce(
         async_grad_allreduce,
         sequence_parallel_enabled,
     )
-    with torch.cuda.amp.autocast(enabled=False):
+    with torch.amp.autocast('cuda', enabled=False):
         return LinearWithGradAccumulationAndAsyncCommunication.apply(*args)
 
 

--- a/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
+++ b/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
@@ -223,7 +223,7 @@ class TestFusedLayerNorm(common_utils.TestCase):
         native_x, fused_x = _prep_inputs(batch_size, normalized_shape, dtype)
 
         expected = native(native_x)
-        with torch.cuda.amp.autocast(dtype=dtype):
+        with torch.amp.autocast('cuda', dtype=dtype):
             actual = fused(fused_x)
         tols = {'rtol': None, 'atol': None} if dtype == torch.half else bf16_fwd_thresholds
         # original tests used torch.testing.assert_allclose, which disables dtype checking by default. 
@@ -261,7 +261,7 @@ class TestFusedLayerNorm(common_utils.TestCase):
         native_x, fused_x = _prep_inputs(batch_size, normalized_shape, dtype)
 
         expected = native(native_x.cpu())
-        with torch.cuda.amp.autocast(dtype=dtype):
+        with torch.amp.autocast('cuda', dtype=dtype):
             actual = fused(fused_x)
         tols = {'rtol': None, 'atol': None} if dtype == torch.half else bf16_fwd_thresholds
         torch.testing.assert_close(actual, expected.detach().clone().cuda(), **tols, check_dtype=False)

--- a/tests/L0/run_optimizers/test_adam.py
+++ b/tests/L0/run_optimizers/test_adam.py
@@ -66,8 +66,8 @@ class AdamTest(unittest.TestCase):
     def testGradScaler(self):
         params_ = [p for p in self.model_.parameters() if p.requires_grad]
         optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=False)
-        scaler = torch.cuda.amp.GradScaler(enabled=True)
-        scaler_ = torch.cuda.amp.GradScaler(enabled=True)
+        scaler = torch.amp.GradScaler('cuda', enabled=True)
+        scaler_ = torch.amp.GradScaler('cuda', enabled=True)
 
         for i in range(100):
             x = torch.rand([32, 1, 28, 28]).cuda().to(memory_format=torch.channels_last)
@@ -76,7 +76,7 @@ class AdamTest(unittest.TestCase):
             gt_ = gt.clone()
 
             # Reference
-            with torch.cuda.amp.autocast(enabled=True):
+            with torch.amp.autocast('cuda', enabled=True):
                 y = self.model(x)
                 loss = ((gt - y) ** 2).mean()
 
@@ -85,7 +85,7 @@ class AdamTest(unittest.TestCase):
             scaler.update()
             
             # DUT
-            with torch.cuda.amp.autocast(enabled=True):
+            with torch.amp.autocast('cuda', enabled=True):
                 y = self.model_(x)
                 loss_ = ((gt_ - y) ** 2).mean()
 
@@ -109,8 +109,8 @@ class AdamTest(unittest.TestCase):
     def testGradScalerCapturable(self):
         params_ = [p for p in self.model_.parameters() if p.requires_grad]
         optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=True)
-        scaler = torch.cuda.amp.GradScaler(enabled=True)
-        scaler_ = torch.cuda.amp.GradScaler(enabled=True)
+        scaler = torch.amp.GradScaler('cuda', enabled=True)
+        scaler_ = torch.amp.GradScaler('cuda', enabled=True)
 
         for i in range(100):
             x = torch.rand([32, 1, 28, 28]).cuda().to(memory_format=torch.channels_last)
@@ -119,7 +119,7 @@ class AdamTest(unittest.TestCase):
             gt_ = gt.clone()
 
             # Reference
-            with torch.cuda.amp.autocast(enabled=True):
+            with torch.amp.autocast('cuda', enabled=True):
                 y = self.model(x)
                 loss = ((gt - y) ** 2).mean()
 
@@ -128,7 +128,7 @@ class AdamTest(unittest.TestCase):
             scaler.update()
             
             # DUT
-            with torch.cuda.amp.autocast(enabled=True):
+            with torch.amp.autocast('cuda', enabled=True):
                 y = self.model_(x)
                 loss_ = ((gt_ - y) ** 2).mean()
 
@@ -156,8 +156,8 @@ class AdamTest(unittest.TestCase):
                 m.half()
         params_ = [p for p in self.model_.parameters() if p.requires_grad]
         optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=True, master_weights=True)
-        scaler = torch.cuda.amp.GradScaler(enabled=True)
-        scaler_ = torch.cuda.amp.GradScaler(enabled=True)
+        scaler = torch.amp.GradScaler('cuda', enabled=True)
+        scaler_ = torch.amp.GradScaler('cuda', enabled=True)
 
         for i in range(100):
             x = torch.rand([32, 1, 28, 28]).cuda().to(memory_format=torch.channels_last)
@@ -166,7 +166,7 @@ class AdamTest(unittest.TestCase):
             gt_ = gt.clone()
 
             # Reference
-            with torch.cuda.amp.autocast(enabled=True):
+            with torch.amp.autocast('cuda', enabled=True):
                 y = self.model(x)
                 loss = ((gt - y) ** 2).mean()
 
@@ -175,7 +175,7 @@ class AdamTest(unittest.TestCase):
             scaler.update()
 
             # DUT
-            with torch.cuda.amp.autocast(enabled=True):
+            with torch.amp.autocast('cuda', enabled=True):
                 y = self.model_(x)
                 loss_ = ((gt_ - y) ** 2).mean()
 

--- a/tests/L0/run_transformer/test_fused_softmax.py
+++ b/tests/L0/run_transformer/test_fused_softmax.py
@@ -128,7 +128,7 @@ class TestFusedScaleMaskSoftmax(common_utils.TestCase):
             mask = torch.randint(0, 2, (4, 1, 24, 24)).bool().cuda()
 
             expected = torch_fn(attention_scores_1, mask)
-            with torch.cuda.amp.autocast(dtype=dtype):
+            with torch.amp.autocast('cuda', dtype=dtype):
                 actual = fused_fn(attention_scores_0, mask)
                 self.assertEqual(actual.dtype, dtype, msg=msg)
             self.assertEqual(actual, expected, msg=msg)
@@ -206,7 +206,7 @@ class TestFusedScaleMaskSoftmax(common_utils.TestCase):
             mask = None
 
             expected = torch_fn(attention_scores_1, mask)
-            with torch.cuda.amp.autocast(dtype=dtype):
+            with torch.amp.autocast('cuda', dtype=dtype):
                 actual = fused_fn(attention_scores_0, mask)
                 self.assertEqual(actual.dtype, dtype, msg=msg)
             self.assertEqual(actual, expected, msg=msg)
@@ -294,7 +294,7 @@ class TestFusedScaleMaskSoftmax(common_utils.TestCase):
                 .unsqueeze(0)
             )
 
-            with torch.cuda.amp.autocast(dtype=dtype):
+            with torch.amp.autocast('cuda', dtype=dtype):
                 actual = fused_fn(attn_weights_0, total_mask)
                 self.assertEqual(actual.dtype, dtype, msg=msg)
             expected = torch_fn(attn_weights_1, total_mask)

--- a/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
+++ b/tests/L0/run_transformer/test_pipeline_parallel_fwd_bwd.py
@@ -144,7 +144,7 @@ class PipelineParallelForwardBackwardTestBase:
             dtype_options, self.deallocate_options,
         ):
             grad_scaler = (
-                torch.cuda.amp.GradScaler(init_scale=4.0)
+                torch.amp.GradScaler('cuda', init_scale=4.0)
                 if dtype == torch.half
                 else None
             )

--- a/tests/L1/transformer/pipeline_parallel_fwd_bwd_ucc_async.py
+++ b/tests/L1/transformer/pipeline_parallel_fwd_bwd_ucc_async.py
@@ -89,7 +89,7 @@ class UccPipelineParallelForwardBackwardProf(UccDistributedTestBase):
             dtype_options, self.deallocate_options,
         ):
             grad_scaler = (
-                torch.cuda.amp.GradScaler(init_scale=4.0)
+                torch.amp.GradScaler('cuda', init_scale=4.0)
                 if dtype == torch.half
                 else None
             )


### PR DESCRIPTION
Deprecates usage of torch.cuda.amp across apex codebase