### PR TITLE
Graph Compiler For Multi-stream

### DIFF
--- a/apex/contrib/torchsched/__init__.py
+++ b/apex/contrib/torchsched/__init__.py
@@ -1,3 +1,81 @@
-import torch
+"""Graph scheduler package."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+import torch._inductor
+from torch._dynamo import list_backends
+from torch._dynamo import register_backend
+from torch._inductor.compile_fx import compile_fx_inner
+
+from .backend import get_backend
+
+if TYPE_CHECKING:
+    from typing import Any
+    from typing import Callable
+
+    from torch._ops import OpOverload
+
+__all__ = ["get_backend", "set_default_backend"]
+
+# Register custom operators
 torch.ops.import_module("apex.contrib.torchsched.ops")
+
+
+# Register torch-sched backend
+# Same API as torch._inductor.compile_fx
+@register_backend
+def torchsched(
+    model_: torch.fx.GraphModule,
+    example_inputs_: list[torch.Tensor],
+    inner_compile: Callable[..., Any] = compile_fx_inner,
+    config_patches: dict[str, Any] | None = None,
+    decompositions: dict[OpOverload, Callable[..., Any]] | None = None,
+) -> Callable:
+    backend = get_backend(backend="torchsched", scheme="dwb")
+    return backend(model_, example_inputs_, inner_compile, config_patches, decompositions)
+
+
+_SUPPORTED_BACKENDS = list_backends()
+_DEFAULT_BACKEND = "inductor"
+__torch_compile__ = torch.compile
+
+
+def set_default_backend(backend: str) -> None:
+    """
+    Set the default backend for torch.compile.
+
+    Parameters:
+        backend (str): The backend to use as the default for torch.compile.
+    """
+    global _SUPPORTED_BACKENDS, _DEFAULT_BACKEND
+    assert backend in _SUPPORTED_BACKENDS, f"Unknown backend {backend}"
+    _DEFAULT_BACKEND = backend
+
+
+def torchsched_compile(
+    *args: object,
+    backend: str | Callable | None = None,
+    **kwargs: object,
+) -> object:
+    """
+    Wrap around the original torch.compile to support default backend.
+
+    Parameters:
+        *args (object): Positional arguments for torch.compile.
+        backend (Union[str, Callable, None]): The backend to use.
+            If None, the default backend is used.
+        **kwargs (object): Additional keyword arguments for torch.compile.
+
+    Returns:
+        object: Compiler or compiled model.
+    """
+    if backend is None:
+        backend = _DEFAULT_BACKEND
+    return __torch_compile__(*args, backend=backend, **kwargs)
+
+
+# Monkey patch torch.compile to set default backend
+torch.compile = torchsched_compile

--- a/apex/contrib/torchsched/backend.py
+++ b/apex/contrib/torchsched/backend.py
@@ -1,0 +1,326 @@
+"""Graph scheduler backend."""
+
+from __future__ import annotations
+
+import functools
+from copy import copy
+from typing import TYPE_CHECKING
+from typing import Callable
+from typing import ParamSpec
+from typing import TypeVar
+
+if TYPE_CHECKING:
+    from types import NotImplementedType
+
+import torch
+from torch import Tensor
+from torch import _TorchCompileInductorWrapper
+from torch._dynamo import lookup_backend
+from torch._inductor.codegen.common import register_backend_for_device
+from torch._inductor.codegen.cuda_combined_scheduling import CUDACombinedScheduling
+from torch._inductor.codegen.wrapper import PythonWrapperCodegen
+from torch._inductor.compile_fx import compile_fx
+from torch._inductor.compile_fx import compile_fx_inner
+from torch._inductor.decomposition import select_decomp_table
+
+import apex.contrib.torchsched.config as config
+from apex.contrib.torchsched.inductor import patch_graph_lowering
+from apex.contrib.torchsched.inductor.wrapper import MultiStreamWrapperCodegen
+from apex.contrib.torchsched.passes import pre_grad_custom_pass
+
+aten = torch.ops.aten
+prims = torch.ops.prims
+
+__all__ = ["get_backend"]
+
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def enable_multi_stream_scheduling(compile_fn: Callable[P, R]) -> Callable[P, R]:
+    assert callable(compile_fn)
+
+    @functools.wraps(compile_fn)
+    def _compile_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        register_backend_for_device("cuda", CUDACombinedScheduling, MultiStreamWrapperCodegen)
+        patch_graph_lowering(patch=True)
+
+        # torch.compile explicitly calls `write_get_raw_stream` via wrapper's class method in its
+        # lowering process to walk around the wrapper-stream LRU cache mechanism. To be compatible
+        # with this, we got to patch wrapper's class method as well.
+        _origin_write_get_raw_stream = PythonWrapperCodegen.write_get_raw_stream
+        PythonWrapperCodegen.write_get_raw_stream = MultiStreamWrapperCodegen._write_get_raw_stream
+
+        compile_results = compile_fn(*args, **kwargs)
+
+        register_backend_for_device("cuda", CUDACombinedScheduling, PythonWrapperCodegen)
+        patch_graph_lowering(patch=False)
+        PythonWrapperCodegen.write_get_raw_stream = _origin_write_get_raw_stream
+
+        return compile_results
+
+    return _compile_wrapper
+
+
+# Refer: https://github.com/pytorch/pytorch/blob/v2.6.0/torch/_inductor/decomposition.py#L213
+def convolution_backward_decomp_dwb(
+    grad_output: Tensor,
+    input: Tensor,
+    weight: Tensor,
+    bias_sizes: tuple[int, ...],
+    stride: tuple[int, ...],
+    padding: tuple[int, ...],
+    dilation: tuple[int, ...],
+    transposed: bool,
+    output_padding: tuple[int, ...],
+    groups: int,
+    output_mask: tuple[bool, bool, bool],
+) -> tuple[Tensor, Tensor, Tensor] | NotImplementedType:
+    """Decomposite convolution bprop using the dgrad/wgrad/bgrad scheme.
+
+    Args:
+        grad_output (Tensor): The gradient w.r.t output.
+        input (Tensor): The input tensor.
+        weight (Tensor): The weight tensor.
+        bias_sizes (Tuple[int, ...]): The sizes of the bias tensor.
+        stride (Tuple[int, ...]): The stride of the convolution.
+        padding (Tuple[int, ...]): The padding of the convolution.
+        dilation (Tuple[int, ...]): The dilation of the convolution.
+        transposed (bool): Whether the convolution is transposed.
+        output_padding (Tuple[int, ...]): The output padding for the transposed convolution.
+        groups (int): The number of groups for the convolution.
+        output_mask (Tuple[bool, bool, bool]): A mask indicating which gradients to compute.
+
+    Returns:
+        Union[Tuple[Tensor, Tensor, Tensor], NotImplemented]: A tuple containing the
+            gradients of the input, weight, and bias, or NotImplemented if the
+            conditions are not met.
+    """
+    if not output_mask[2] or grad_output.device.type != "cuda":
+        return NotImplemented
+    grad_inp, _, _ = aten.convolution_backward(
+        grad_output,
+        input,
+        weight,
+        bias_sizes,
+        stride,
+        padding,
+        dilation,
+        transposed,
+        output_padding,
+        groups,
+        [output_mask[0], False, False],
+    )
+    _, grad_weight, _ = aten.convolution_backward(
+        grad_output,
+        input,
+        weight,
+        bias_sizes,
+        stride,
+        padding,
+        dilation,
+        transposed,
+        output_padding,
+        groups,
+        [False, output_mask[1], False],
+    )
+    grad_bias = aten.sum(grad_output, [0] + list(range(2, grad_output.dim())))
+    return (grad_inp, grad_weight, grad_bias)
+
+
+def convolution_backward_decomp_wbd(
+    grad_output: Tensor,
+    input: Tensor,
+    weight: Tensor,
+    bias_sizes: tuple[int, ...],
+    stride: tuple[int, ...],
+    padding: tuple[int, ...],
+    dilation: tuple[int, ...],
+    transposed: bool,
+    output_padding: tuple[int, ...],
+    groups: int,
+    output_mask: tuple[bool, bool, bool],
+) -> tuple[Tensor, Tensor, Tensor] | NotImplementedType:
+    """Decomposite convolution bprop using the wgrad/bgrad/dgrad scheme.
+
+    Args:
+        grad_output (Tensor): The gradient w.r.t output.
+        input (Tensor): The input tensor.
+        weight (Tensor): The weight tensor.
+        bias_sizes (Tuple[int, ...]): The sizes of the bias tensor.
+        stride (Tuple[int, ...]): The stride of the convolution.
+        padding (Tuple[int, ...]): The padding of the convolution.
+        dilation (Tuple[int, ...]): The dilation of the convolution.
+        transposed (bool): Whether the convolution is transposed.
+        output_padding (Tuple[int, ...]): The output padding for the transposed convolution.
+        groups (int): The number of groups for the convolution.
+        output_mask (Tuple[bool, bool, bool]): A mask indicating which gradients to compute.
+
+    Returns:
+        Union[Tuple[Tensor, Tensor, Tensor], NotImplemented]: A tuple containing the
+            gradients of the input, weight, and bias, or NotImplemented if the
+            conditions are not met.
+    """
+    if not output_mask[2] or grad_output.device.type != "cuda":
+        return NotImplemented
+    _, grad_weight, _ = aten.convolution_backward(
+        grad_output,
+        input,
+        weight,
+        bias_sizes,
+        stride,
+        padding,
+        dilation,
+        transposed,
+        output_padding,
+        groups,
+        [False, output_mask[1], False],
+    )
+    grad_bias = aten.sum(grad_output, [0] + list(range(2, grad_output.dim())))
+    grad_inp, _, _ = aten.convolution_backward(
+        grad_output,
+        input,
+        weight,
+        bias_sizes,
+        stride,
+        padding,
+        dilation,
+        transposed,
+        output_padding,
+        groups,
+        [output_mask[0], False, False],
+    )
+    return (grad_inp, grad_weight, grad_bias)
+
+
+class DecompositionsWrapper(_TorchCompileInductorWrapper):
+    """A wrapper class for handling decompositions in model compilation.
+
+    This class extends the `_TorchCompileInductorWrapper` to include additional
+    decompositions for model compilation.
+
+    Args:
+        mode (str): The mode for the wrapper.
+        options (Optional[Dict]): Additional options for the wrapper.
+        dynamic (bool): Whether the wrapper is dynamic.
+        decompositions (Dict): A dictionary of decompositions to use.
+
+    Attributes:
+        decompositions (Dict): The decompositions used by the wrapper.
+    """
+
+    def __init__(
+        self,
+        mode: str,
+        options: dict | None,
+        dynamic: bool,
+        decompositions: dict,
+    ) -> None:
+        """Initialize the DecompositionsWrapper."""
+        super().__init__(mode, options, dynamic)
+        self.decompositions = decompositions
+        # Force skip the type checking in self.apply_options() since default values are None type.
+        self.config.update(
+            {
+                "pre_grad_custom_pass": (
+                    pre_grad_custom_pass if config.enable_pre_grad_pass else None
+                ),
+            },
+        )
+
+    def __eq__(self, rhs: object) -> bool:
+        """Check equality with another DecompositionsWrapper.
+
+        Args:
+            rhs (object): The other object to compare with.
+
+        Returns:
+            bool: True if the wrappers are equal, False otherwise.
+        """
+        eq = (
+            isinstance(rhs, DecompositionsWrapper)
+            and super().__eq__(rhs)
+            and rhs.decompositions == self.decompositions
+        )
+        return eq
+
+    def __call__(
+        self,
+        model_: torch.nn.Module,
+        inputs_: list,
+        *args: object,
+        **kwargs: object,
+    ) -> Callable:
+        """Compiles the model with the given inputs and decompositions.
+
+        Args:
+            model_ (torch.nn.Module): The model to compile.
+            inputs_ (list): The inputs to the model.
+            args (object): Positional argument.
+            kwargs (object): Keyword argument.
+
+        Returns:
+            Callable: The compiled model.
+        """
+        # Modifications to compilation process should be isolated between each compilations.
+        decompositions = copy(select_decomp_table())
+        decompositions.update(self.decompositions)
+        return compile_fx(
+            model_,
+            inputs_,
+            inner_compile=enable_multi_stream_scheduling(compile_fx_inner),
+            config_patches=self.config,
+            decompositions=decompositions,
+        )
+
+
+def get_backend(
+    backend: str = "torch",
+    scheme: str = "dwb",
+) -> Callable | DecompositionsWrapper:
+    """Get the graph scheduler backend for model compilation.
+
+    This function returns the appropriate backend for model compilation based on
+    the specified parameters.
+
+    Args:
+        backend (str, optional): The backend to use. Defaults to "torch".
+        scheme (str, optional): The decomposition scheme to use. Defaults to "dwb".
+
+    Returns:
+        Union[Callable, DecompositionsWrapper]: The backend for model compilation.
+
+    Raises:
+        Exception: If an unknown scheme is specified.
+    """
+    if backend not in ("torch", "torchsched"):
+        raise ValueError(f"Unknown compilation {backend=}")
+    if scheme not in ("dwb", "wbd"):
+        raise ValueError(f"Invalid {scheme=}, use scheme=dwb or wbd instead")
+
+    if backend == "torch":
+        return lookup_backend("inductor")
+
+    if scheme == "dwb":
+        return DecompositionsWrapper(
+            mode="default",
+            # TODO(@davidli): Elegantly solve cross-stream buffer reusing conflicts.
+            options={"allow_buffer_reuse": False},
+            dynamic=False,
+            decompositions={
+                aten.convolution_backward.default: convolution_backward_decomp_dwb,
+            },
+        )
+    elif scheme == "wbd":
+        return DecompositionsWrapper(
+            mode="default",
+            options={"allow_buffer_reuse": False},
+            dynamic=False,
+            decompositions={
+                aten.convolution_backward.default: convolution_backward_decomp_wbd,
+            },
+        )
+    else:
+        # To please mypy
+        raise ValueError(f"Invalid {scheme=}, use scheme=dwb or wbd instead")

--- a/apex/contrib/torchsched/config.py
+++ b/apex/contrib/torchsched/config.py
@@ -1,9 +1,21 @@
-"""Configurations for graph scheduler."""""
+"""Configurations for graph scheduler."""
 
+import os
 import sys
+
+# Debug info and dump grpahs
+debug = os.getenv("TORCH_SCHED_DEBUG", "0") == "1"
+
+# Toggle pre_grad_pass for various pattern matches
+enable_pre_grad_pass = False
 
 # Pre grad pass patterns
 pre_grad_pass_options: list[str] = ["cudnn_layer_norm"]
+
+# Number of CUDA streams used for multi-stream scheduling.
+# The first stream will be critical path stream, operators on non-critical path will be
+# scheduled to other streams in a round-robin way.
+num_streams = int(os.getenv("TORCH_SCHED_NUM_STREAMS", "8"))
 
 from torch.utils._config_module import install_config_module  # noqa: E402
 

--- a/apex/contrib/torchsched/inductor/__init__.py
+++ b/apex/contrib/torchsched/inductor/__init__.py
@@ -1,0 +1,5 @@
+"""Scheduling abstractions on PyTorch Inductor level."""
+
+from apex.contrib.torchsched.inductor.graph import patch_graph_lowering
+
+__all__ = ["patch_graph_lowering"]

--- a/apex/contrib/torchsched/inductor/_utils.py
+++ b/apex/contrib/torchsched/inductor/_utils.py
@@ -1,6 +1,23 @@
 from __future__ import annotations
 
 import functools
+import queue
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+import torch
+
+__all__ = [
+    "DEFAULT_STREAM",
+    "DEFAULT_STREAM_IDX",
+    "ENTRANCE_EVENT",
+    "EVENT_NAME_TEMPLATE",
+    "STREAM_NAME_TEMPLATE",
+    "CUDAStreamPool",
+    "get_cuda_stream_pool",
+]
 
 DEFAULT_STREAM: str = "default_stream"
 DEFAULT_STREAM_IDX: int = 0
@@ -21,3 +38,93 @@ def get_stream_name(stream_idx: int) -> str:
         return DEFAULT_STREAM
     else:
         return STREAM_NAME_TEMPLATE.format(stream_idx=stream_idx)
+
+
+class CUDAStreamPool:
+    """A pool managing reusable CUDA streams to optimize GPU operations.
+
+    Attributes:
+        pool_size (int): The maximum number of CUDA streams managed by the pool.
+        stream_queue (queue.Queue): Queue holding the available CUDA streams.
+    """
+
+    def __init__(self, device: int | None = None, pool_size: int = 8) -> None:
+        """Initializesthe CUDAStreamPool instance.
+
+        Args:
+            device (Optional[int], optional): The CUDA device ID.
+                Defaults to None (current device).
+            pool_size (int, optional): The maximum number of CUDA streams in the pool.
+                Defaults to 8.
+        """
+        self.pool_size: int = pool_size
+        self.stream_queue: queue.Queue[torch.cuda.Stream] = queue.Queue(maxsize=pool_size)
+
+        for _ in range(pool_size):
+            stream = torch.cuda.Stream(device=device)
+            self.stream_queue.put(stream)
+
+    def acquire(self) -> torch.cuda.Stream:
+        """Acquire a CUDA stream from the pool.
+
+        Returns:
+            torch.cuda.Stream: A CUDA stream object from the pool.
+        """
+        return self.stream_queue.get()
+
+    def release(self, stream: torch.cuda.Stream | None) -> None:
+        """Return a CUDA stream back to the pool.
+
+        Args:
+            stream (Optional[torch.cuda.Stream]): The CUDA stream to return to the pool.
+        """
+        if stream is not None:
+            self.stream_queue.put(stream)
+
+    def __enter__(self) -> torch.cuda.Stream:
+        """Enters the runtime context and acquires a CUDA stream.
+
+        Returns:
+            torch.cuda.Stream: The acquired CUDA stream.
+        """
+        self.stream = self.acquire()
+        self.stream.__enter__()
+        return self.stream
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit the runtime context and releases the acquired CUDA stream.
+
+        Args:
+            exc_type (type[BaseException] | None): Exception type, if raised.
+            exc_val (BaseException | None): Exception instance, if raised.
+            exc_tb (TracebackType | None): Traceback object, if raised.
+        """
+        self.stream.__exit__(exc_type, exc_val, exc_tb)
+        self.release(self.stream)
+
+
+_cuda_stream_pool: CUDAStreamPool | None = None
+
+
+def get_cuda_stream_pool(device: int | None = None, pool_size: int = 32) -> CUDAStreamPool:
+    """Retrieve a global CUDA stream pool, creating it if necessary.
+
+    This function ensures that only one CUDAStreamPool instance exists globally.
+
+    Args:
+        device (Optional[int], optional): The CUDA device ID to initialize the pool on.
+            Defaults to None (current device).
+        pool_size (int, optional): The number of streams in the pool. Defaults to 32.
+
+    Returns:
+        CUDAStreamPool: The global CUDA stream pool instance.
+    """
+    global _cuda_stream_pool
+    if _cuda_stream_pool is None:
+        _cuda_stream_pool = CUDAStreamPool(device=device, pool_size=pool_size)
+    return _cuda_stream_pool

