### PR TITLE
Avoid unnecessary NCCL collective coalescing in distributed optimizer

### DIFF
--- a/apex/contrib/optimizers/distributed_fused_adam.py
+++ b/apex/contrib/optimizers/distributed_fused_adam.py
@@ -1966,7 +1966,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         comm_stream.wait_stream(main_stream)
 
         # Reduce-scatter over distributed process group
-        if self.distributed_size > 1:
+        if buckets and self.distributed_size > 1:
             with torch.cuda.stream(comm_stream):
                 group = self.distributed_process_group
                 with _coalescing_manager(group, self.device, async_ops=True) as cm:
@@ -1986,7 +1986,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
                 cm.wait()
 
         # All-reduce over redundant process group
-        if self.redundant_size > 1:
+        if buckets and self.redundant_size > 1:
             with torch.cuda.stream(comm_stream):
                 group = self.redundant_process_group
                 with _coalescing_manager(group, self.device, async_ops=True) as cm:
@@ -2117,7 +2117,7 @@ class DistributedFusedAdam(torch.optim.Optimizer):
         comm_stream.wait_stream(main_stream)
 
         # All-gather over distributed process group
-        if self.distributed_size > 1:
+        if buckets and self.distributed_size > 1:
             with torch.cuda.stream(comm_stream):
                 group = self.distributed_process_group
                 with _coalescing_manager(group, self.device, async_ops=True) as cm:


### PR DESCRIPTION
I've been experiencing some data corruption in distributed optimizer checkpoints because PyTorch is not properly synchronizing the NCCL stream with the main CUDA stream. All indications point to a bug in PyTorch's infrastructure for coalesced NCCL calls and I've isolated it down to cases where we enter [PyTorch's `_coalescing_manager`](https://github.com/pytorch/pytorch/blob/156ca01e51f766b1b069c5c6f3d57112a5c8f9ff/torch/distributed/distributed_c10d.py#L2244) but do not perform any NCCL collectives. The debugger suggests that `_coalescing_manager` sets [this flag](https://github.com/pytorch/pytorch/blob/156ca01e51f766b1b069c5c6f3d57112a5c8f9ff/torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp#L1103) when it enters the context and fails to unset it, resulting in weird behavior in later NCCL calls. I haven't fully bottomed out this bug, but this PR fixes the issue for me.