### PR TITLE
Traceable RMSNorm part 2: non affine fused rms norm

### DIFF
--- a/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
+++ b/tests/L0/run_fused_layer_norm/test_fused_layer_norm.py
@@ -310,11 +310,12 @@ class TestFusedLayerNorm(common_utils.TestCase):
         self._verify_export(fused, fused_x)
         self._verify_export(fused_m, fused_x)
 
-    def test_compile_fused_rms_norm(self):
+    @common_utils.parametrize("elementwise_affine", (True, False))
+    def test_compile_fused_rms_norm(self, elementwise_affine):
         batch_size = 16
         normalized_shape = [32, 16]
         eager_mod = FusedRMSNorm(
-            normalized_shape=normalized_shape, elementwise_affine=True
+            normalized_shape=normalized_shape, elementwise_affine=elementwise_affine
         ).cuda()
         compiled_mod = torch.compile(fullgraph=True)(eager_mod)
         input_shape = [batch_size] + normalized_shape


### PR DESCRIPTION
Make non affine ```FusedRMSNorm``` can be traced through by TorchDynamo to provide a better composibility with torch.compile.

cc @crcrpar 