### PR TITLE
[NCCL] Updated fix for premature destruction of ProcessGroupNCCL

### DIFF
--- a/apex/transformer/testing/distributed_test_base.py
+++ b/apex/transformer/testing/distributed_test_base.py
@@ -41,6 +41,11 @@ class DistributedTestBase(common_distributed.MultiProcessTestCase):
     def init_method(self):
         return f"{common_utils.FILE_SCHEMA}{self.file_name}"
 
+    @property
+    def destroy_pg_upon_exit(self) -> bool:
+        # Overriding base test class: do not auto destroy PG upon exit.
+        return False
+
     @classmethod
     def _run(cls, rank, test_name, file_name, pipe, **kwargs):
         self = cls(test_name)
@@ -67,7 +72,7 @@ class DistributedTestBase(common_distributed.MultiProcessTestCase):
         torch.cuda.set_device(self.rank % torch.cuda.device_count())
 
         dist.barrier()
-        self.run_test(test_name, pipe, destroy_process_group=False)
+        self.run_test(test_name, pipe)
         dist.barrier()
 
         dist.destroy_process_group()


### PR DESCRIPTION
This PR updates the previous fix as unfortunately the fix in https://github.com/NVIDIA/apex/pull/1859 was broken by another update to upstream PyTorch which changed the interface for avoiding automatic PG destruction https://github.com/pytorch/pytorch/commit/66476617bf82b4b8ae76b7143fd319a7e456756c

CC @nWEIdia 
