### PR TITLE
NCCLAllocator: Fix build failure

### DIFF
--- a/apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp
+++ b/apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp
@@ -324,7 +324,7 @@ c10::cuda::CUDACachingAllocator::SnapshotInfo NCCLAllocator::snapshot() {
   return result;
 }
 
-c10::cuda::CUDACachingAllocator::ShareableHandle CUDAPluggableAllocator::
+c10::cuda::CUDACachingAllocator::ShareableHandle NCCLAllocator::
     shareIpcHandle(void* ptr) {
   TORCH_CHECK(
       false,

--- a/apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp
+++ b/apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp
@@ -440,4 +440,12 @@ void NCCLAllocator::copy_data(void* dest, const void* src, std::size_t count)
       cudaMemcpy(dest, src, count, cudaMemcpyKind::cudaMemcpyDeviceToDevice));
 }
 
+void NCCLAllocator::enable() {
+
+}
+
+bool NCCLAllocator::isEnabled() {
+  return true;
+}
+
 } // namespace nccl_allocator::cuda

--- a/apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp
+++ b/apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp
@@ -324,6 +324,14 @@ c10::cuda::CUDACachingAllocator::SnapshotInfo NCCLAllocator::snapshot() {
   return result;
 }
 
+c10::cuda::CUDACachingAllocator::ShareableHandle CUDAPluggableAllocator::
+    shareIpcHandle(void* ptr) {
+  TORCH_CHECK(
+      false,
+      "CUDAPluggableAllocator does not yet support shareIPcHandle. "
+      "If you need it, please file an issue describing your use case.");
+}
+
 std::shared_ptr<void> NCCLAllocator::getIpcDevPtr(std::string handle) {
   TORCH_CHECK(
       false,

--- a/apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp
+++ b/apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp
@@ -440,11 +440,9 @@ void NCCLAllocator::copy_data(void* dest, const void* src, std::size_t count)
       cudaMemcpy(dest, src, count, cudaMemcpyKind::cudaMemcpyDeviceToDevice));
 }
 
-void NCCLAllocator::enable() {
+void NCCLAllocator::enable() {}
 
-}
-
-bool NCCLAllocator::isEnabled() {
+bool NCCLAllocator::isEnabled() const {
   return true;
 }
 

--- a/apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp
+++ b/apex/contrib/csrc/nccl_allocator/NCCLAllocator.cpp
@@ -440,7 +440,7 @@ void NCCLAllocator::copy_data(void* dest, const void* src, std::size_t count)
       cudaMemcpy(dest, src, count, cudaMemcpyKind::cudaMemcpyDeviceToDevice));
 }
 
-void NCCLAllocator::enable() {}
+void NCCLAllocator::enable(bool) {}
 
 bool NCCLAllocator::isEnabled() const {
   return true;

--- a/apex/contrib/csrc/nccl_allocator/NCCLAllocator.h
+++ b/apex/contrib/csrc/nccl_allocator/NCCLAllocator.h
@@ -87,7 +87,7 @@ struct NCCLAllocator
       bool p2p_enabled) override;
   std::string name() override;
   void copy_data(void* dest, const void* src, std::size_t count) const;
-  void enable(bool value) override;
+  void enable(bool) override;
   bool isEnabled() const override;
 
  protected:

--- a/apex/contrib/csrc/nccl_allocator/NCCLAllocator.h
+++ b/apex/contrib/csrc/nccl_allocator/NCCLAllocator.h
@@ -87,6 +87,8 @@ struct NCCLAllocator
       bool p2p_enabled) override;
   std::string name() override;
   void copy_data(void* dest, const void* src, std::size_t count) const;
+  void enable(bool value) override;
+  bool isEnabled() const override;
 
  protected:
   std::function<void(int)> init_fn_;

--- a/apex/contrib/csrc/nccl_allocator/NCCLAllocator.h
+++ b/apex/contrib/csrc/nccl_allocator/NCCLAllocator.h
@@ -59,6 +59,8 @@ struct NCCLAllocator
       override;
   void releasePool(c10::DeviceIndex device, c10::cuda::MempoolId_t mempool_id) override;
   std::shared_ptr<void> getIpcDevPtr(std::string handle) override;
+  c10::cuda::CUDACachingAllocator::ShareableHandle shareIpcHandle(
+      void*) override;
   void recordHistory(
       bool enabled,
       c10::cuda::CUDACachingAllocator::CreateContextFn context_recorder,


### PR DESCRIPTION
This PR adds `shareIpcHandle` to `NCCLAllocator` to satisfy its base class definition `CUDAAllocator` which has recently changed (https://github.com/pytorch/pytorch/pull/130888). 

cc @xwang233 