### PR TITLE
[FutureWarning] Resolving warnings caused by deprecated function usage.

### DIFF
--- a/apex/contrib/cudnn_gbn/batch_norm.py
+++ b/apex/contrib/cudnn_gbn/batch_norm.py
@@ -4,12 +4,12 @@ from torch.nn import functional as F
 from torch import Tensor
 import peer_memory_cuda as pm
 import cudnn_gbn_lib
-from torch.cuda.amp import custom_fwd, custom_bwd
+from torch.amp import custom_fwd, custom_bwd
 
 class _GroupBatchNorm2d(torch.autograd.Function):
 
     @staticmethod
-    @custom_fwd
+    @custom_fwd(device_type='cuda')
     def forward(ctx, input, weight, bias, running_mean, running_variance,
                 minibatch_mean, minibatch_inv_var, momentum, eps, group_size, group_rank, fwd_buffers, bwd_buffers):
         ctx.save_for_backward(input, weight, minibatch_mean, minibatch_inv_var)
@@ -21,7 +21,7 @@ class _GroupBatchNorm2d(torch.autograd.Function):
                                      minibatch_mean, minibatch_inv_var, momentum, eps, group_size, group_rank, fwd_buffers)
 
     @staticmethod
-    @custom_bwd
+    @custom_bwd(device_type='cuda')
     def backward(ctx, grad_output):
         x, scale, minibatch_mean, minibatch_inv_var = ctx.saved_variables
         eps = ctx.eps


### PR DESCRIPTION
This PR provides a fix for the following warnings:
```
/usr/local/lib/python3.12/dist-packages/apex/contrib/cudnn_gbn/batch_norm.py:12: FutureWarning: 
`torch.cuda.amp.custom_fwd(args...)` is deprecated. Please use `torch.amp.custom_fwd(args..., device_type='cuda')` instead.
  @custom_fwd
/usr/local/lib/python3.12/dist-packages/apex/contrib/cudnn_gbn/batch_norm.py:24: FutureWarning: 
`torch.cuda.amp.custom_bwd(args...)` is deprecated. Please use `torch.amp.custom_bwd(args..., device_type='cuda')` instead.
  @custom_bwd
```