--- a/apex/contrib/torchsched/inductor/_utils.py
+++ b/apex/contrib/torchsched/inductor/_utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import functools
+
+DEFAULT_STREAM: str = "default_stream"
+DEFAULT_STREAM_IDX: int = 0
+ENTRANCE_EVENT: str = "event0"
+EVENT_NAME_TEMPLATE: str = "event{event_idx:d}"
+STREAM_NAME_TEMPLATE: str = "stream{stream_idx:d}"
+
+
+@functools.lru_cache()
+def get_stream_name(stream_idx: int) -> str:
+    """Generate CUDA Stream name from stream index number.
+
+    Args:
+        stream_idx: Non-negative index number. 0 refers to the default stream, others refer to side
+            streams.
+    """
+    if stream_idx == 0:
+        return DEFAULT_STREAM
+    else:
+        return STREAM_NAME_TEMPLATE.format(stream_idx=stream_idx)

--- a/apex/contrib/torchsched/inductor/event.py
+++ b/apex/contrib/torchsched/inductor/event.py
@@ -1,0 +1,182 @@
+"""CUDA Event abstractions used in Inductor multi-stream scheduling.
+
+Attributes:
+    ENTRANCE_EVENT: Name of the first event on the default CUDA Stream that got recorded before all
+        kernels.
+    EVENT_NAME_TEMPLATE: Python string template to generate event names. Can be used as:
+
+            idx: int = ...
+            event = EVENT_NAME_TEMPLATE.format(event_idx=idx)
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+import itertools
+
+from torch._inductor.codegen.wrapper import IndentedBuffer
+from torch._inductor.codegen.wrapper import WrapperLine
+
+from apex.contrib.torchsched.inductor._utils import ENTRANCE_EVENT
+from apex.contrib.torchsched.inductor._utils import EVENT_NAME_TEMPLATE
+from apex.contrib.torchsched.inductor._utils import get_stream_name
+
+
+@functools.total_ordering
+@dataclasses.dataclass
+class CudaEventSym:
+    """Symbolic representation of CUDA Events in the Inductor scheduling phase.
+
+    Args:
+        factory: The CUDAEventFactory that generate this event.
+        idx: Indexing number assigned in chronological order during scheduling.
+        ref_count: Reference count of this event instance.
+        materialized_event: The actual CUDA Event name that will be used in the final PyTorch
+            program. Only symbolic event with reference count larger than one will be materialized.
+
+    Note:
+        In most cases this class should not be used standalone. Use
+        `CUDAEventFactory.get_sym_event()` to instantiate one.
+    """
+
+    factory: CudaEventFactory
+    idx: int
+    ref_count: int = 0
+    materialized_event: str | None = None
+
+    def __lt__(self, rhs: CudaEventSym) -> bool:
+        """Whether the current event is generated before the rhs event."""
+        return self.idx < rhs.idx and self.factory is rhs.factory
+
+    def __eq__(self, rhs: object) -> bool:
+        """Whether the current event is identical to the rhs event."""
+        if not isinstance(rhs, CudaEventSym):
+            return NotImplemented
+        return self.idx == rhs.idx and self.factory is rhs.factory
+
+    def __str__(self) -> str:
+        """Represent this symbolic event in string."""
+        ret = f"{self.__class__.__name__} (idx={self.idx}"
+        if self.ref_count:
+            ret += f", ref_count={self.ref_count}"
+        if self.materialized_event:
+            ret += f", materialized to `{self.materialized_event}`"
+        ret += ")"
+        return ret
+
+    def __hash__(self) -> int:
+        """Hash this symbolic event."""
+        return hash(f"{id(self.factory)=},{self.idx=}")
+
+    def record(self, stream_idx: int) -> _CudaEventRecordLine:
+        """Record this event on a given stream.
+
+        Args:
+            stream_idx: The index of the stream that this event will record on.
+
+        Returns:
+            An internal data structure that depicts stream <-> event dependency.
+
+        Note:
+            This method doesn't necessarily generate a event recording in the final program.
+            Instead it records the dependence between the stream and the current event. Whether
+            or not this event recording show up in the final program depends on the reference
+            count of the current event. I.e., if this event is never waited for by the later
+            code, this event recording will not be code-generated.
+        """
+        stream = get_stream_name(stream_idx)
+        return _CudaEventRecordLine(self, stream)
+
+    def wait(self, stream_idx: int) -> _CudaEventWaitLine:
+        """Wait for this event to complete by a given stream.
+
+        Args:
+            stream_idx: The index of the stream that will be waiting for this event to complete.
+
+        Returns:
+            An internal data structure that depicts stream <-> event dependency.
+
+        Note:
+            This method doesn't necessarily generate a event waiting in the final program. Instead
+            it records the dependence between the stream and the current event and also increase
+            the reference count of this event. If an event object has called this method, it is
+            guaranteed to be generated in the final program.
+        """
+        self.ref_count += 1
+        stream = get_stream_name(stream_idx)
+        return _CudaEventWaitLine(self, stream)
+
+
+@dataclasses.dataclass
+class _CudaEventRecordLine(WrapperLine):
+
+    event: CudaEventSym
+    stream: str
+
+    def codegen(self, code: IndentedBuffer) -> None:
+        assert 0 <= self.event.ref_count
+        assert self.event.materialized_event is None
+        if self.event.ref_count:
+            self.event.materialized_event = self.event.factory.get_materialized_event(code)
+            code.writeline(f"{self.event.materialized_event}.record({self.stream})")
+
+
+@dataclasses.dataclass
+class _CudaEventWaitLine(WrapperLine):
+
+    event: CudaEventSym
+    stream: str
+
+    def codegen(self, code: IndentedBuffer) -> None:
+        assert 0 < self.event.ref_count
+        assert self.event.materialized_event is not None
+        code.writeline(f"{self.event.materialized_event}.wait({self.stream})")
+        self.event.ref_count -= 1
+        if self.event.ref_count == 0:
+            self.event.factory.deposit_materialized_event(self.event.materialized_event)
+            self.event.materialized_event = None
+            code.writeline(f"# End lifecycle of {self.event}")
+
+
+class CudaEventFactory:
+    """A factory that managements CUDA event creations and materializations.
+
+    This factory maintains internal states to ensure that created cuda events get monotonically
+    increasing indices as compilation goes along. It also maintains a pool of materialized cuda
+    events that symbolic events can reuse.
+    """
+
+    def __init__(self) -> None:
+        """Initialize a event factory."""
+        self.symbolic_event_idx: itertools.count = itertools.count(start=1)
+        self.materialized_event_idx: itertools.count = itertools.count(start=1)
+        self.available_materialized_events: set[str] = set()
+        self._entrance_event: CudaEventSym | None = None
+
+    def get_entrance_event(self) -> CudaEventSym:
+        """Return the cuda event that corresponding to compute graph entering."""
+        if self._entrance_event is None:
+            self._entrance_event = CudaEventSym(factory=self, idx=0)
+            # Code-gen for entrance event is almost hard-coded in device guard enter so the
+            # materialization is slightly different here.
+            self._entrance_event.materialized_event = ENTRANCE_EVENT
+        return self._entrance_event
+
+    def get_sym_event(self) -> CudaEventSym:
+        """Allocate a symbolic cuda event."""
+        return CudaEventSym(factory=self, idx=next(self.symbolic_event_idx))
+
+    def get_materialized_event(self, code: IndentedBuffer) -> str:
+        """Allocate or reuse a materialized cuda event."""
+        if self.available_materialized_events:
+            return self.available_materialized_events.pop()
+        else:
+            event = EVENT_NAME_TEMPLATE.format(event_idx=next(self.materialized_event_idx))
+            code.writeline(f"{event} = torch.cuda.Event()")
+            return event
+
+    def deposit_materialized_event(self, event: str) -> None:
+        """Give back a materialized cuda event when the corresponding sym event ends lifecycle."""
+        assert event not in self.available_materialized_events
+        self.available_materialized_events.add(event)

--- a/apex/contrib/torchsched/inductor/graph.py
+++ b/apex/contrib/torchsched/inductor/graph.py
@@ -1,0 +1,59 @@
+"""Scheduling abstractions on PyTorch Inductor GraphLowering level."""
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING
+
+from torch._inductor.graph import GraphLowering
+from torch._inductor.scheduler import Scheduler
+from torch._inductor.virtualized import V
+
+if TYPE_CHECKING:
+    from torch.fx.node import Node
+
+from apex.contrib.torchsched.inductor.scheduler import MultiCudaStreamScheduler
+
+
+@functools.wraps(GraphLowering.codegen)
+def _codegen(graph: GraphLowering) -> tuple[str, list[tuple[int, Node]]]:
+    graph.init_wrapper_code()
+
+    if graph.device_type == "cuda":
+        graph.scheduler = MultiCudaStreamScheduler(graph.operations)
+    else:
+        graph.scheduler = Scheduler(graph.operations)
+    V.debug.draw_orig_fx_graph(graph.orig_gm, graph.scheduler.nodes)
+
+    graph.wrapper_code.push_codegened_graph(graph)
+    graph.scheduler.codegen()
+    result = graph.wrapper_code.generate(graph.is_inference)
+    graph.wrapper_code.pop_codegened_graph()
+
+    return result
+
+
+_origin_codegen = GraphLowering.codegen
+
+
+def patch_graph_lowering(patch: bool = True) -> None:
+    """Patch PyTorch Inductor lowerings with multi-stream scheduling.
+
+    This function patches the `torch.compile` stack on the GraphLowering level,
+    i.e., the compute graph has been captured by Dynamo and it has undergone
+    post-auto-gradient passes, including pattern-matching optimizations and
+    preliminary operator fusions. At that point, most nodes in the graph are
+    either fused Triton templates, or function calls to external libraries. The
+    multi-stream scheduler then finds the longest critical path in this graph,
+    and schedule other nodes to side streams to exploit the inherent parallelism
+    of the given compute graph.
+
+    Args:
+        patch: Whether to patch Inductor `GraphLowering` with multi-stream
+            scheduler. Set to `False` to restore the default `torch.compile`
+            behavior. (default: `True`)
+    """
+    if patch:
+        GraphLowering.codegen = _codegen
+    else:
+        GraphLowering.codegen = _origin_codegen

--- a/apex/contrib/torchsched/inductor/scheduler.py
+++ b/apex/contrib/torchsched/inductor/scheduler.py
@@ -1,0 +1,538 @@
+"""Scheduling abstractions on PyTorch Inductor Scheduler level."""
+
+from __future__ import annotations
+
+import collections
+import copy
+import itertools
+import re
+from typing import TYPE_CHECKING
+from typing import cast
+
+import torch
+import torch._inductor.config as inductor_config
+from torch._inductor import ir
+from torch._inductor.dependencies import WeakDep
+from torch._inductor.scheduler import BaseSchedulerNode
+from torch._inductor.scheduler import ExternKernelSchedulerNode  # noqa: F401
+from torch._inductor.scheduler import ForeachKernelSchedulerNode  # noqa: F401
+from torch._inductor.scheduler import FusedSchedulerNode
+from torch._inductor.scheduler import NopKernelSchedulerNode
+from torch._inductor.scheduler import Scheduler
+from torch._inductor.scheduler import SchedulerNode
+from torch._inductor.utils import device_need_guard
+from torch._inductor.virtualized import V
+
+import apex.contrib.torchsched.config as config
+from apex.contrib.torchsched.inductor.event import CudaEventFactory
+from apex.contrib.torchsched.inductor.event import CudaEventSym
+from apex.contrib.torchsched.inductor.wrapper import DEFAULT_STREAM_IDX
+from apex.contrib.torchsched.inductor.wrapper import EnterCudaStreamContextLine
+
+if TYPE_CHECKING:
+    from apex.contrib.torchsched.inductor.wrapper import MultiStreamWrapperCodegen  # noqa: F401
+
+
+schedule_log = torch._logging.getArtifactLogger(__name__, "schedule")
+
+
+class MultiCudaStreamScheduler(Scheduler):
+    """Scheduling post-fusion graph with multi-stream awareness.
+
+    This class introduced a new optimization pass on top of the Inductor :class:`Scheduler`. I.e.,
+    it firstly searches for the longest critical path in the given compute graph, currently using
+    the path depth as a proxy of execution cost. Then it executes the non-critical computations in
+    parallel with the critical path computations by launching them to side CUDA Streams, with the
+    goal of scheduling critical path computations back-to-back while saturating GPU resources at
+    runtime.
+
+    Args:
+        operations: A list of Inductor IR nodes representing fused computations.
+    """
+
+    def __init__(self, operations: list[ir.Operation]) -> None:
+        """Construct a scheduler object from a list of Inductor IR nodes.
+
+        Refer to :class:`MultiCudaStreamScheduler` doc for argument specification.
+        """
+        super().__init__(operations)
+        self.event_factory = CudaEventFactory()
+        self.buff_to_event: dict[str, CudaEventSym] = collections.defaultdict(
+            lambda: self.event_factory.get_sym_event(),
+        )
+        self.unjoined_events: dict[int, set[CudaEventSym]] = collections.defaultdict(set)
+        self.buffers_requiring_device_check: set[str] = set()
+        self.current_stream: int | None = None
+        self.current_ctx_entrance: EnterCudaStreamContextLine | None = None
+        self.current_ctx_ending_event: CudaEventSym | None = None
+        self.schedule_multi_cuda_streams()
+
+    def _schedule_execution(self) -> None:
+        # A linear representation of parallelizable execution schedule.
+        #
+        #    schedule := List[producer, consumer]
+        #    producer := List | Set | Node
+        #    consumer := Set | Node
+        #    List     := Sequential execution
+        #    Set      := Emit parallel primitives on set opening, sync parallel results on set
+        #                close
+        #
+        # NOTE: Greedy construction of this data structure is suboptimal, very likely to miss
+        # parallel opportunities, thus this design is kept here but not used.
+        producer_graph = None
+        consumer_graph: set[BaseSchedulerNode] = set()
+        produced_dependency: set[str] = set()
+        consuming_dependency: set[str] = set()
+
+        for node in self.nodes:
+            consuming_dependency |= {d.name for d in node.unmet_dependencies}
+            if consuming_dependency - produced_dependency:
+                # Turn current consumers to producers.
+                if producer_graph is None:
+                    producer_graph = copy.copy(consumer_graph)
+                else:
+                    producer_graph = [copy.copy(producer_graph), copy.copy(consumer_graph)]
+                produced_dependency |= set().union(*[n.get_buffer_names() for n in consumer_graph])
+                consumer_graph.clear()
+                consuming_dependency.clear()
+            consumer_graph.add(node)
+            consuming_dependency = set().union(*[n.get_buffer_names() for n in consumer_graph])
+
+        if consumer_graph:
+            execution_schedule = [copy.copy(producer_graph), copy.copy(consumer_graph)]
+        else:
+            execution_schedule = [copy.copy(producer_graph)]
+
+        self.execution_schedule = execution_schedule
+
+    def debug_str_short(self, node: BaseSchedulerNode) -> str:
+        """Generate short string representing scheduler node's calling function or indices."""
+        if node.is_extern() and isinstance(node.node, ir.MultiOutput):
+            kernel_str = node.node.codegen_list_tuple_access(
+                basename="getitem",
+                indices=node.node.indices,
+            )
+            return f"{node.get_name()} ({kernel_str})"
+        elif node.is_extern():
+            kernel_name = node.node.get_kernel_name() or str(node.node.op_overload)
+            return f"{node.get_name()} ({kernel_name})"
+        else:
+            return node.get_name()
+
+    def get_last_event(self, events: set[CudaEventSym]) -> CudaEventSym:
+        """Identify the latest generated CUDA event among all given events."""
+        return sorted(events, reverse=True)[0]  # CudaEventSym is total-ordering.
+
+    def schedule_multi_cuda_streams(self) -> None:
+        """Assign each fused Inductor IR nodes with the CUDA Stream to be launched to."""
+        if not self.nodes:
+            # Empty graphs are sent to compiler in very rare circumstances. Just Skip scheduling.
+            return
+
+        buf_originate: dict[str, BaseSchedulerNode] = {}
+        node_users: dict[BaseSchedulerNode, set[BaseSchedulerNode]] = collections.defaultdict(set)
+        for node in self.nodes:
+            for n in node.get_buffer_names():
+                buf_originate[n] = node
+        for node in self.nodes:
+            for d in node.unmet_dependencies:
+                assert d.name in buf_originate
+                node_users[buf_originate[d.name]].add(node)
+
+        critical_path_per_depth: dict[int, set[BaseSchedulerNode]] = collections.defaultdict(set)
+        node_depth: dict[BaseSchedulerNode, int] = collections.defaultdict(lambda: -1)
+
+        def visit(node: BaseSchedulerNode, depth: int, prev: set[BaseSchedulerNode]) -> None:
+            if node_depth[node] < depth:
+                node_depth[node] = depth
+                path = prev | {node}
+                if len(critical_path_per_depth[depth]) < len(path):
+                    critical_path_per_depth[depth] = path
+                for user in node_users[node]:
+                    visit(user, depth + 1, path)
+
+        graph_entries = [n for n in self.nodes if not n.unmet_dependencies]
+        for entry in graph_entries:
+            visit(entry, depth=1, prev=set())
+
+        max_depth, longest_critical_path = sorted(critical_path_per_depth.items(), reverse=True)[0]
+
+        # Allocate CUDA Streams for each fused node:
+        # - Critical path nodes go to the default stream
+        # - Nodes without GPU operations (currently only covered getitem nodes) go to their
+        #   producer's stream
+        # - Other nodes go to a set of pre-defined number of side-streams in a round-robin manner
+        num_streams = config.num_streams
+        if num_streams == 1:
+            node_to_stream = {node: DEFAULT_STREAM_IDX for node in self.nodes}
+        else:
+            node_to_stream = {}
+            side_stream_indices = itertools.cycle(range(1, num_streams))
+            for node in self.nodes:
+                if node in longest_critical_path:
+                    node_to_stream[node] = DEFAULT_STREAM_IDX
+                elif node.is_extern() and isinstance(node.node, ir.MultiOutput):
+                    assert len(node.unmet_dependencies) == 1
+                    producer = buf_originate[next(iter(node.unmet_dependencies)).name]
+                    node_to_stream[node] = node_to_stream[producer]
+                else:
+                    node_to_stream[node] = next(side_stream_indices)
+        self.node_to_stream = node_to_stream
+
+        # Also remember buffer originate streams.
+        buff_to_stream = {}
+        for node, stream_idx in node_to_stream.items():
+            for buf_name in node.get_buffer_names():
+                buff_to_stream[buf_name] = stream_idx
+        self.buff_to_stream = buff_to_stream
+
+        schedule_log.debug(f"{' Multi-CUDA-Stream scheduling results ':=^79}")
+        schedule_log.debug("Post-fusion graph depth: %d", max_depth)
+        schedule_log.debug("Total number of allocated CUDA Streams: %d", num_streams)
+        schedule_log.debug(f"{' Critical path ':-^79}")
+        for node in self.nodes:
+            if node in longest_critical_path:
+                schedule_log.debug("- %s", self.debug_str_short(node))
+        schedule_log.debug(f"{' Stream assignments of other nodes ':-^79}")
+        for node, stream_idx in node_to_stream.items():
+            if node not in longest_critical_path:
+                schedule_log.debug("- %s -> Stream %d", self.debug_str_short(node), stream_idx)
+
+    def prune_unjoined_events(self, synced_upstream_events: dict[int, set[CudaEventSym]]) -> None:
+        """Remove synced CUDA Events on specific CUDA Streams.
+
+        Args:
+            sync_upstream_events: A dict that maps event names to stream indices. Each key-value
+                pair represents a event on the corresponding stream has been properly synced so it
+                do not need to be synced again at the end of the program.
+
+        Raises:
+            ValueError: If any of the event name was not registered to its corresponding stream.
+        """
+        for stream_idx, events in synced_upstream_events.items():
+            if stream_idx != DEFAULT_STREAM_IDX:
+                self.unjoined_events[stream_idx] -= events
+
+    def get_final_events_to_sync(self) -> set[CudaEventSym]:
+        """Return the CUDA Events that need to be synced at the end of the program.
+
+        Raises:
+            ValueError: If there is hanging event on the default stream. This usually means the
+                user didn't properly use :meth:`add_unjointed_event` to register hanging events.
+        """
+        if self.unjoined_events.get(DEFAULT_STREAM_IDX):
+            raise ValueError(
+                f"Unexpected {self.unjoined_events[DEFAULT_STREAM_IDX]=} on default stream",
+            )
+        events_to_sync = set()
+        for stream, events in self.unjoined_events.items():
+            if len(events) == 0:
+                schedule_log.debug(f"All events on stream{stream} have been consumed")
+                continue
+            last_event = self.get_last_event(events)
+            if 1 < len(events):
+                schedule_log.debug(
+                    f"Seeing multiple hanging {events=} on stream{stream}, scheduling the "
+                    f"{last_event=} to sync",
+                )
+            else:
+                schedule_log.debug(
+                    f"Scheduling the {last_event=} on stream{stream} to sync",
+                )
+            events_to_sync.add(last_event)
+        return events_to_sync
+
+    def clear_unjoined_events(self) -> None:
+        """Clear handing event syncs registered by :meth:`add_unjointed_event`."""
+        self.unjoined_events.clear()
+
+    def register_downstream_event(
+        self,
+        node: BaseSchedulerNode,
+    ) -> CudaEventSym:
+        """Register one CUDA event indicating node execution complete.
+
+        For ordinary Inductor IR nodes, the completion event is newly created using an internal
+        event counter. For Inductor no-op nodes, the last event corresponding to its inputs will be
+        used instead.
+
+        Args:
+            node: The Inductor IR node to generate completion event for.
+
+        Returns:
+            The name of the completion event.
+
+        Raises:
+            ValueError: If this function is called out side of any stream context.
+        """
+        if isinstance(node, NopKernelSchedulerNode) and node.unmet_dependencies:
+            upstream_events = set()
+            for dep in node.unmet_dependencies:
+                assert dep.name in self.buff_to_event
+                upstream_events.add(self.buff_to_event[dep.name])
+            assert 1 <= len(upstream_events)
+            downstream_event = self.get_last_event(upstream_events)
+            for buff in node.get_buffer_names():
+                self.buff_to_event[buff] = downstream_event
+        else:
+            for i, buff in enumerate(sorted(node.get_buffer_names())):
+                if i == 0:
+                    downstream_event = self.buff_to_event[buff]
+                else:
+                    self.buff_to_event[buff] = downstream_event
+            if (node_stream := self.node_to_stream[node]) != DEFAULT_STREAM_IDX:
+                self.unjoined_events[node_stream].add(downstream_event)
+            V.graph.wrapper_code.writeline(downstream_event.record(node_stream))
+        return downstream_event
+
+    def get_cross_stream_dependencies(
+        self,
+        node: BaseSchedulerNode,
+        prune_unjointed_events: bool = False,
+    ) -> tuple[set[CudaEventSym], set[str]]:
+        """Get CUDA Event and buffer dependencies of an IR node.
+
+        Args:
+            node: The Inductor IR node to generate code for.
+            prune_unjointed_events: If set to True, the returned CUDA Events will be considered
+                synced and no need to be synced again before program exiting. (Default: True)
+
+        Returns:
+            upstream_events: A set of CUDA Event symbols, these events need to be synced before
+                executing `node`'s code.
+            buffer_from_other_streams: A set of buffer names, these buffers need to be recorded on
+                the CUDA Stream that `node` is running on.
+        """
+        assert node in self.node_to_stream
+
+        # Process cross-cuda-stream dependencies.
+        node_stream = self.node_to_stream[node]
+        events_on_stream: dict[int, set[CudaEventSym]] = collections.defaultdict(set)
+        buffers_from_other_streams = set()
+        if not node.unmet_dependencies and node_stream != DEFAULT_STREAM_IDX:
+            # Graph entries on side streams should wait upon the main stream entrance.
+            entrance_event = self.event_factory.get_entrance_event()
+            events_on_stream[DEFAULT_STREAM_IDX].add(entrance_event)
+        for dep in node.read_writes.reads:
+            buff = dep.name  # To track stream number and cuda events.
+            buff_real = self.mutation_real_name.get(buff, buff)  # The real name in code.
+            if dep not in node.unmet_dependencies and not isinstance(dep, WeakDep):
+                # Materialized dependencies should be recorded on this stream.
+                buffers_from_other_streams.add(buff_real)
+                # The scalar tensor argument `dropout_p` of SDPA backward kernels might be on CUDA
+                # or CPU devices depending on execution scenario. To ensure program correctness we
+                # add a runtime check for it.
+                #
+                # TODO (@davidli): Remove this ad-hoc checking once PyTorch fix SDPA and
+                # MultiOutputLayout issues.
+                if node.is_extern() and re.match(
+                    r"aten._scaled_dot_product_.*_attention_backward",
+                    str(node.node.op_overload),
+                ):
+                    self.buffers_requiring_device_check.add(buff_real)
+                continue
+            elif isinstance(dep, WeakDep):
+                # Skip unmaterialized dependencies.
+                continue
+            assert buff in self.buff_to_event
+            assert buff in self.buff_to_stream
+            buff_event = self.buff_to_event[buff]
+            buff_stream = self.buff_to_stream[buff]
+            events_on_stream[buff_stream].add(buff_event)
+            if buff_stream != node_stream:
+                if node.is_extern() and isinstance(node.node, ir.MultiOutput):
+                    assert len(node.read_writes.reads) == 1
+                    buff_real = node.node.codegen_list_tuple_access(
+                        basename=buff_real,
+                        indices=node.node.indices,
+                    )
+                    self.buffers_requiring_device_check |= {buff_real, node.node.get_name()}
+                buffers_from_other_streams.add(buff_real)
+
+        # Should only wait for the latest event from each stream.
+        upstream_events = set()
+        for stream, events in events_on_stream.items():
+            if stream != node_stream:
+                last_event = self.get_last_event(events)
+                upstream_events.add(last_event)
+
+        # Side-effect: Populated cross-stream events get pruned optionally.
+        if prune_unjointed_events:
+            self.prune_unjoined_events(events_on_stream)
+
+        return upstream_events, buffers_from_other_streams
+
+    def generate_stream_ctx_enter(self, node: BaseSchedulerNode) -> None:
+        """Code-gen to enter the Stream context assigned to node."""
+        assert not isinstance(node, NopKernelSchedulerNode)
+        wrapper_code = cast("MultiStreamWrapperCodegen", V.graph.wrapper_code)
+        upstream_events, buffers_from_other_streams = self.get_cross_stream_dependencies(node)
+        node_stream = self.node_to_stream[node]
+        self.current_ctx_entrance = wrapper_code.codegen_cuda_stream_enter(
+            stream_idx=node_stream,
+            upstream_events=upstream_events,
+            buffers_from_other_streams=buffers_from_other_streams,
+            buffers_requiring_device_check=self.buffers_requiring_device_check,
+        )
+
+    def generate_stream_ctx_exit(self) -> None:
+        """Code-gen to exit from the current Stream context."""
+        assert self.current_stream is not None
+        wrapper_code = cast("MultiStreamWrapperCodegen", V.graph.wrapper_code)
+        wrapper_code.codegen_cuda_stream_exit(
+            stream_idx=self.current_stream,
+        )
+        self.current_ctx_entrance = None
+
+    def propagate_cross_stream_dependencies(self, node: BaseSchedulerNode) -> None:
+        """Move input node's dependencies to the entrance of current CUDA Stream context.
+
+        If node is scheduled in the middle of a stream context, its dependencies should be properly
+        synced before entering this context. This function extracts `node`'s dependencies and move
+        them to the data structure that represents the entrance of current stream context.
+
+        Args:
+            node: The Inductor IR node to generate code for. This node must have an assigned stream
+                in :meth:`schedule_multi_cuda_streams`.
+        """
+        assert self.current_ctx_entrance is not None
+        upstream_events, buffers_from_other_streams = self.get_cross_stream_dependencies(node)
+        self.current_ctx_entrance.upstream_events |= upstream_events
+        self.current_ctx_entrance.buffers_from_other_streams |= buffers_from_other_streams
+
+    def generate_stream_ctx_switching(self, node: BaseSchedulerNode) -> None:
+        """Generate stream entering and exiting to properly run node in a multi-stream scenario.
+
+        Stream context switching is only generated if `node`'s assigned stream is different from
+        the previous node's stream. If the node is a no-op, its code will be generated in the same
+        context of previous node.
+        """
+        assert node in self.node_to_stream
+        stream = None if isinstance(node, NopKernelSchedulerNode) else self.node_to_stream[node]
+        if stream == self.current_stream:
+            if stream is not None:
+                self.propagate_cross_stream_dependencies(node)
+            return
+        elif self.current_stream is not None and stream is None:
+            # Don't generate ctx switching. Memory plaining code (e.g., delete buffers) on current
+            # node goes to previous stream ctx.
+            return
+        elif self.current_stream is None and stream is not None:
+            # Enter new ctx, update current stream status.
+            self.generate_stream_ctx_enter(node)
+            self.current_stream = stream
+        else:
+            # Switching from previous stream ctx to the new stream ctx.
+            self.generate_stream_ctx_exit()
+            self.generate_stream_ctx_enter(node)
+            self.current_stream = stream
+
+    def codegen(self) -> None:
+        """Generate Python code for each of the Scheduler IR nodes.
+
+        Note:
+            The overall `torch.compile` code-gen is a multi-pass process, which means that this
+            method doesn't necessarily generate final program strings for every IR nodes. For
+            certain types of IRs, e.g., those involve memory allocation/deletion and CUDA Stream
+            switching, this method only generates respective data structures, and the final
+            code-gen is delegated to :meth:`WrapperCodeGen.codegen` using information form these
+            data structures.
+
+        Raises:
+            AssertionError: If any of the conditions met
+                * A node need to switch device context but it didn't include device information;
+                * A node contains at least one non-weak dependence that was not seen in the
+                  :meth:`schedule_multi_cuda_streams` pass;
+                * A node contains at least one non-weak cross-stream dependence that the
+                  corresponding event was not generated before that point;
+                * The fused compute graph contains :class:`ForeachKernelSchedulerNode` but the
+                  target backend doesn't support SIMD scheme.
+        """
+        wrapper_code = cast("MultiStreamWrapperCodegen", V.graph.wrapper_code)
+        for node in self.nodes:
+            try:
+                schedule_log.debug(
+                    "Generating code for node %s with estimated runtime %f",
+                    node.get_name(),
+                    node.get_estimated_runtime(),
+                )
+            except Exception:
+                schedule_log.debug(
+                    "Generating code for node %s with estimated runtime 0.0",
+                    node.get_name(),
+                )
+
+            self.enter_context(node)
+
+            if not isinstance(node, NopKernelSchedulerNode) and (device := node.get_device()):
+                if device != self.current_device or node.is_extern() or node.is_template():
+                    self.flush()
+                if device != self.current_device:
+                    if self.current_device and device_need_guard(
+                        self.current_device.type,
+                    ):
+                        wrapper_code.codegen_device_guard_exit()
+                    if device_need_guard(device.type):
+                        assert device.index is not None, "device should have an index"
+                        wrapper_code.codegen_device_guard_enter(device.index)
+                    self.current_device: torch.device | None = device
+
+            self.generate_stream_ctx_switching(node)
+            self.buffer_names_to_free.update(node.last_usage)
+
+            if node.is_template():
+                node, *epilogue = node.get_nodes()
+                self.get_backend(device).codegen_template(node, epilogue)
+            elif node.is_extern():
+                node = cast("ExternKernelSchedulerNode", node)
+                self.codegen_extern_call(node)
+            elif node.is_foreach():
+                node = cast("ForeachKernelSchedulerNode", node)
+                backend_ = self.get_backend(device)
+                from torch._inductor.codegen.cuda_combined_scheduling import CUDACombinedScheduling
+                from torch._inductor.codegen.simd import SIMDScheduling
+
+                if isinstance(backend_, (SIMDScheduling, CUDACombinedScheduling)):
+                    backend = backend_
+                else:
+                    raise AssertionError(f"{type(self)=}")
+                backend.codegen_combo_kernel(node)
+            elif isinstance(node, (FusedSchedulerNode, SchedulerNode)):
+                self.get_backend(device).codegen_node(node)
+            else:
+                assert isinstance(node, NopKernelSchedulerNode)
+                node.mark_run()
+
+            if inductor_config.triton.debug_sync_kernel:
+                self.get_backend(device).codegen_sync()
+
+            self.available_buffer_names.update(node.get_buffer_names())
+            self.completed_operations.update(node.get_operation_names())
+            self.current_ctx_ending_event = self.register_downstream_event(node)
+
+            if not isinstance(node, NopKernelSchedulerNode):
+                device = node.get_device()
+                if device is not None and self.get_backend(device).ready_to_flush():
+                    self.flush()
+
+        if self.current_device and device_need_guard(self.current_device.type):
+            # Exit the last stream context.
+            if self.current_ctx_entrance:
+                self.generate_stream_ctx_exit()
+            # Record the default stream on buffers from other streams.
+            side_stream_buffers = set()
+            for output in V.graph.get_output_names():
+                if self.buff_to_stream.get(output, DEFAULT_STREAM_IDX) != DEFAULT_STREAM_IDX:
+                    side_stream_buffers.add(output)
+            wrapper_code.codegen_record_buff_from_side_streams(
+                buffers=side_stream_buffers,
+                buffers_requiring_device_check=self.buffers_requiring_device_check,
+            )
+            # Sync hanging events from other streams.
+            if events_to_sync := self.get_final_events_to_sync():
+                wrapper_code.codegen_sync_unjoined_cuda_events(events_to_sync)
+            # exit the outermost CUDA device guard. this is
+            # important for nested indentation codegen-ing.
+            wrapper_code.codegen_device_guard_exit()
+
+        self.flush()

