### PR TITLE
build extensions in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,7 @@ pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation -
 
 To reduce the build time of APEX, parallel building can be enhanced via
 ```bash
-export NVCC_APPEND_FLAGS="--threads 4"
-pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext --cuda_ext --parallel 8" ./
+NVCC_APPEND_FLAGS="--threads 4" pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext --cuda_ext --parallel 8" ./
 ```
 When CPU cores or memory are limited, the `--parallel` option is generally preferred over `--threads`. See [pull#1882](https://github.com/NVIDIA/apex/pull/1882) for more details.
 

--- a/README.md
+++ b/README.md
@@ -130,10 +130,17 @@ CUDA and C++ extensions via
 git clone https://github.com/NVIDIA/apex
 cd apex
 # if pip >= 23.1 (ref: https://pip.pypa.io/en/stable/news/#v23-1) which supports multiple `--config-settings` with the same key... 
-pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext --cuda_ext --parallel 4" ./
+pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext" --config-settings "--build-option=--cuda_ext" ./
 # otherwise
 pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 ```
+
+To reduce the build time of APEX, parallel building can be enhanced via
+```bash
+export NVCC_APPEND_FLAGS="--threads 4"
+pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext --cuda_ext --parallel 8" ./
+```
+When CPU cores or memory are limited, the `--parallel` option is generally preferred over `--threads`. See [pull#1882](https://github.com/NVIDIA/apex/pull/1882) for more details.
 
 APEX also supports a Python-only build via
 ```bash

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ CUDA and C++ extensions via
 git clone https://github.com/NVIDIA/apex
 cd apex
 # if pip >= 23.1 (ref: https://pip.pypa.io/en/stable/news/#v23-1) which supports multiple `--config-settings` with the same key... 
-pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext" --config-settings "--build-option=--cuda_ext" ./
+pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext --cuda_ext --parallel 4" ./
 # otherwise
 pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 ```

--- a/setup.py
+++ b/setup.py
@@ -860,7 +860,7 @@ if "--gpu_direct_storage" in sys.argv:
     )
 
 
-# Patch because `setup.py bdist_wheel` does not accept the `parallel` option
+# Patch because `setup.py bdist_wheel` and `setup.py develop` do not support the `parallel` option
 parallel = None
 if "--parallel" in sys.argv:
     idx = sys.argv.index("--parallel")
@@ -873,6 +873,11 @@ if "--parallel" in sys.argv:
 class BuildExtensionSeparateDir(BuildExtension):
     build_extension_patch_lock = threading.Lock()
     thread_ext_name_map = {}
+
+    def finalize_options(self):
+        if parallel is not None:
+            self.parallel = parallel
+        super().finalize_options()
 
     def build_extension(self, ext):
         with self.build_extension_patch_lock:
@@ -902,6 +907,6 @@ setup(
     install_requires=["packaging>20.6"],
     description="PyTorch Extensions written by NVIDIA",
     ext_modules=ext_modules,
-    cmdclass={"build_ext": BuildExtensionSeparateDir.with_options(parallel=parallel)} if ext_modules else {},
+    cmdclass={"build_ext": BuildExtensionSeparateDir} if ext_modules else {},
     extras_require=extras,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import sys
 import warnings
 import os
+import threading
 import glob
 from packaging.version import parse, Version
 
@@ -859,6 +860,39 @@ if "--gpu_direct_storage" in sys.argv:
     )
 
 
+# Patch because `setup.py bdist_wheel` does not accept the `parallel` option
+parallel = None
+if "--parallel" in sys.argv:
+    idx = sys.argv.index("--parallel")
+    parallel = int(sys.argv[idx + 1])
+    sys.argv.pop(idx + 1)
+    sys.argv.pop(idx)
+
+
+# Prevent file conflicts when multiple extensions are compiled simultaneously
+class BuildExtensionSeparateDir(BuildExtension):
+    build_extension_patch_lock = threading.Lock()
+    thread_ext_name_map = {}
+
+    def build_extension(self, ext):
+        with self.build_extension_patch_lock:
+            if not getattr(self.compiler, "_compile_separate_output_dir", False):
+                compile_orig = self.compiler.compile
+
+                def compile_new(*args, **kwargs):
+                    return compile_orig(*args, **{
+                        **kwargs,
+                        "output_dir": os.path.join(
+                            kwargs["output_dir"],
+                            self.thread_ext_name_map[threading.current_thread().ident]),
+                    })
+                self.compiler.compile = compile_new
+                self.compiler._compile_separate_output_dir = True
+        self.thread_ext_name_map[threading.current_thread().ident] = ext.name
+        objects = super().build_extension(ext)
+        return objects
+
+
 setup(
     name="apex",
     version="0.1",
@@ -868,6 +902,6 @@ setup(
     install_requires=["packaging>20.6"],
     description="PyTorch Extensions written by NVIDIA",
     ext_modules=ext_modules,
-    cmdclass={"build_ext": BuildExtension} if ext_modules else {},
+    cmdclass={"build_ext": BuildExtensionSeparateDir.with_options(parallel=parallel)} if ext_modules else {},
     extras_require=extras,
 )


### PR DESCRIPTION
Previous Behaviour: extensions are built in series, despite the fact that multiple files in the same extension are compiled in parallel

This pull request adds support for parallel building of multiple extensions. Benchmark results show:

| CPU | Build Parameters | Build Time |
|--|--|--|
| AMD EPYC 24-Core (48 threads) | Original (No optimizations) | 45m29.243s |
| AMD EPYC 24-Core (48 threads) | `--parallel 4` | 12m55.243s |
| AMD EPYC 24-Core (48 threads) | `--parallel 16` | 6m47.962s |
| AMD EPYC 24-Core (48 threads) | `NVCC_APPEND_FLAGS="--threads 8"` | 19m23.878s |
| AMD EPYC 24-Core (48 threads) | `--parallel 4`, `NVCC_APPEND_FLAGS="--threads 8"` | 7m33.151s |
| AMD EPYC 24-Core (48 threads) | `--parallel 16`, `NVCC_APPEND_FLAGS="--threads 8"` | 5m58.479s |
| Intel Xeon 112-Core (224 threads) | `NVCC_APPEND_FLAGS="--threads 8"` | 14m9.081s |
| Intel Xeon 112-Core (224 threads) | `--parallel 16`, `NVCC_APPEND_FLAGS="--threads 8"` | 2m24.733s |

Memory usage is shown below. The "mem used" values are obtained using the `free` command, and background memory usage is included.

![image](https://github.com/user-attachments/assets/ded16974-de12-40bf-b854-ff8faa005878)

| Build Parameters | Peak mem used |
|--|--|
| Original | 24.11 GiB |
| `--parallel 16` | 58.25 GiB |
| `NVCC_APPEND_FLAGS="--threads 8"` | 91.39 GiB |
| `--parallel 16`, `NVCC_APPEND_FLAGS="--threads 8"` | 150.96 GiB |


Image: nvcr.io/nvidia/pytorch:25.01-py3
(or other images with the same CUDA version and TORCH_CUDA_ARCH_LISTS)

cmdline: `time NVCC_APPEND_FLAGS="--threads 8" pip wheel -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext --distributed_adam --distributed_lamb --cuda_ext --permutation_search --bnp --xentropy --focal_loss --group_norm --index_mul_2d --deprecated_fused_adam --deprecated_fused_lamb --fast_layer_norm --fmha --fast_multihead_attn --transducer --cudnn_gbn --peer_memory --nccl_p2p --fast_bottleneck --fused_conv_bias_relu --nccl_allocator --gpu_direct_storage --parallel 16" ./`