### PR TITLE
[GroupNorm] Skip GroupNorm tests on A16, A2  etc.,

### DIFF
--- a/apex/contrib/test/group_norm/test_group_norm.py
+++ b/apex/contrib/test/group_norm/test_group_norm.py
@@ -27,7 +27,7 @@ try:
 except ImportError as e:
     SKIP_TEST = e
 
-
+@unittest.skipIf(torch.cuda.get_device_properties().multi_processor_count < 16, "GroupNorm is unsupported on low SM count devices")
 @unittest.skipIf(SKIP_TEST, f"{SKIP_TEST}")
 class GroupNormTest(unittest.TestCase):
 


### PR DESCRIPTION
The grid dim calculations (among others) seem to make assumptions about the minimal number of SMs on a device e.g.,
```
grid.y = std::min(max_blocks_per_grid / blocks_per_slice, params.groups * params.n);
```

This assumption causes `grid.y` to be set to `0` on certain devices with low SM count (10) e.g., A16, A2. Disabling this test for now.

CC @alpha0422 @crcrpar @ptrblck 