--- a/apex/contrib/torchsched/inductor/wrapper.py
+++ b/apex/contrib/torchsched/inductor/wrapper.py
@@ -1,0 +1,274 @@
+"""Scheduling abstractions on PyTorch Inductor WrapperCodeGen level.
+
+Attributes:
+    DEFAULT_STREAM: Name of the default CUDA Stream on the final generated Python code.
+    DEFAULT_STREAM_IDX: Index number of the default CUDA Stream in `torchsched` internal passes.
+    STREAM_NAME_TEMPLATE: Python string template to generate stream names. Can be used as:
+
+            idx: int = ...
+            stream = STREAM_NAME_TEMPLATE.format(stream_idx=idx)
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+from torch._inductor.codegen.wrapper import EnterDeviceContextManagerLine
+from torch._inductor.codegen.wrapper import IndentedBuffer
+from torch._inductor.codegen.wrapper import PythonWrapperCodegen
+from torch._inductor.codegen.wrapper import SubgraphPythonWrapperCodegen
+from torch._inductor.codegen.wrapper import WrapperLine
+from torch._inductor.virtualized import V
+
+import apex.contrib.torchsched.config as config
+from apex.contrib.torchsched.inductor._utils import DEFAULT_STREAM
+from apex.contrib.torchsched.inductor._utils import DEFAULT_STREAM_IDX
+from apex.contrib.torchsched.inductor._utils import ENTRANCE_EVENT
+from apex.contrib.torchsched.inductor._utils import STREAM_NAME_TEMPLATE
+from apex.contrib.torchsched.inductor._utils import get_stream_name
+
+if TYPE_CHECKING:
+    from torch._inductor.graph import GraphLowering
+
+    from apex.contrib.torchsched.inductor.event import CudaEventSym
+
+
+@dataclasses.dataclass
+class EnterDeviceContextManagerWithStreamInfoLine(EnterDeviceContextManagerLine):
+    """Enter a CUDA device context and allocate required side streams.
+
+    Note:
+        - The number of allocated streams is controlled by :attr:`apex.contrib.torchsched.config.num_streams`;
+    """
+
+    def codegen(self, code: IndentedBuffer) -> None:
+        """Generate context switching and stream allocation code."""
+        if V.graph.cpp_wrapper:
+            super().codegen(code)
+        else:
+            super().codegen(code)
+            code.writeline(f"{DEFAULT_STREAM} = torch.cuda.current_stream()")
+            code.writeline(f"{ENTRANCE_EVENT} = {DEFAULT_STREAM}.record_event()")
+
+            for i in range(1, config.num_streams):
+                code.writeline(
+                    f"{STREAM_NAME_TEMPLATE.format(stream_idx=i)} "
+                    f"= torch.cuda.Stream(device={self.device_idx})",
+                )
+
+
+@dataclasses.dataclass
+class EnterCudaStreamContextLine(WrapperLine):
+    """Enter a context executed by respective CUDA Stream and insert necessary syncs.
+
+    Attributes:
+        wrapper: The code-gen wrapper of the current compilation phase.
+        stream_idx: The index number corresponds to the entering CUDA Stream context.
+        upstream_events: Names of CUDA Events that the current stream should be waiting for before
+            the stream switching.
+        buffers_from_other_streams: Name of buffers produced by other CUDA Streams. Those buffers
+            should be recorded to the current stream to avoid accidental memory free.
+        buffers_requiring_device_check: Name of buffers that might not be on CUDA devices and
+            require runtime device checking before recording stream to them.
+    """
+
+    wrapper: MultiStreamWrapperCodegen
+    stream_idx: int
+    upstream_events: set[CudaEventSym]
+    buffers_from_other_streams: set[str]
+    buffers_requiring_device_check: set[str]
+
+    def __post_init__(self) -> None:
+        """Construct stream name by the given index number."""
+        self.stream_name = get_stream_name(self.stream_idx)
+        # Symbolic event dependency should be handled in the 1st pass of code-gen so the reference
+        # counters can be properly tracked.
+        for event in self.upstream_events:
+            self.wrapper.writeline(event.wait(self.stream_idx))
+
+    def codegen(self, code: IndentedBuffer) -> None:
+        """Generate event sync and stream switching code."""
+        code.writeline(f"with torch.cuda.stream({self.stream_name}):")
+        code.do_indent()
+
+        # [NOTE] The 3-indent-level assertion
+        #
+        #     Indent level 1: Inductor wrapper call indent
+        #         Indent level 2: Device guard context indent
+        #             Indent level 3: CUDA Stream context indent
+        #
+        # Over or under indenting usually means that :meth:`MultiCudaStreamScheduler.codegen`
+        # introduced bugs on stream context switching. This check also applies to stream context
+        # exiting, as in :meth:`ExitCudaStreamContextLine.codegen`.
+        assert code._indent == 3
+
+        for buff in self.buffers_from_other_streams:
+            prefix = f"if {buff}.is_cuda: " if buff in self.buffers_requiring_device_check else ""
+            code.writeline(f"{prefix}{buff}.record_stream({self.stream_name})")
+
+
+@dataclasses.dataclass
+class ExitCudaStreamContextLine(WrapperLine):
+    """Generate code to exit the current stream context.
+
+    Note:
+        Most attributes and checking logics of this class have been moved to
+        :meth:`MultiStreamWrapperCodeGen.codegen_cuda_stream_exit`. We preserve this data structure
+        because the checking and unindent should be generated in the latter phase of code-gen.
+    """
+
+    def codegen(self, code: IndentedBuffer) -> None:
+        """Check indentation level and exit the current stream context."""
+        assert code._indent == 3  # See :note:`The 3-indent-level assertion` above.
+        code.do_unindent()
+
+
+@dataclasses.dataclass
+class RecordBuffFromSideStreams(WrapperLine):
+    """Record the returning tensors on the default stream to avoid accidental memory free.
+
+    Attributes:
+        buffers: Names of the returning tensors that need to be recorded on the default stream.
+        buffers_requiring_device_check: Name of buffers that might not be on CUDA devices and
+            require runtime device checking before recording stream to them.
+    """
+
+    buffers: set[str]
+    buffers_requiring_device_check: set[str]
+
+    def codegen(self, code: IndentedBuffer) -> None:
+        """Generate stream recording for returning tensors."""
+        for buff in self.buffers:
+            prefix = f"if {buff}.is_cuda: " if buff in self.buffers_requiring_device_check else ""
+            code.writeline(f"{prefix}{buff}.record_stream({DEFAULT_STREAM})")
+
+
+class MultiStreamWrapperCodegen(PythonWrapperCodegen):
+    """Wrapper code generator for graph scheduling."""
+
+    def __init__(self) -> None:
+        """Construct a code-gen wrapper and disable raw stream caching.
+
+        Note:
+            The :meth:`write_get_raw_stream` method processed in this constructor is invoked from
+            literally everywhere throughout the Inductor stack, but the current
+            :meth:`PythonWrapperCodegen.write_get_raw_stream` is LRU-cached and always returns a
+            const raw stream name. This is not what we wanted in a multi-stream environment. Thus
+            we need to re-patch this function in instance initialization.
+        """
+        super().__init__()
+        self.current_stream_name: str | None = None
+        self.write_get_raw_stream = self._write_get_raw_stream
+
+    @staticmethod
+    def create(
+        is_subgraph: bool,
+        subgraph_name: str,
+        parent_wrapper: MultiStreamWrapperCodegen,
+    ) -> MultiStreamWrapperCodegen | SubgraphPythonWrapperCodegen:
+        """Instantiate a wrapper codegen for an Inductor graph or a subgraph."""
+        if is_subgraph:
+            return SubgraphPythonWrapperCodegen(subgraph_name, parent_wrapper)
+        return MultiStreamWrapperCodegen()
+
+    def _write_get_raw_stream(self, device_idx: int, graph: GraphLowering | None = None) -> str:
+        self.write_triton_header_once()
+        if self.current_stream_name is not None:
+            name = f"{self.current_stream_name}_raw"
+            self.writeline(f"{name} = {self.current_stream_name}.cuda_stream")
+        else:
+            name = f"stream{device_idx}"
+            self.writeline(f"{name} = get_raw_stream({device_idx})")
+        return name
+
+    def codegen_device_guard_enter(self, device_idx: int) -> None:
+        """Generate data structure for device guard context.
+
+        Note:
+            Refer to :class:`EnterDeviceContextManagerWithStreamInfoLine` doc for more details.
+        """
+        self.writeline(
+            EnterDeviceContextManagerWithStreamInfoLine(
+                device_idx,
+                self.last_seen_device_guard_index,
+            ),
+        )
+        self.last_seen_device_guard_index: int = device_idx
+
+    def codegen_cuda_stream_enter(
+        self,
+        stream_idx: int,
+        upstream_events: set[CudaEventSym],
+        buffers_from_other_streams: set[str],
+        buffers_requiring_device_check: set[str],
+    ) -> EnterCudaStreamContextLine:
+        """Generate data structure for entering a CUDA Stream context.
+
+        Note:
+            - Refer to :class:`EnterCudaStreamContextLine` for argument specifications;
+            - Once entered a context, the stream associated with this context will also be recorded
+              such that kernels in subsequent code-gen can get the correct stream index.
+
+        Raises:
+            ValueError: If this function is called while the previous stream context isn't exited.
+        """
+        if self.current_stream_name is not None:
+            raise ValueError(
+                f"Nested stream context switching: {self.current_stream_name} -> "
+                f"{get_stream_name(stream_idx)}",
+            )
+        ctx_entrance = EnterCudaStreamContextLine(
+            self,
+            stream_idx,
+            upstream_events,
+            buffers_from_other_streams,
+            buffers_requiring_device_check,
+        )
+        self.writeline(ctx_entrance)
+        self.current_stream_name = ctx_entrance.stream_name
+        return ctx_entrance
+
+    def codegen_cuda_stream_exit(
+        self,
+        stream_idx: int,
+    ) -> None:
+        """Generate data structure for exiting a CUDA Stream context.
+
+        Args:
+            stream_idx: Index of the stream context to exit from.
+
+        Raises:
+            ValueError: If attempting to exit from a different context than `steam_idx` or to exit
+                from code not in any stream context.
+        """
+        if self.current_stream_name is None:
+            raise ValueError("Attempting to exit from code that isn't in a stream context")
+        elif (stream_name := get_stream_name(stream_idx)) != self.current_stream_name:
+            raise ValueError(
+                f"Attempting to exit from {stream_name} but the current stream context is "
+                f"{self.current_stream_name}",
+            )
+        self.writeline(ExitCudaStreamContextLine())
+        self.current_stream_name = None
+
+    def codegen_sync_unjoined_cuda_events(self, events: set[CudaEventSym]) -> None:
+        """Generate data structure for syncing hanging CUDA Events before program exit.
+
+        Args:
+            events: Symbols of the events that need to be waited for before program exit.
+        """
+        for event in events:
+            self.writeline(event.wait(DEFAULT_STREAM_IDX))
+
+    def codegen_record_buff_from_side_streams(
+        self,
+        buffers: set[str],
+        buffers_requiring_device_check: set[str],
+    ) -> None:
+        """Generate data structure for recording steam on return tensors before program exit.
+
+        Note:
+            Refer to :class:`RecordBuffFromSideStreams` for more details.
+        """
+        self.writeline(RecordBuffFromSideStreams(buffers, buffers_requiring_device_check))


### PR DESCRIPTION
This PR contains an experimental graph compiler on top of `torch.compile`. We used it for a couple of studies. In this PR we'd like to expose one functionality, which is scheduling independent operators in the graph on multi-streams automatically.

Right now the best use case of it is for small workloads where a single GEMM/Conv can’t fully utilize all the GPU resources, especially during back-propagation.

We achieved 5%-9% E2E performance imporvement for Stable Diffusion with small batch size and full iteration CUDA graph.                                                                       
                                                                                    
On importing `apex.contrib.torchsched`, a new `torch.compile` backend `torchsched` is registered:
                                                                                    
```python                                                                           
import apex.contrib.torchsched                                                                   
                                                                                    
compiled = torch.compile(model, backend="torchsched")                               
```                                                                                 
                                                                                    
Alternatively, one can import `torchsched` at first and then set `torchsched` as    
default backend:                                                                    
                                                                                    
```python                                                                           
import apex.contrib.torchsched                                                                   
apex.contrib.torchsched.set_default_backend("torchsched")                                        
                                                                                    
compiled = torch.compile(model)                                                     
```                                                                                 