### PR TITLE
adjust threshold for test_encdec_multihead_attn.py

### DIFF
--- a/apex/contrib/test/multihead_attn/test_self_multihead_attn.py
+++ b/apex/contrib/test/multihead_attn/test_self_multihead_attn.py
@@ -110,7 +110,7 @@ class SelfMultiheadAttnTest(unittest.TestCase):
         self.tst_inputs.backward(grads)
 
         torch.testing.assert_close(self.ref_inputs, self.tst_inputs, atol=1e-5, rtol=1e-5)
-        torch.testing.assert_close(ref_outputs, tst_outputs, atol=1e-3, rtol=1e-3)
+        torch.testing.assert_close(ref_outputs, tst_outputs, atol=5e-3, rtol=1e-3)
         torch.testing.assert_close(self.ref_inputs.grad, self.tst_inputs.grad, atol=1e-3, rtol=1e-3)
 
     def test_self_multihead_attn_pad_mask(self):


### PR DESCRIPTION
Adjust threshold due to failure in nvidia internal qa testing on RTX 6000.