### PR TITLE
Add group_norm_v2

### DIFF
--- a/apex/contrib/csrc/group_norm_v2/generate_gn_cuda_inst.py
+++ b/apex/contrib/csrc/group_norm_v2/generate_gn_cuda_inst.py
@@ -1,0 +1,48 @@
+import pathlib
+
+
+hw_c_list = [
+    (8 * 8, 1280),
+    (8 * 8, 2560),
+    (16 * 16, 640),
+    (16 * 16, 1280),
+    (16 * 16, 1920),
+    (16 * 16, 2560),
+    (32 * 32, 320),
+    (32 * 32, 640),
+    (32 * 32, 960),
+    (32 * 32, 1280),
+    (32 * 32, 1920),
+    (64 * 64, 320),
+    (64 * 64, 640),
+    (64 * 64, 960),
+]
+
+
+def run():
+    src_path = pathlib.Path(__file__).parent.absolute()
+
+    for f in src_path.glob("gn_cuda_inst_*.cu"):
+        f.unlink()
+
+    for hw, c in hw_c_list:
+        print(f"GN_CUDA_INST_DEFINE({hw}, {c})")
+        with open(src_path / f"gn_cuda_inst_{hw}_{c}.cu", "w") as f:
+            f.write(f"#include \"gn_cuda_host_template.cuh\"\n")
+            f.write(f"\n")
+            f.write(f"namespace group_norm_v2 {{\n")
+            f.write(f"GN_CUDA_INST_DEFINE({hw}, {c})\n")
+            f.write(f"}}\n")
+
+    with open(src_path / "gn_dispatch_hw_c.hpp", "w") as f:
+        f.write(f"#pragma once\n")
+        f.write(f"\n")
+        f.write(f"#define DISPATCH_HW_C(hw, c, HW, C, ...) [&] {{ \\\n")
+        for hw, c in hw_c_list:
+            f.write(f"    if (hw == {hw} && c == {c}) {{ constexpr int HW = {hw}, C = {c}; return __VA_ARGS__(); }} \\\n")
+        f.write(f"    throw std::invalid_argument(\"DISPATCH_HW_C \" + std::to_string(hw) + \" \" + std::to_string(c)); \\\n")
+        f.write(f"    }}()\n")
+
+
+if __name__ == "__main__":
+    run()

--- a/apex/contrib/csrc/group_norm_v2/generate_gn_cuda_inst.py
+++ b/apex/contrib/csrc/group_norm_v2/generate_gn_cuda_inst.py
@@ -30,9 +30,12 @@ def run():
         with open(src_path / f"gn_cuda_inst_{hw}_{c}.cu", "w") as f:
             f.write(f"#include \"gn_cuda_host_template.cuh\"\n")
             f.write(f"\n")
+            f.write(f"\n")
             f.write(f"namespace group_norm_v2 {{\n")
+            f.write(f"\n")
             f.write(f"GN_CUDA_INST_DEFINE({hw}, {c})\n")
-            f.write(f"}}\n")
+            f.write(f"\n")
+            f.write(f"}}  // namespace group_norm_v2\n")
 
     with open(src_path / "gn_dispatch_hw_c.hpp", "w") as f:
         f.write(f"#pragma once\n")

--- a/apex/contrib/csrc/group_norm_v2/gn.cpp
+++ b/apex/contrib/csrc/group_norm_v2/gn.cpp
@@ -97,7 +97,7 @@ auto gn_bwd(torch::Tensor grad_output, torch::Tensor x, torch::Tensor w, torch::
     return std::make_tuple(grad_input, grad_weight, grad_bias);
 }
 
-}
+}  // namespace group_norm_v2
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("gn", &group_norm_v2::gn, py::arg("x"), py::arg("w"), py::arg("b"), py::arg("eps"), py::arg("silu"), py::arg("num_groups"), py::arg("mean_var_out") = py::none(), py::arg("sm_margin") = 0, "");

--- a/apex/contrib/csrc/group_norm_v2/gn.cpp
+++ b/apex/contrib/csrc/group_norm_v2/gn.cpp
@@ -1,0 +1,105 @@
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+
+#include "gn.hpp"
+
+
+namespace group_norm_v2 {
+
+torch::Tensor gn(torch::Tensor x, torch::Tensor w, torch::Tensor b, float eps, bool silu, int num_groups, std::optional<torch::Tensor> mean_var_out, int sm_margin) {
+    if (w.dtype() != b.dtype() || (mean_var_out.has_value() && mean_var_out->dtype() != torch::kFloat32)) {
+        throw std::invalid_argument("gn dtype mismatch");
+    }
+    torch::Tensor out = torch::empty_like(x);
+    float *ptr_mean_var_out = mean_var_out.has_value() ? mean_var_out->data_ptr<float>() : nullptr;
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+    int device_id = at::cuda::getCurrentCUDAStream().device().index();
+    group_norm_v2::Meta meta;
+    if (x.dtype() == torch::kHalf && w.dtype() == torch::kHalf) {
+        group_norm_v2::gn_cuda(
+            (half *)out.data_ptr(), (half *)x.data_ptr(), (half *)w.data_ptr(), (half *)b.data_ptr(),
+            eps, silu, x.size(0), x.size(2) * x.size(3), num_groups, x.size(1) / num_groups, ptr_mean_var_out,
+            nullptr, nullptr, sm_margin, stream, device_id, &meta, true);
+    } else if (x.dtype() == torch::kBFloat16 && w.dtype() == torch::kBFloat16) {
+        group_norm_v2::gn_cuda(
+            (__nv_bfloat16 *)out.data_ptr(), (__nv_bfloat16 *)x.data_ptr(), (__nv_bfloat16 *)w.data_ptr(), (__nv_bfloat16 *)b.data_ptr(),
+            eps, silu, x.size(0), x.size(2) * x.size(3), num_groups, x.size(1) / num_groups, ptr_mean_var_out,
+            nullptr, nullptr, sm_margin, stream, device_id, &meta, true);
+    } else {
+        throw std::invalid_argument("gn only supports half or bfloat16 input and weight");
+    }
+    torch::Tensor red_buffer = torch::empty({meta.red_buffer_size}, torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA));
+    thread_local torch::Tensor barrier;
+    if (barrier.size(0) < meta.barrier_size) {
+        barrier = torch::zeros({meta.barrier_size}, torch::TensorOptions().dtype(torch::kUInt32).device(torch::kCUDA));
+    }
+    if (x.dtype() == torch::kHalf && w.dtype() == torch::kHalf) {
+        group_norm_v2::gn_cuda(
+            (half *)out.data_ptr(), (half *)x.data_ptr(), (half *)w.data_ptr(), (half *)b.data_ptr(),
+            eps, silu, x.size(0), x.size(2) * x.size(3), num_groups, x.size(1) / num_groups, ptr_mean_var_out,
+            red_buffer.data_ptr<float>(), barrier.data_ptr<unsigned>(), sm_margin, stream, device_id, nullptr, false);
+    } else if (x.dtype() == torch::kBFloat16 && w.dtype() == torch::kBFloat16) {
+        group_norm_v2::gn_cuda(
+            (__nv_bfloat16 *)out.data_ptr(), (__nv_bfloat16 *)x.data_ptr(), (__nv_bfloat16 *)w.data_ptr(), (__nv_bfloat16 *)b.data_ptr(),
+            eps, silu, x.size(0), x.size(2) * x.size(3), num_groups, x.size(1) / num_groups, ptr_mean_var_out,
+            red_buffer.data_ptr<float>(), barrier.data_ptr<unsigned>(), sm_margin, stream, device_id, nullptr, false);
+    } else {
+        throw std::invalid_argument("gn only supports half or bfloat16 input and weight");
+    }
+    return out;
+}
+
+auto gn_bwd(torch::Tensor grad_output, torch::Tensor x, torch::Tensor w, torch::Tensor b, torch::Tensor mean_var, float eps, bool silu, int num_groups, int sm_margin) {
+    if (w.dtype() != b.dtype() || x.dtype() != grad_output.dtype() || mean_var.dtype() != torch::kFloat32) {
+        throw std::invalid_argument("gn_bwd dtype mismatch");
+    }
+    torch::Tensor grad_input = torch::empty_like(x);
+    torch::Tensor grad_weight = torch::empty_like(w);
+    torch::Tensor grad_bias = torch::empty_like(w);
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+    int device_id = at::cuda::getCurrentCUDAStream().device().index();
+    group_norm_v2::Meta meta;
+    if (x.dtype() == torch::kHalf && w.dtype() == torch::kHalf) {
+        group_norm_v2::gn_bwd_cuda(
+            (half *)grad_input.data_ptr(), (half *)grad_weight.data_ptr(), (half *)grad_bias.data_ptr(),
+            (half *)grad_output.data_ptr(), (half *)x.data_ptr(), (half *)w.data_ptr(), (half *)b.data_ptr(), mean_var.data_ptr<float>(),
+            eps, silu, x.size(0), x.size(2) * x.size(3), num_groups, x.size(1) / num_groups,
+            nullptr, nullptr, sm_margin, stream, device_id, &meta, true);
+    } else if (x.dtype() == torch::kBFloat16 && w.dtype() == torch::kBFloat16) {
+        group_norm_v2::gn_bwd_cuda(
+            (__nv_bfloat16 *)grad_input.data_ptr(), (__nv_bfloat16 *)grad_weight.data_ptr(), (__nv_bfloat16 *)grad_bias.data_ptr(),
+            (__nv_bfloat16 *)grad_output.data_ptr(), (__nv_bfloat16 *)x.data_ptr(), (__nv_bfloat16 *)w.data_ptr(), (__nv_bfloat16 *)b.data_ptr(), mean_var.data_ptr<float>(),
+            eps, silu, x.size(0), x.size(2) * x.size(3), num_groups, x.size(1) / num_groups,
+            nullptr, nullptr, sm_margin, stream, device_id, &meta, true);
+    } else {
+        throw std::invalid_argument("gn only supports half or bfloat16 input and weight");
+    }
+    torch::Tensor red_buffer = torch::empty({meta.red_buffer_size}, torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA));
+    thread_local torch::Tensor barrier;
+    if (barrier.size(0) < meta.barrier_size) {
+        barrier = torch::zeros({meta.barrier_size}, torch::TensorOptions().dtype(torch::kUInt32).device(torch::kCUDA));
+    }
+    if (x.dtype() == torch::kHalf && w.dtype() == torch::kHalf) {
+        group_norm_v2::gn_bwd_cuda(
+            (half *)grad_input.data_ptr(), (half *)grad_weight.data_ptr(), (half *)grad_bias.data_ptr(),
+            (half *)grad_output.data_ptr(), (half *)x.data_ptr(), (half *)w.data_ptr(), (half *)b.data_ptr(), mean_var.data_ptr<float>(),
+            eps, silu, x.size(0), x.size(2) * x.size(3), num_groups, x.size(1) / num_groups,
+            red_buffer.data_ptr<float>(), barrier.data_ptr<unsigned>(), sm_margin, stream, device_id, nullptr, false);
+    } else if (x.dtype() == torch::kBFloat16 && w.dtype() == torch::kBFloat16) {
+        group_norm_v2::gn_bwd_cuda(
+            (__nv_bfloat16 *)grad_input.data_ptr(), (__nv_bfloat16 *)grad_weight.data_ptr(), (__nv_bfloat16 *)grad_bias.data_ptr(),
+            (__nv_bfloat16 *)grad_output.data_ptr(), (__nv_bfloat16 *)x.data_ptr(), (__nv_bfloat16 *)w.data_ptr(), (__nv_bfloat16 *)b.data_ptr(), mean_var.data_ptr<float>(),
+            eps, silu, x.size(0), x.size(2) * x.size(3), num_groups, x.size(1) / num_groups,
+            red_buffer.data_ptr<float>(), barrier.data_ptr<unsigned>(), sm_margin, stream, device_id, nullptr, false);
+    } else {
+        throw std::invalid_argument("gn only supports half or bfloat16 input and weight");
+    }
+    return std::make_tuple(grad_input, grad_weight, grad_bias);
+}
+
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("gn", &group_norm_v2::gn, py::arg("x"), py::arg("w"), py::arg("b"), py::arg("eps"), py::arg("silu"), py::arg("num_groups"), py::arg("mean_var_out") = py::none(), py::arg("sm_margin") = 0, "");
+    m.def("gn_bwd", &group_norm_v2::gn_bwd, py::arg("grad_output"), py::arg("x"), py::arg("w"), py::arg("b"), py::arg("mean_var"), py::arg("eps"), py::arg("silu"), py::arg("num_groups"), py::arg("sm_margin") = 0, "");
+}

--- a/apex/contrib/csrc/group_norm_v2/gn.hpp
+++ b/apex/contrib/csrc/group_norm_v2/gn.hpp
@@ -25,4 +25,4 @@ void gn_cuda(T *out, T *x, T *w, T *b, float eps, bool silu, int64_t n, int64_t 
 template<typename T>
 void gn_bwd_cuda(T *grad_input, T *grad_weight, T *grad_bias, T *grad_output, T *x, T *w, T *b, float *mean_var, float eps, bool silu, int64_t n, int64_t hw, int num_groups, int channels_per_group, float *red_buffer, unsigned *barrier, int sm_margin, cudaStream_t stream, int device_id, Meta *meta_ptr, bool meta_only);
 
-}
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn.hpp
+++ b/apex/contrib/csrc/group_norm_v2/gn.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+#include <cuda_runtime.h>
+
+
+namespace group_norm_v2 {
+
+struct Meta {
+    int64_t red_buffer_size;
+    int64_t barrier_size;
+    int BLOCK_DIM_X;
+    int C_PER_BLOCK;
+    int ROWS_PER_BLOCK;
+    int VEC_ELEMS;
+    bool LOAD_TWICE;
+    int BLOCKS_PER_SM;
+    bool HARDWARE_CLUSTER;
+    int wgrad_sync_method;
+};
+
+template<typename T>
+void gn_cuda(T *out, T *x, T *w, T *b, float eps, bool silu, int64_t n, int64_t hw, int num_groups, int channels_per_group, float *mean_var_out, float *red_buffer, unsigned *barrier, int sm_margin, cudaStream_t stream, int device_id, Meta *meta_ptr, bool meta_only);
+
+template<typename T>
+void gn_bwd_cuda(T *grad_input, T *grad_weight, T *grad_bias, T *grad_output, T *x, T *w, T *b, float *mean_var, float eps, bool silu, int64_t n, int64_t hw, int num_groups, int channels_per_group, float *red_buffer, unsigned *barrier, int sm_margin, cudaStream_t stream, int device_id, Meta *meta_ptr, bool meta_only);
+
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda.cu
@@ -1,0 +1,54 @@
+#include "gn.hpp"
+
+#include <cstdio>
+#include <mutex>
+#include <stdexcept>
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+#include "gn_utils.hpp"
+#include "gn_dispatch_hw_c.hpp"
+
+
+#define DISPATCH_G_SILU(g, silu, G, SILU, ...) [&] { \
+    if (g == 16 && silu == (g == 16)) { constexpr int G = 16; constexpr bool SILU = G == 16; return __VA_ARGS__(); } \
+    if (g == 32 && silu == (g == 16)) { constexpr int G = 32; constexpr bool SILU = G == 16; return __VA_ARGS__(); } \
+    throw std::invalid_argument("DISPATCH_G_SILU " + std::to_string(g) + " " + std::to_string(silu)); \
+    }()
+
+namespace group_norm_v2 {
+
+template<typename T, int HW, int C, int G, bool SILU>
+void gn_cuda_single_shape(GN_CUDA_HOST_PARAMS(T));
+
+template<typename T, int HW, int C, int G, bool SILU>
+void gn_bwd_cuda_single_shape(GN_BWD_CUDA_HOST_PARAMS(T));
+
+template<typename T>
+void gn_cuda(GN_CUDA_HOST_PARAMS(T)) {
+    DISPATCH_HW_C(hw, num_groups * channels_per_group, HW, C, [&] {
+        DISPATCH_G_SILU(num_groups, silu, G, SILU, [&] {
+            return gn_cuda_single_shape<T, HW, C, G, SILU>(GN_CUDA_HOST_ARGS);
+        });
+    });
+}
+
+template<typename T>
+void gn_bwd_cuda(GN_BWD_CUDA_HOST_PARAMS(T)) {
+    DISPATCH_HW_C(hw, num_groups * channels_per_group, HW, C, [&] {
+        DISPATCH_G_SILU(num_groups, silu, G, SILU, [&] {
+            return gn_bwd_cuda_single_shape<T, HW, C, G, SILU>(GN_BWD_CUDA_HOST_ARGS);
+        });
+    });
+}
+
+template void gn_cuda(GN_CUDA_HOST_PARAMS(half));
+template void gn_cuda(GN_CUDA_HOST_PARAMS(__nv_bfloat16));
+
+template void gn_bwd_cuda(GN_BWD_CUDA_HOST_PARAMS(half));
+template void gn_bwd_cuda(GN_BWD_CUDA_HOST_PARAMS(__nv_bfloat16));
+
+
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_host_template.cuh
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_host_template.cuh
@@ -378,7 +378,7 @@ void gn_bwd_cuda_single_shape(GN_BWD_CUDA_HOST_PARAMS(T)) {
             constexpr WgradSyncMethod wgrad_sync_method =
                 wgrad_sync_method_hint == WGRAD_SYNC_UNSPECIFIED ?
                     NUM_VIRTUAL_CLUSTERS_NOT_ALIGNED > 2 * (C / C_PER_CLUSTER) || NUM_VIRTUAL_CLUSTERS_NOT_ALIGNED % (C / C_PER_CLUSTER) == 0 ?
-                        WGRAD_REUSE_SUM_SYNC_GROUP :
+                        (HARDWARE_CLUSTER ? WGRAD_ARRIVE_AND_WAIT_GROUP : WGRAD_REUSE_SUM_SYNC_GROUP) :
                         WGRAD_REUSE_SUM_SYNC_GRID :
                     wgrad_sync_method_hint;
             constexpr int NUM_VIRTUAL_CLUSTERS =

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_host_template.cuh
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_host_template.cuh
@@ -49,11 +49,12 @@ template<typename T, bool BWD, bool REQUIRES_WGRAD, int HW, int G, int CPG, int 
 constexpr auto compute_gn_params() {
     constexpr int C = G * CPG;
 
-    int BLOCK_DIM_X;
-    int C_PER_BLOCK;
-    int ROWS_PER_BLOCK;
-    bool LOAD_TWICE;
-    int BLOCKS_PER_SM;
+    // Initialize each variable to comply with C++17
+    int BLOCK_DIM_X = 0;
+    int C_PER_BLOCK = 0;
+    int ROWS_PER_BLOCK = 0;
+    bool LOAD_TWICE = false;
+    int BLOCKS_PER_SM = 0;
     WgradSyncMethod wgrad_sync_method = WGRAD_SYNC_UNSPECIFIED;
 
     // There are two tiling strategies:
@@ -120,7 +121,15 @@ constexpr auto compute_gn_params() {
                     -blocks_per_sm,             // Prefer fewer blocks per SM in order to reduce threads overhead
                 };
                 if (candidate > best_candidate) {
-                    best_candidate = candidate;
+                    // Assign each element respectively to comply with C++17
+                    std::get<0>(best_candidate) = std::get<0>(candidate);
+                    std::get<1>(best_candidate) = std::get<1>(candidate);
+                    std::get<2>(best_candidate) = std::get<2>(candidate);
+                    std::get<3>(best_candidate) = std::get<3>(candidate);
+                    std::get<4>(best_candidate) = std::get<4>(candidate);
+                    std::get<5>(best_candidate) = std::get<5>(candidate);
+                    static_assert(std::tuple_size<decltype(best_candidate)>::value == 6, "missing assignments");
+
                     BLOCKS_PER_SM = blocks_per_sm;
                     ROWS_PER_BLOCK = rows_per_block;
                 }

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_host_template.cuh
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_host_template.cuh
@@ -418,4 +418,4 @@ void gn_bwd_cuda_single_shape(GN_BWD_CUDA_HOST_PARAMS(T)) {
     template void gn_bwd_cuda_single_shape<__nv_bfloat16, HW, C, 16, true>(GN_BWD_CUDA_HOST_PARAMS(__nv_bfloat16)); \
     template void gn_bwd_cuda_single_shape<__nv_bfloat16, HW, C, 32, false>(GN_BWD_CUDA_HOST_PARAMS(__nv_bfloat16));
 
-}
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_host_template.cuh
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_host_template.cuh
@@ -1,0 +1,421 @@
+#pragma once
+
+#include <cstdio>
+#include <stdexcept>
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+
+#include "gn_utils.hpp"
+#include "gn_cuda_kernel.cuh"
+
+
+namespace group_norm_v2 {
+
+#define DISPATCH_LOWER_BOUND_N(VALUE, CONST_NAME, ...) [&] { \
+    if (VALUE >= 16) { constexpr int CONST_NAME = 16; return __VA_ARGS__(); } \
+    if (VALUE >= 8) { constexpr int CONST_NAME = 8; return __VA_ARGS__(); } \
+    if (VALUE >= 4) { constexpr int CONST_NAME = 4; return __VA_ARGS__(); } \
+    if (VALUE >= 2) { constexpr int CONST_NAME = 2; return __VA_ARGS__(); } \
+    if (VALUE >= 1) { constexpr int CONST_NAME = 1; return __VA_ARGS__(); } \
+    throw std::invalid_argument("DISPATCH_LOWER_BOUND_N " + std::to_string(VALUE)); \
+    }()
+
+#define DISPATCH_CUDA_ARCH_AND_LOWER_BOUND_SM_COUNT(runtime_cuda_arch, sm_count, RUNTIME_CUDA_ARCH, LB_SM_COUNT, ...) [&] { \
+    if (runtime_cuda_arch == 1000 && sm_count >= 148 && sm_count == 148) { constexpr int RUNTIME_CUDA_ARCH = 1000, LB_SM_COUNT = 148; return __VA_ARGS__(); } \
+    throw std::invalid_argument("DISPATCH_CUDA_ARCH_AND_LOWER_BOUND_SM_COUNT " + std::to_string(runtime_cuda_arch) + " " + std::to_string(sm_count)); \
+    }()
+
+#define DISPATCH_SM_MARGIN(VALUE, CONST_NAME, ...) [&] { \
+    if (VALUE == 0) { constexpr int CONST_NAME = 0; return __VA_ARGS__(); } \
+    if (VALUE == 32) { constexpr int CONST_NAME = 32; return __VA_ARGS__(); } \
+    throw std::invalid_argument("DISPATCH_SM_MARGIN " + std::to_string(VALUE)); \
+    }()
+
+
+inline constexpr int get_max_cuda_arch() {
+    int cuda_arch_list[] = {__CUDA_ARCH_LIST__};
+    int max_cuda_arch = -1;
+    for (int cuda_arch_item : cuda_arch_list) {
+        if (cuda_arch_item > max_cuda_arch) {
+            max_cuda_arch = cuda_arch_item;
+        }
+    }
+    return max_cuda_arch;
+}
+
+template<typename T, bool BWD, bool REQUIRES_WGRAD, int HW, int G, int CPG, int LB_N, int RUNTIME_CUDA_ARCH, int LB_SM_COUNT, int EFFECTIVE_CUDA_ARCH, int SM_MARGIN>
+constexpr auto compute_gn_params() {
+    constexpr int C = G * CPG;
+
+    int BLOCK_DIM_X;
+    int C_PER_BLOCK;
+    int ROWS_PER_BLOCK;
+    bool LOAD_TWICE;
+    int BLOCKS_PER_SM;
+    WgradSyncMethod wgrad_sync_method = WGRAD_SYNC_UNSPECIFIED;
+
+    if (HW * CPG * (1 + BWD) * sizeof(T) <= 20480) {
+        // block sync
+        C_PER_BLOCK = CPG;
+        ROWS_PER_BLOCK = HW;
+        BLOCK_DIM_X = lcm(32, C_PER_BLOCK);
+        while (BLOCK_DIM_X < 256) {
+            BLOCK_DIM_X *= 2;
+        }
+        BLOCKS_PER_SM = 1;
+        LOAD_TWICE = BLOCKS_PER_SM * ROWS_PER_BLOCK * C_PER_BLOCK * (1 + BWD) * sizeof(T) > 36000 * 4;
+    } else {
+        // virtual cluster sync
+        int c_per_cluster = lcm(128 / (int)sizeof(T), CPG);
+
+        C_PER_BLOCK = c_per_cluster;
+        BLOCK_DIM_X = C_PER_BLOCK == 320 ? 320 : 480;
+
+        int one_pass_max_rows = 36000 * 4 / (C_PER_BLOCK * (1 + BWD) * sizeof(T));
+
+        std::tuple<bool, int, int, int, int, int> best_candidate{};
+        BLOCKS_PER_SM = 0;
+        ROWS_PER_BLOCK = 0;
+        for (int blocks_per_sm = 1; blocks_per_sm <= 3; blocks_per_sm++) {
+            for (int rows_per_block = HW; rows_per_block >= 1; rows_per_block /= 2) {
+                int virtual_cluster_size = (HW / rows_per_block) * (c_per_cluster / C_PER_BLOCK);
+                if (virtual_cluster_size > blocks_per_sm * (LB_SM_COUNT - SM_MARGIN)) {
+                    continue;
+                }
+                int num_clusters = blocks_per_sm * (LB_SM_COUNT - SM_MARGIN) / virtual_cluster_size;
+                int num_tasks = LB_N * (C / c_per_cluster);
+                int num_waves = up_div(num_tasks, num_clusters);
+                bool load_twice = rows_per_block > one_pass_max_rows / blocks_per_sm;
+                int wave_util = 10000 * std::min(num_tasks, num_clusters) * virtual_cluster_size / (blocks_per_sm * (LB_SM_COUNT - SM_MARGIN));
+                decltype(best_candidate) candidate = {
+                    true,
+                    !load_twice,
+                    !(num_waves >= 2 && blocks_per_sm == 1),  // overlap
+                    -num_waves,
+                    std::min(9000, wave_util),
+                    -blocks_per_sm,
+                };
+                if (candidate > best_candidate) {
+                    best_candidate = candidate;
+                    BLOCKS_PER_SM = blocks_per_sm;
+                    ROWS_PER_BLOCK = rows_per_block;
+                }
+            }
+        }
+
+        LOAD_TWICE = ROWS_PER_BLOCK > one_pass_max_rows / BLOCKS_PER_SM;
+    }
+
+    int c_per_cluster = lcm(CPG, C_PER_BLOCK);
+    int virtual_cluster_size = (c_per_cluster / C_PER_BLOCK) * (HW / ROWS_PER_BLOCK);
+    bool HARDWARE_CLUSTER = virtual_cluster_size <= 2 && virtual_cluster_size != 1 && SM_MARGIN == 0;
+    int MAX_VEC_BYTES = 8;
+    int VEC_ELEMS = std::min(gcd(MAX_VEC_BYTES / (int)sizeof(T), C_PER_BLOCK),
+                             gcd(MAX_VEC_BYTES / (int)sizeof(T), ROWS_PER_BLOCK * C_PER_BLOCK / BLOCK_DIM_X));
+
+    return std::make_tuple(
+        BLOCK_DIM_X,
+        C_PER_BLOCK,
+        ROWS_PER_BLOCK,
+        VEC_ELEMS,
+        LOAD_TWICE,
+        BLOCKS_PER_SM,
+        HARDWARE_CLUSTER,
+        wgrad_sync_method
+    );
+}
+
+template<int EFFECTIVE_CUDA_ARCH>
+class CompileCondition {
+public:
+    // Save compilation time for unused CUDA_ARCHs
+    __host__ __device__ static constexpr bool matches() {
+#if defined(__CUDA_ARCH__)
+        return __CUDA_ARCH__ == EFFECTIVE_CUDA_ARCH;
+#else
+        return false;
+#endif
+    }
+};
+
+template<typename T, int HW, int C, int G, bool SILU>
+void gn_cuda_single_shape(GN_CUDA_HOST_PARAMS(T)) {
+    if (out == x) {
+        throw std::invalid_argument("not __restrict__");
+    }
+
+    cudaDeviceProp const &deviceProp = get_device_prop(device_id);
+    int runtime_cuda_arch = deviceProp.major * 100 + deviceProp.minor * 10;
+    int sm_count = deviceProp.multiProcessorCount;
+
+    DISPATCH_LOWER_BOUND_N(n, LB_N, [&] {
+        DISPATCH_CUDA_ARCH_AND_LOWER_BOUND_SM_COUNT(runtime_cuda_arch, sm_count, RUNTIME_CUDA_ARCH, LB_SM_COUNT, [&] {
+        DISPATCH_SM_MARGIN(sm_margin, SM_MARGIN, [&] {
+            if (hw != HW) {
+                throw std::invalid_argument("wrong HW");
+            }
+            if (num_groups * channels_per_group != C) {
+                throw std::invalid_argument("wrong C");
+            }
+            if (num_groups != G) {
+                throw std::invalid_argument("wrong G");
+            }
+            if (silu != SILU) {
+                throw std::invalid_argument("wrong SILU");
+            }
+            if (n < LB_N) {
+                throw std::invalid_argument("wrong LB_N");
+            }
+            if (runtime_cuda_arch != RUNTIME_CUDA_ARCH) {
+                throw std::invalid_argument("wrong RUNTIME_CUDA_ARCH");
+            }
+            if (sm_count < LB_SM_COUNT) {
+                throw std::invalid_argument("wrong LB_SM_COUNT");
+            }
+            if (sm_margin != SM_MARGIN) {
+                throw std::invalid_argument("wrong SM_MARGIN");
+            }
+            constexpr int EFFECTIVE_CUDA_ARCH = std::min(RUNTIME_CUDA_ARCH, get_max_cuda_arch());
+
+            constexpr int CPG = C / G;
+
+            constexpr auto params = compute_gn_params<T, false, false, HW, G, CPG, LB_N, RUNTIME_CUDA_ARCH, LB_SM_COUNT, EFFECTIVE_CUDA_ARCH, SM_MARGIN>();
+            constexpr int BLOCK_DIM_X =       std::get<0>(params);
+            constexpr int C_PER_BLOCK =       std::get<1>(params);
+            constexpr int ROWS_PER_BLOCK =    std::get<2>(params);
+            constexpr int VEC_ELEMS =         std::get<3>(params);
+            constexpr bool LOAD_TWICE =       std::get<4>(params);
+            constexpr int BLOCKS_PER_SM =     std::get<5>(params);
+            constexpr bool HARDWARE_CLUSTER = std::get<6>(params);
+
+            constexpr int C_PER_CLUSTER = lcm(CPG, C_PER_BLOCK);
+            constexpr int VIRTUAL_CLUSTER_SIZE = (C_PER_CLUSTER / C_PER_BLOCK) * (HW / ROWS_PER_BLOCK);
+            constexpr int NUM_VIRTUAL_CLUSTERS = ((LB_SM_COUNT - SM_MARGIN) * BLOCKS_PER_SM) / VIRTUAL_CLUSTER_SIZE;
+            constexpr bool PERSISTENT = !HARDWARE_CLUSTER && VIRTUAL_CLUSTER_SIZE >= 2;
+
+            if (meta_ptr) {
+                constexpr int MAX_NUM_GROUPS_PER_BLOCK = C_PER_BLOCK % CPG == 0 ? C_PER_BLOCK / CPG : up_div(C_PER_BLOCK - gcd(C_PER_BLOCK, CPG), CPG) + 1;
+                meta_ptr->red_buffer_size = 2 * NUM_VIRTUAL_CLUSTERS * VIRTUAL_CLUSTER_SIZE * MAX_NUM_GROUPS_PER_BLOCK * 2;
+                meta_ptr->barrier_size = NUM_VIRTUAL_CLUSTERS;
+                meta_ptr->BLOCK_DIM_X = BLOCK_DIM_X;
+                meta_ptr->C_PER_BLOCK = C_PER_BLOCK;
+                meta_ptr->ROWS_PER_BLOCK = ROWS_PER_BLOCK;
+                meta_ptr->VEC_ELEMS = VEC_ELEMS;
+                meta_ptr->LOAD_TWICE = LOAD_TWICE;
+                meta_ptr->BLOCKS_PER_SM = BLOCKS_PER_SM;
+                meta_ptr->HARDWARE_CLUSTER = HARDWARE_CLUSTER;
+                meta_ptr->wgrad_sync_method = (int)WGRAD_SYNC_UNSPECIFIED;
+            }
+            if (meta_only) {
+                return;
+            }
+
+            cudaLaunchConfig_t config = {0};
+            // The grid dimension is not affected by cluster launch, and is still enumerated
+            // using number of blocks.
+            // The grid dimension should be a multiple of cluster size.
+            config.gridDim = dim3(VIRTUAL_CLUSTER_SIZE, PERSISTENT ? std::min((int)n * (C / C_PER_CLUSTER), NUM_VIRTUAL_CLUSTERS) : n * (C / C_PER_CLUSTER), 1);
+            config.blockDim = BLOCK_DIM_X;
+            config.stream = stream;
+
+            cudaLaunchAttribute attribute[2];
+            if constexpr (HARDWARE_CLUSTER) {
+                attribute[0].id = cudaLaunchAttributeClusterDimension;
+                attribute[0].val.clusterDim.x = VIRTUAL_CLUSTER_SIZE; // Cluster size in X-dimension
+                attribute[0].val.clusterDim.y = 1;
+                attribute[0].val.clusterDim.z = 1;
+                config.attrs = attribute;
+                config.numAttrs++;
+            }
+            if constexpr (PERSISTENT) {
+                attribute[config.numAttrs].id = cudaLaunchAttributeCooperative;
+                attribute[config.numAttrs].val.cooperative = 1;
+                config.attrs = attribute;
+                config.numAttrs++;
+            }
+
+            auto kernel = &gn_cuda_kernel<T, BLOCK_DIM_X, BLOCKS_PER_SM, G, CPG, HW, SILU, ROWS_PER_BLOCK, C_PER_BLOCK, C_PER_CLUSTER, VEC_ELEMS, PERSISTENT, NUM_VIRTUAL_CLUSTERS, LOAD_TWICE, HARDWARE_CLUSTER, CompileCondition<EFFECTIVE_CUDA_ARCH> >;
+            if constexpr (HARDWARE_CLUSTER) {
+                if constexpr (VIRTUAL_CLUSTER_SIZE > 8) {
+                    CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeNonPortableClusterSizeAllowed, 1));
+                }
+                int max_cluster_size;
+                int active_clusters;
+                CUDA_CHECK(cudaOccupancyMaxPotentialClusterSize(&max_cluster_size, (void *)kernel, &config));
+                if (VIRTUAL_CLUSTER_SIZE <= max_cluster_size && PERSISTENT) {
+                    attribute[0].val.clusterDim.x = VIRTUAL_CLUSTER_SIZE;
+                    CUDA_CHECK(cudaOccupancyMaxActiveClusters(&active_clusters, (void *)kernel, &config));
+                }
+                if (VIRTUAL_CLUSTER_SIZE <= max_cluster_size && (!PERSISTENT || PERSISTENT && NUM_VIRTUAL_CLUSTERS <= active_clusters)) {
+                    attribute[0].val.clusterDim.x = VIRTUAL_CLUSTER_SIZE;
+                } else {
+                    constexpr bool HARDWARE_CLUSTER_NEW = false;
+                    constexpr bool PERSISTENT_NEW = !HARDWARE_CLUSTER_NEW && VIRTUAL_CLUSTER_SIZE >= 2;
+                    config.gridDim = dim3(VIRTUAL_CLUSTER_SIZE, PERSISTENT_NEW ? std::min((int)n * (C / C_PER_CLUSTER), NUM_VIRTUAL_CLUSTERS) : n * (C / C_PER_CLUSTER), 1);
+                    config.attrs = nullptr;
+                    config.numAttrs = 0;
+                    if constexpr (PERSISTENT_NEW) {
+                        attribute[config.numAttrs].id = cudaLaunchAttributeCooperative;
+                        attribute[config.numAttrs].val.cooperative = 1;
+                        config.attrs = attribute;
+                        config.numAttrs++;
+                    }
+                    kernel = &gn_cuda_kernel<T, BLOCK_DIM_X, BLOCKS_PER_SM, G, CPG, HW, SILU, ROWS_PER_BLOCK, C_PER_BLOCK, C_PER_CLUSTER, VEC_ELEMS, PERSISTENT_NEW, NUM_VIRTUAL_CLUSTERS, LOAD_TWICE, HARDWARE_CLUSTER_NEW, CompileCondition<EFFECTIVE_CUDA_ARCH> >;
+                }
+            }
+            CUDA_CHECK(cudaLaunchKernelEx(&config, kernel, out, x, w, b, eps, n, mean_var_out, red_buffer, barrier));
+        });
+        });
+    });
+}
+
+
+template<typename T, int HW, int C, int G, bool SILU>
+void gn_bwd_cuda_single_shape(GN_BWD_CUDA_HOST_PARAMS(T)) {
+    if (grad_input == grad_output || grad_input == x) {
+        throw std::invalid_argument("not __restrict__");
+    }
+
+    cudaDeviceProp const &deviceProp = get_device_prop(device_id);
+    int runtime_cuda_arch = deviceProp.major * 100 + deviceProp.minor * 10;
+    int sm_count = deviceProp.multiProcessorCount;
+
+    DISPATCH_LOWER_BOUND_N(n, LB_N, [&] {
+        DISPATCH_CUDA_ARCH_AND_LOWER_BOUND_SM_COUNT(runtime_cuda_arch, sm_count, RUNTIME_CUDA_ARCH, LB_SM_COUNT, [&] {
+        DISPATCH_SM_MARGIN(sm_margin, SM_MARGIN, [&] {
+            if (hw != HW) {
+                throw std::invalid_argument("wrong HW");
+            }
+            if (num_groups * channels_per_group != C) {
+                throw std::invalid_argument("wrong C");
+            }
+            if (num_groups != G) {
+                throw std::invalid_argument("wrong G");
+            }
+            if (silu != SILU) {
+                throw std::invalid_argument("wrong SILU");
+            }
+            if (n < LB_N) {
+                throw std::invalid_argument("wrong LB_N");
+            }
+            if (runtime_cuda_arch != RUNTIME_CUDA_ARCH) {
+                throw std::invalid_argument("wrong RUNTIME_CUDA_ARCH");
+            }
+            if (sm_count < LB_SM_COUNT) {
+                throw std::invalid_argument("wrong LB_SM_COUNT");
+            }
+            if (sm_margin != SM_MARGIN) {
+                throw std::invalid_argument("wrong SM_MARGIN");
+            }
+            constexpr int EFFECTIVE_CUDA_ARCH = std::min(RUNTIME_CUDA_ARCH, get_max_cuda_arch());
+
+            constexpr bool REQUIRES_WGRAD = true;
+            constexpr int CPG = C / G;
+
+            constexpr auto params = compute_gn_params<T, true, REQUIRES_WGRAD, HW, G, CPG, LB_N, RUNTIME_CUDA_ARCH, LB_SM_COUNT, EFFECTIVE_CUDA_ARCH, SM_MARGIN>();
+            constexpr int BLOCK_DIM_X =       std::get<0>(params);
+            constexpr int C_PER_BLOCK =       std::get<1>(params);
+            constexpr int ROWS_PER_BLOCK =    std::get<2>(params);
+            constexpr int VEC_ELEMS =         std::get<3>(params);
+            constexpr bool LOAD_TWICE =       std::get<4>(params);
+            constexpr int BLOCKS_PER_SM =     std::get<5>(params);
+            constexpr bool HARDWARE_CLUSTER = std::get<6>(params);
+            constexpr WgradSyncMethod wgrad_sync_method_hint = std::get<7>(params);
+
+            constexpr int C_PER_CLUSTER = lcm(CPG, C_PER_BLOCK);
+            constexpr int VIRTUAL_CLUSTER_SIZE = (C_PER_CLUSTER / C_PER_BLOCK) * (HW / ROWS_PER_BLOCK);
+            constexpr int NUM_VIRTUAL_CLUSTERS_NOT_ALIGNED = ((LB_SM_COUNT - SM_MARGIN) * BLOCKS_PER_SM) / VIRTUAL_CLUSTER_SIZE;
+
+            // TODO: specilize for the case that REQUIRES_WGRAD == false
+            constexpr bool PERSISTENT = true;
+            constexpr WgradSyncMethod wgrad_sync_method =
+                wgrad_sync_method_hint == WGRAD_SYNC_UNSPECIFIED ?
+                    NUM_VIRTUAL_CLUSTERS_NOT_ALIGNED > 2 * (C / C_PER_CLUSTER) || NUM_VIRTUAL_CLUSTERS_NOT_ALIGNED % (C / C_PER_CLUSTER) == 0 ?
+                        WGRAD_REUSE_SUM_SYNC_GROUP :
+                        WGRAD_REUSE_SUM_SYNC_GRID :
+                    wgrad_sync_method_hint;
+            constexpr int NUM_VIRTUAL_CLUSTERS =
+                wgrad_sync_method == WGRAD_ARRIVE_AND_WAIT_GROUP || wgrad_sync_method == WGRAD_REUSE_SUM_SYNC_GROUP ?
+                    NUM_VIRTUAL_CLUSTERS_NOT_ALIGNED / (C / C_PER_CLUSTER) * (C / C_PER_CLUSTER) :
+                    NUM_VIRTUAL_CLUSTERS_NOT_ALIGNED;
+
+            if (meta_ptr) {
+                constexpr int MAX_NUM_GROUPS_PER_BLOCK = C_PER_BLOCK % CPG == 0 ? C_PER_BLOCK / CPG : up_div(C_PER_BLOCK - gcd(C_PER_BLOCK, CPG), CPG) + 1;
+                meta_ptr->red_buffer_size = 2 * NUM_VIRTUAL_CLUSTERS * VIRTUAL_CLUSTER_SIZE * MAX_NUM_GROUPS_PER_BLOCK * 2 +
+                    std::max(n, (int64_t)NUM_VIRTUAL_CLUSTERS / (C / C_PER_CLUSTER)) * (HW / ROWS_PER_BLOCK) * C * 2;
+                meta_ptr->barrier_size = NUM_VIRTUAL_CLUSTERS + C / C_PER_CLUSTER;
+                meta_ptr->BLOCK_DIM_X = BLOCK_DIM_X;
+                meta_ptr->C_PER_BLOCK = C_PER_BLOCK;
+                meta_ptr->ROWS_PER_BLOCK = ROWS_PER_BLOCK;
+                meta_ptr->VEC_ELEMS = VEC_ELEMS;
+                meta_ptr->LOAD_TWICE = LOAD_TWICE;
+                meta_ptr->BLOCKS_PER_SM = BLOCKS_PER_SM;
+                meta_ptr->HARDWARE_CLUSTER = HARDWARE_CLUSTER;
+                meta_ptr->wgrad_sync_method = (int)wgrad_sync_method;
+            }
+            if (meta_only) {
+                return;
+            }
+
+            cudaLaunchConfig_t config = {0};
+            // The grid dimension is not affected by cluster launch, and is still enumerated
+            // using number of blocks.
+            // The grid dimension should be a multiple of cluster size.
+            config.gridDim = dim3(VIRTUAL_CLUSTER_SIZE, PERSISTENT ? NUM_VIRTUAL_CLUSTERS : n * (C / C_PER_CLUSTER), 1);
+            config.blockDim = BLOCK_DIM_X;
+            config.stream = stream;
+
+            cudaLaunchAttribute attribute[2];
+            if constexpr (HARDWARE_CLUSTER) {
+                attribute[0].id = cudaLaunchAttributeClusterDimension;
+                attribute[0].val.clusterDim.x = 1; // Cluster size in X-dimension
+                attribute[0].val.clusterDim.y = 1;
+                attribute[0].val.clusterDim.z = 1;
+                config.attrs = attribute;
+                config.numAttrs++;
+            }
+            if constexpr (PERSISTENT) {
+                attribute[config.numAttrs].id = cudaLaunchAttributeCooperative;
+                attribute[config.numAttrs].val.cooperative = 1;
+                config.attrs = attribute;
+                config.numAttrs++;
+            }
+
+            auto kernel = &gn_bwd_cuda_kernel<T, BLOCK_DIM_X, BLOCKS_PER_SM, G, CPG, HW, SILU, REQUIRES_WGRAD, ROWS_PER_BLOCK, C_PER_BLOCK, C_PER_CLUSTER, VEC_ELEMS, PERSISTENT, NUM_VIRTUAL_CLUSTERS, LOAD_TWICE, HARDWARE_CLUSTER, wgrad_sync_method, CompileCondition<EFFECTIVE_CUDA_ARCH> >;
+            if constexpr (HARDWARE_CLUSTER) {
+                if constexpr (VIRTUAL_CLUSTER_SIZE > 8) {
+                    CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeNonPortableClusterSizeAllowed, 1));
+                }
+                int max_cluster_size;
+                int active_clusters;
+                CUDA_CHECK(cudaOccupancyMaxPotentialClusterSize(&max_cluster_size, (void *)kernel, &config));
+                if (VIRTUAL_CLUSTER_SIZE <= max_cluster_size && PERSISTENT) {
+                    attribute[0].val.clusterDim.x = VIRTUAL_CLUSTER_SIZE;
+                    CUDA_CHECK(cudaOccupancyMaxActiveClusters(&active_clusters, (void *)kernel, &config));
+                }
+                if (VIRTUAL_CLUSTER_SIZE <= max_cluster_size && (!PERSISTENT || PERSISTENT && NUM_VIRTUAL_CLUSTERS <= active_clusters)) {
+                    attribute[0].val.clusterDim.x = VIRTUAL_CLUSTER_SIZE;
+                } else {
+                    attribute[0].val.clusterDim.x = 1;
+                    kernel = &gn_bwd_cuda_kernel<T, BLOCK_DIM_X, BLOCKS_PER_SM, G, CPG, HW, SILU, REQUIRES_WGRAD, ROWS_PER_BLOCK, C_PER_BLOCK, C_PER_CLUSTER, VEC_ELEMS, PERSISTENT, NUM_VIRTUAL_CLUSTERS, LOAD_TWICE, false, wgrad_sync_method, CompileCondition<EFFECTIVE_CUDA_ARCH> >;
+                }
+            }
+            CUDA_CHECK(cudaLaunchKernelEx(&config, kernel, grad_input, grad_weight, grad_bias, grad_output, x, w, b, mean_var, eps, n, red_buffer, barrier));
+        });
+        });
+    });
+}
+
+#define GN_CUDA_INST_DEFINE(HW, C) \
+    template void gn_cuda_single_shape<half, HW, C, 16, true>(GN_CUDA_HOST_PARAMS(half)); \
+    template void gn_cuda_single_shape<half, HW, C, 32, false>(GN_CUDA_HOST_PARAMS(half)); \
+    template void gn_bwd_cuda_single_shape<half, HW, C, 16, true>(GN_BWD_CUDA_HOST_PARAMS(half)); \
+    template void gn_bwd_cuda_single_shape<half, HW, C, 32, false>(GN_BWD_CUDA_HOST_PARAMS(half)); \
+    template void gn_cuda_single_shape<__nv_bfloat16, HW, C, 16, true>(GN_CUDA_HOST_PARAMS(__nv_bfloat16)); \
+    template void gn_cuda_single_shape<__nv_bfloat16, HW, C, 32, false>(GN_CUDA_HOST_PARAMS(__nv_bfloat16)); \
+    template void gn_bwd_cuda_single_shape<__nv_bfloat16, HW, C, 16, true>(GN_BWD_CUDA_HOST_PARAMS(__nv_bfloat16)); \
+    template void gn_bwd_cuda_single_shape<__nv_bfloat16, HW, C, 32, false>(GN_BWD_CUDA_HOST_PARAMS(__nv_bfloat16));
+
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_host_template.cuh
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_host_template.cuh
@@ -23,7 +23,7 @@ namespace group_norm_v2 {
     }()
 
 #define DISPATCH_CUDA_ARCH_AND_LOWER_BOUND_SM_COUNT(runtime_cuda_arch, sm_count, RUNTIME_CUDA_ARCH, LB_SM_COUNT, ...) [&] { \
-    if (runtime_cuda_arch == 1000 && sm_count >= 148 && sm_count == 148) { constexpr int RUNTIME_CUDA_ARCH = 1000, LB_SM_COUNT = 148; return __VA_ARGS__(); } \
+    if (runtime_cuda_arch == 1000 && sm_count >= 148) { constexpr int RUNTIME_CUDA_ARCH = 1000, LB_SM_COUNT = 148; return __VA_ARGS__(); } \
     throw std::invalid_argument("DISPATCH_CUDA_ARCH_AND_LOWER_BOUND_SM_COUNT " + std::to_string(runtime_cuda_arch) + " " + std::to_string(sm_count)); \
     }()
 

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_1280.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_1280.cu
@@ -1,5 +1,8 @@
 #include "gn_cuda_host_template.cuh"
 
+
 namespace group_norm_v2 {
+
 GN_CUDA_INST_DEFINE(1024, 1280)
-}
+
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_1280.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_1280.cu
@@ -1,0 +1,5 @@
+#include "gn_cuda_host_template.cuh"
+
+namespace group_norm_v2 {
+GN_CUDA_INST_DEFINE(1024, 1280)
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_1920.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_1920.cu
@@ -1,0 +1,5 @@
+#include "gn_cuda_host_template.cuh"
+
+namespace group_norm_v2 {
+GN_CUDA_INST_DEFINE(1024, 1920)
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_1920.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_1920.cu
@@ -1,5 +1,8 @@
 #include "gn_cuda_host_template.cuh"
 
+
 namespace group_norm_v2 {
+
 GN_CUDA_INST_DEFINE(1024, 1920)
-}
+
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_320.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_320.cu
@@ -1,5 +1,8 @@
 #include "gn_cuda_host_template.cuh"
 
+
 namespace group_norm_v2 {
+
 GN_CUDA_INST_DEFINE(1024, 320)
-}
+
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_320.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_320.cu
@@ -1,0 +1,5 @@
+#include "gn_cuda_host_template.cuh"
+
+namespace group_norm_v2 {
+GN_CUDA_INST_DEFINE(1024, 320)
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_640.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_640.cu
@@ -1,0 +1,5 @@
+#include "gn_cuda_host_template.cuh"
+
+namespace group_norm_v2 {
+GN_CUDA_INST_DEFINE(1024, 640)
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_640.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_640.cu
@@ -1,5 +1,8 @@
 #include "gn_cuda_host_template.cuh"
 
+
 namespace group_norm_v2 {
+
 GN_CUDA_INST_DEFINE(1024, 640)
-}
+
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_960.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_960.cu
@@ -1,0 +1,5 @@
+#include "gn_cuda_host_template.cuh"
+
+namespace group_norm_v2 {
+GN_CUDA_INST_DEFINE(1024, 960)
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_960.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_1024_960.cu
@@ -1,5 +1,8 @@
 #include "gn_cuda_host_template.cuh"
 
+
 namespace group_norm_v2 {
+
 GN_CUDA_INST_DEFINE(1024, 960)
-}
+
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_1280.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_1280.cu
@@ -1,5 +1,8 @@
 #include "gn_cuda_host_template.cuh"
 
+
 namespace group_norm_v2 {
+
 GN_CUDA_INST_DEFINE(256, 1280)
-}
+
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_1280.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_1280.cu
@@ -1,0 +1,5 @@
+#include "gn_cuda_host_template.cuh"
+
+namespace group_norm_v2 {
+GN_CUDA_INST_DEFINE(256, 1280)
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_1920.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_1920.cu
@@ -1,0 +1,5 @@
+#include "gn_cuda_host_template.cuh"
+
+namespace group_norm_v2 {
+GN_CUDA_INST_DEFINE(256, 1920)
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_1920.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_1920.cu
@@ -1,5 +1,8 @@
 #include "gn_cuda_host_template.cuh"
 
+
 namespace group_norm_v2 {
+
 GN_CUDA_INST_DEFINE(256, 1920)
-}
+
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_2560.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_2560.cu
@@ -1,5 +1,8 @@
 #include "gn_cuda_host_template.cuh"
 
+
 namespace group_norm_v2 {
+
 GN_CUDA_INST_DEFINE(256, 2560)
-}
+
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_2560.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_2560.cu
@@ -1,0 +1,5 @@
+#include "gn_cuda_host_template.cuh"
+
+namespace group_norm_v2 {
+GN_CUDA_INST_DEFINE(256, 2560)
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_640.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_640.cu
@@ -1,0 +1,5 @@
+#include "gn_cuda_host_template.cuh"
+
+namespace group_norm_v2 {
+GN_CUDA_INST_DEFINE(256, 640)
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_640.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_256_640.cu
@@ -1,5 +1,8 @@
 #include "gn_cuda_host_template.cuh"
 
+
 namespace group_norm_v2 {
+
 GN_CUDA_INST_DEFINE(256, 640)
-}
+
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_4096_320.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_4096_320.cu
@@ -1,0 +1,5 @@
+#include "gn_cuda_host_template.cuh"
+
+namespace group_norm_v2 {
+GN_CUDA_INST_DEFINE(4096, 320)
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_4096_320.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_4096_320.cu
@@ -1,5 +1,8 @@
 #include "gn_cuda_host_template.cuh"
 
+
 namespace group_norm_v2 {
+
 GN_CUDA_INST_DEFINE(4096, 320)
-}
+
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_4096_640.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_4096_640.cu
@@ -1,0 +1,5 @@
+#include "gn_cuda_host_template.cuh"
+
+namespace group_norm_v2 {
+GN_CUDA_INST_DEFINE(4096, 640)
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_4096_640.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_4096_640.cu
@@ -1,5 +1,8 @@
 #include "gn_cuda_host_template.cuh"
 
+
 namespace group_norm_v2 {
+
 GN_CUDA_INST_DEFINE(4096, 640)
-}
+
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_4096_960.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_4096_960.cu
@@ -1,0 +1,5 @@
+#include "gn_cuda_host_template.cuh"
+
+namespace group_norm_v2 {
+GN_CUDA_INST_DEFINE(4096, 960)
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_4096_960.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_4096_960.cu
@@ -1,5 +1,8 @@
 #include "gn_cuda_host_template.cuh"
 
+
 namespace group_norm_v2 {
+
 GN_CUDA_INST_DEFINE(4096, 960)
-}
+
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_64_1280.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_64_1280.cu
@@ -1,5 +1,8 @@
 #include "gn_cuda_host_template.cuh"
 
+
 namespace group_norm_v2 {
+
 GN_CUDA_INST_DEFINE(64, 1280)
-}
+
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_64_1280.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_64_1280.cu
@@ -1,0 +1,5 @@
+#include "gn_cuda_host_template.cuh"
+
+namespace group_norm_v2 {
+GN_CUDA_INST_DEFINE(64, 1280)
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_64_2560.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_64_2560.cu
@@ -1,0 +1,5 @@
+#include "gn_cuda_host_template.cuh"
+
+namespace group_norm_v2 {
+GN_CUDA_INST_DEFINE(64, 2560)
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_64_2560.cu
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_inst_64_2560.cu
@@ -1,5 +1,8 @@
 #include "gn_cuda_host_template.cuh"
 
+
 namespace group_norm_v2 {
+
 GN_CUDA_INST_DEFINE(64, 2560)
-}
+
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_kernel.cuh
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_kernel.cuh
@@ -1,0 +1,1056 @@
+#pragma once
+
+#include <cooperative_groups.h>
+
+#include "gn_utils.hpp"
+
+
+namespace group_norm_v2 {
+
+namespace cg = cooperative_groups;
+
+template<typename T>
+inline constexpr T up_div(T a, T b) { return (a + b - 1) / b; }
+
+template<typename T>
+inline constexpr T round_up(T a, T b) { return up_div(a, b) * b; }
+
+inline constexpr unsigned round_up_pow2(unsigned x) {
+    int log = 0;
+    x--;
+    while (x) {
+        x /= 2;
+        log++;
+    }
+    return 1U << log;
+}
+
+inline constexpr unsigned round_down_pow2(unsigned x) {
+    return round_up_pow2(x + 1) / 2;
+}
+
+template<typename T>
+inline constexpr T gcd(T a, T b) {
+    while (b != 0) {
+        int t = b;
+        b = a % b;
+        a = t;
+    }
+    return a;
+}
+
+template<typename T>
+inline constexpr T lcm(T a, T b) { return (a * b) / gcd(a, b); }
+
+template<typename T>
+inline constexpr T relative_prime(T x, T min) {
+    int p = min;
+    while (gcd(p, x) != 1) {
+        p++;
+    }
+    return p;
+}
+
+template<typename T>
+inline constexpr T max_divisor(T x, T max) {
+    int p = max;
+    while (x % p != 0) {
+        p--;
+    }
+    return p;
+}
+
+constexpr unsigned FINAL_MASK = 0xffffffff;
+
+template<int VIRTUAL_CLUSTER_SIZE, bool PERSISTENT, bool HARDWARE_CLUSTER>
+__device__ void virtual_cluster_sync(unsigned int *barrier) {
+    if constexpr (VIRTUAL_CLUSTER_SIZE == 1) {
+        __syncthreads();
+    } else if constexpr (HARDWARE_CLUSTER) {
+        cg::this_cluster().sync();
+    } else {
+        static_assert(PERSISTENT, "potential deadlock");
+        volatile unsigned int *arrived = &barrier[blockIdx.y];
+        __syncthreads();
+        if (threadIdx.x == 0) {
+            unsigned int expected = VIRTUAL_CLUSTER_SIZE;
+            bool gpu_master = blockIdx.x == 0;
+            unsigned int nb = 1;
+            if (gpu_master) {
+                nb = 0x80000000 - (expected - 1);
+            }
+            unsigned int oldArrive;
+            asm volatile("atom.add.release.gpu.u32 %0,[%1],%2;" : "=r"(oldArrive) : _CG_ASM_PTR_CONSTRAINT((unsigned int*)arrived), "r"(nb) : "memory");
+            unsigned int current_arrive;
+            do {
+                asm volatile("ld.acquire.gpu.u32 %0,[%1];" : "=r"(current_arrive) : _CG_ASM_PTR_CONSTRAINT((unsigned int *)arrived) : "memory");
+            } while (!cooperative_groups::details::bar_has_flipped(oldArrive, current_arrive));
+        }
+        __syncthreads();
+    }
+}
+
+template<int NUM_BLOCKS, bool PERSISTENT>
+__device__ unsigned int group_barrier_arrive(unsigned int *barrier, bool gpu_master) {
+    static_assert(PERSISTENT, "potential deadlock");
+    volatile unsigned int *arrived = &barrier[0];
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        unsigned int expected = NUM_BLOCKS;
+        unsigned int nb = 1;
+        if (gpu_master) {
+            nb = 0x80000000 - (expected - 1);
+        }
+        unsigned int oldArrive;
+        asm volatile("atom.add.release.gpu.u32 %0,[%1],%2;" : "=r"(oldArrive) : _CG_ASM_PTR_CONSTRAINT((unsigned int*)arrived), "r"(nb) : "memory");
+        return oldArrive;
+    } else {
+        return 0;
+    }
+}
+
+__device__ inline void group_barrier_wait(unsigned int *barrier, unsigned int oldArrive) {
+    volatile unsigned int *arrived = &barrier[0];
+    if (threadIdx.x == 0) {
+        unsigned int current_arrive;
+        do {
+            asm volatile("ld.acquire.gpu.u32 %0,[%1];" : "=r"(current_arrive) : _CG_ASM_PTR_CONSTRAINT((unsigned int *)arrived) : "memory");
+        } while (!cooperative_groups::details::bar_has_flipped(oldArrive, current_arrive));
+    }
+    __syncthreads();
+}
+
+template<bool CONSTANT_C_LOOP, int C, int C_PER_CLUSTER, int NUM_VIRTUAL_CLUSTERS, bool PERSISTENT>
+class NCScheduler;
+
+template<int C, int C_PER_CLUSTER, int NUM_VIRTUAL_CLUSTERS, bool PERSISTENT>
+class NCScheduler<false, C, C_PER_CLUSTER, NUM_VIRTUAL_CLUSTERS, PERSISTENT> {
+public:
+    __device__ NCScheduler(int64_t n) {
+        nc_loop_ = blockIdx.y;
+        at_end_ = nc_loop_ >= n * (C / C_PER_CLUSTER);
+    }
+    __device__ auto get_nc() {
+        int64_t n_loop = nc_loop_ / (C / C_PER_CLUSTER);
+        int c_loop = nc_loop_ % (C / C_PER_CLUSTER);
+        return std::make_tuple(n_loop, c_loop);
+    }
+    __device__ void next(int64_t n) {
+        if constexpr (PERSISTENT) {
+            nc_loop_ += NUM_VIRTUAL_CLUSTERS;
+            at_end_ = nc_loop_ >= n * (C / C_PER_CLUSTER);
+        }
+    }
+    __device__ bool at_end(int64_t n) {
+        return !PERSISTENT || at_end_;
+    }
+private:
+    int64_t nc_loop_;
+    bool at_end_;
+};
+
+template<int C, int C_PER_CLUSTER, int NUM_VIRTUAL_CLUSTERS, bool PERSISTENT>
+class NCScheduler<true, C, C_PER_CLUSTER, NUM_VIRTUAL_CLUSTERS, PERSISTENT> {
+public:
+    __device__ NCScheduler(int64_t n) {
+        n_loop_ = blockIdx.y / (C / C_PER_CLUSTER);
+        c_loop_ = blockIdx.y % (C / C_PER_CLUSTER);
+    }
+    __device__ auto get_nc() {
+        return std::make_tuple(n_loop_, c_loop_);
+    }
+    __device__ void next(int64_t n) {
+        if constexpr (PERSISTENT) {
+            n_loop_ += NUM_VIRTUAL_CLUSTERS / (C / C_PER_CLUSTER);
+        }
+    }
+    __device__ bool at_end(int64_t n) {
+        return !PERSISTENT || n_loop_ >= n;
+    }
+private:
+    int64_t n_loop_;
+    int c_loop_;
+};
+
+class CompileConditionAlwaysTrue {
+public:
+    __device__ static constexpr bool matches() {
+        return true;
+    }
+};
+
+template<typename T, int BLOCK_DIM_X, int BLOCKS_PER_SM, int G, int CPG, int HW, bool SILU, int ROWS_PER_BLOCK, int C_PER_BLOCK, int C_PER_CLUSTER, int VEC_ELEMS, bool PERSISTENT, int NUM_VIRTUAL_CLUSTERS, bool LOAD_TWICE, bool HARDWARE_CLUSTER, class CompileCondition = CompileConditionAlwaysTrue>
+__global__ __launch_bounds__(BLOCK_DIM_X, BLOCKS_PER_SM) void gn_cuda_kernel(T *__restrict__ out, T const *__restrict__ x, T const *__restrict__ w, T const *__restrict__ b, float eps, int64_t n, float *__restrict__ mean_var_out, float *__restrict__ red_buffer, unsigned *__restrict__ barrier) {
+    static_assert(BLOCK_DIM_X % 32 == 0, "warp shuffle error");
+
+    constexpr int C = G * CPG;
+    static_assert(C % C_PER_CLUSTER == 0, "cannot divide channels into clusters");
+    static_assert(C_PER_CLUSTER % C_PER_BLOCK == 0, "cannot divide a cluster into blocks");
+    static_assert(C_PER_CLUSTER % CPG == 0, "no reduce between clusters, results would be wrong");
+    static_assert(!(C_PER_BLOCK % CPG == 0 && C_PER_CLUSTER != C_PER_BLOCK), "inefficient configuration, please reduce C_PER_CLUSTER");
+
+    static_assert(ROWS_PER_BLOCK * C_PER_BLOCK % BLOCK_DIM_X == 0, "cannot divide tile into threads");
+    struct alignas(VEC_ELEMS * sizeof(T)) U {
+        T data[VEC_ELEMS];
+    };
+
+    auto compute_mean_var = [&](float2 sum) {
+        float mean = sum.x / (HW * CPG);
+        float var = std::max(0.f, sum.y / (HW * CPG) - mean * mean);
+        return float2{mean, var};
+    };
+
+    static_assert(HW % ROWS_PER_BLOCK == 0, "HW must be divisible by ROWS_PER_BLOCK to determine the number of blocks on the HW axis");
+    constexpr int MAX_NUM_GROUPS_PER_BLOCK = C_PER_BLOCK % CPG == 0 ? C_PER_BLOCK / CPG : up_div(C_PER_BLOCK - gcd(C_PER_BLOCK, CPG), CPG) + 1;
+    constexpr int VIRTUAL_CLUSTER_SIZE = (C_PER_CLUSTER / C_PER_BLOCK) * (HW / ROWS_PER_BLOCK);
+    constexpr int virtual_cluster_dim_x = C_PER_CLUSTER / C_PER_BLOCK;
+    constexpr int virtual_cluster_dim_y = HW / ROWS_PER_BLOCK;
+    int virtual_block_idx_x = (blockIdx.x % VIRTUAL_CLUSTER_SIZE) % virtual_cluster_dim_x;
+    int virtual_block_idx_y = (blockIdx.x % VIRTUAL_CLUSTER_SIZE) / virtual_cluster_dim_x;
+
+    if constexpr (CompileCondition::matches()) {
+        int step = 0;
+        constexpr bool CONSTANT_C_LOOP = PERSISTENT && NUM_VIRTUAL_CLUSTERS % (C / C_PER_CLUSTER) == 0;
+        NCScheduler<CONSTANT_C_LOOP, C, C_PER_CLUSTER, NUM_VIRTUAL_CLUSTERS, PERSISTENT> nc_scheduler(n);
+        while (true) {
+            if constexpr (PERSISTENT) {
+                if (nc_scheduler.at_end(n)) {
+                    break;
+                }
+            }
+            auto [n_loop, c_loop] = nc_scheduler.get_nc();
+            if constexpr (PERSISTENT) {
+                nc_scheduler.next(n);
+            }
+            static_assert(C_PER_BLOCK % VEC_ELEMS == 0, "cannot vectorize");
+            static_assert((BLOCK_DIM_X * VEC_ELEMS) % C_PER_BLOCK == 0, "each block should load one or more C_PER_BLOCK at once");
+            constexpr int ROWS_PER_IO = BLOCK_DIM_X * VEC_ELEMS / C_PER_BLOCK;
+            static_assert(ROWS_PER_BLOCK % ROWS_PER_IO == 0, "cannot determine the IO times per batch");
+            int block_channel_start = virtual_block_idx_x * C_PER_BLOCK + c_loop * C_PER_CLUSTER;
+            int block_group_start = block_channel_start / CPG;
+            int thread_channel_start = block_channel_start + threadIdx.x % (C_PER_BLOCK / VEC_ELEMS) * VEC_ELEMS;
+            U frag[ROWS_PER_BLOCK / ROWS_PER_IO];
+
+            constexpr int GCD_VEC_CPG = gcd(VEC_ELEMS, CPG);
+            constexpr bool SINGLE_GROUP_PER_BLOCK = CPG % C_PER_BLOCK == 0;
+            [[maybe_unused]] __shared__ float2 sum_per_channel_single_group[BLOCK_DIM_X / 32];
+            [[maybe_unused]] __shared__ float2 sum_per_channel_multi_group[C_PER_BLOCK / GCD_VEC_CPG][relative_prime(128 / (int)sizeof(float2), ROWS_PER_IO)];
+
+            float2 frag_sum_per_channel[VEC_ELEMS / GCD_VEC_CPG]{};
+            if constexpr (LOAD_TWICE) {
+                for (int j = 0; j < ROWS_PER_BLOCK / ROWS_PER_IO; j++) {
+                    int64_t input_idx = n_loop * HW * C +
+                                        (virtual_block_idx_y * ROWS_PER_BLOCK + j * ROWS_PER_IO + threadIdx.x / (C_PER_BLOCK / VEC_ELEMS)) * C +
+                                        thread_channel_start;
+                    U val = *reinterpret_cast<U const *>(&x[input_idx]);
+                    for (int i = 0; i < VEC_ELEMS / GCD_VEC_CPG; i++) {
+                        float2 sum = frag_sum_per_channel[i];
+                        for (int k = 0; k < GCD_VEC_CPG; k++) {
+                            sum.x += (float)val.data[i * GCD_VEC_CPG + k];
+                            sum.y += (float)val.data[i * GCD_VEC_CPG + k] * (float)val.data[i * GCD_VEC_CPG + k];
+                        }
+                        frag_sum_per_channel[i] = sum;
+                    }
+                }
+                for (int i = 0; i < VEC_ELEMS / GCD_VEC_CPG; i++) {
+                    if constexpr (SINGLE_GROUP_PER_BLOCK) {
+                        for (int mask = 16; mask > 0; mask >>= 1) {
+                            frag_sum_per_channel[i].x += __shfl_xor_sync(FINAL_MASK, frag_sum_per_channel[i].x, mask, 32);
+                            frag_sum_per_channel[i].y += __shfl_xor_sync(FINAL_MASK, frag_sum_per_channel[i].y, mask, 32);
+                        }
+                        static_assert(VEC_ELEMS / GCD_VEC_CPG == 1, "process only one element for each warp");
+                        if (threadIdx.x % 32 == 0) {
+                            sum_per_channel_single_group[threadIdx.x / 32] = frag_sum_per_channel[i];
+                        }
+                    } else {
+                        sum_per_channel_multi_group[i * (C_PER_BLOCK / VEC_ELEMS) + threadIdx.x % (C_PER_BLOCK / VEC_ELEMS)][threadIdx.x / (C_PER_BLOCK / VEC_ELEMS)] = frag_sum_per_channel[i];
+                    }
+                }
+                __syncthreads();
+            } else {
+                for (int j = 0; j < ROWS_PER_BLOCK / ROWS_PER_IO; j++) {
+                    int64_t input_idx = n_loop * HW * C +
+                                        (virtual_block_idx_y * ROWS_PER_BLOCK + j * ROWS_PER_IO + threadIdx.x / (C_PER_BLOCK / VEC_ELEMS)) * C +
+                                        thread_channel_start;
+                    frag[j] = *reinterpret_cast<U const *>(&x[input_idx]);
+                }
+
+                for (int i = 0; i < VEC_ELEMS / GCD_VEC_CPG; i++) {
+                    float2 sum = {0.f, 0.f};
+                    for (int j = 0; j < ROWS_PER_BLOCK / ROWS_PER_IO; j++) {
+                        for (int k = 0; k < GCD_VEC_CPG; k++) {
+                            sum.x += (float)frag[j].data[i * GCD_VEC_CPG + k];
+                            sum.y += (float)frag[j].data[i * GCD_VEC_CPG + k] * (float)frag[j].data[i * GCD_VEC_CPG + k];
+                        }
+                    }
+                    if constexpr (SINGLE_GROUP_PER_BLOCK) {
+                        for (int mask = 16; mask > 0; mask >>= 1) {
+                            sum.x += __shfl_xor_sync(FINAL_MASK, sum.x, mask, 32);
+                            sum.y += __shfl_xor_sync(FINAL_MASK, sum.y, mask, 32);
+                        }
+                        static_assert(VEC_ELEMS / GCD_VEC_CPG == 1, "process only one element for each warp");
+                        if (threadIdx.x % 32 == 0) {
+                            sum_per_channel_single_group[threadIdx.x / 32] = sum;
+                        }
+                    } else {
+                        sum_per_channel_multi_group[i * (C_PER_BLOCK / VEC_ELEMS) + threadIdx.x % (C_PER_BLOCK / VEC_ELEMS)][threadIdx.x / (C_PER_BLOCK / VEC_ELEMS)] = sum;
+                    }
+                }
+                __syncthreads();
+            }
+
+            U uw = *reinterpret_cast<U const *>(&w[thread_channel_start]);
+            U ub = *reinterpret_cast<U const *>(&b[thread_channel_start]);
+
+            constexpr bool USE_SHARED_RED_BUFFER = HARDWARE_CLUSTER || VIRTUAL_CLUSTER_SIZE == 1;
+            constexpr bool STORE_MEAN_VAR_IN_SHARED_RED_BUFFER = VIRTUAL_CLUSTER_SIZE == 1 && MAX_NUM_GROUPS_PER_BLOCK == 1;  // MAX_NUM_GROUPS_PER_BLOCK > 1 is possible but not implemented
+            [[maybe_unused]] __align__(16) __shared__ float2 shared_red_buffer[MAX_NUM_GROUPS_PER_BLOCK * (STORE_MEAN_VAR_IN_SHARED_RED_BUFFER ? 1 : 2)];
+
+            if constexpr (SINGLE_GROUP_PER_BLOCK) {
+                // block reduce
+                if (threadIdx.x < 32) {
+                    float2 sum_local_group = threadIdx.x < BLOCK_DIM_X / 32 ? sum_per_channel_single_group[threadIdx.x] : float2{0.f, 0.f};
+                    constexpr int warp_num_pow2 = round_up_pow2(BLOCK_DIM_X / 32);
+                    for (int mask = warp_num_pow2 / 2; mask > 0; mask >>= 1) {
+                        sum_local_group.x += __shfl_xor_sync(FINAL_MASK, sum_local_group.x, mask, 32);
+                        sum_local_group.y += __shfl_xor_sync(FINAL_MASK, sum_local_group.y, mask, 32);
+                    }
+                    if (threadIdx.x == 0) {
+                        if constexpr (USE_SHARED_RED_BUFFER) {
+                            if constexpr (STORE_MEAN_VAR_IN_SHARED_RED_BUFFER) {
+                                shared_red_buffer[0] = compute_mean_var(sum_local_group);
+                            } else {
+                                shared_red_buffer[step * MAX_NUM_GROUPS_PER_BLOCK + 0] = sum_local_group;
+                            }
+                        } else {
+                            *reinterpret_cast<float2 *>(&red_buffer[((step * gridDim.y + blockIdx.y) * VIRTUAL_CLUSTER_SIZE * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                     virtual_block_idx_x * virtual_cluster_dim_y * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                     // (threadIdx.x / THREADS_PER_GROUP) * virtual_cluster_dim_y +
+                                                                     virtual_block_idx_y) * 2]) = sum_local_group;
+                        }
+                    }
+                }
+            } else {
+                constexpr int THREADS_PER_GROUP = std::min(std::min(32U,
+                                                                    round_up_pow2(ROWS_PER_IO)),
+                                                                    round_up_pow2(BLOCK_DIM_X / MAX_NUM_GROUPS_PER_BLOCK / 2 + 1));
+                static_assert(BLOCK_DIM_X >= MAX_NUM_GROUPS_PER_BLOCK * THREADS_PER_GROUP, "not enough threads");
+                float2 sum_local_group = {0.f, 0.f};
+                if (threadIdx.x / THREADS_PER_GROUP < MAX_NUM_GROUPS_PER_BLOCK) {
+                    int local_group_idx = block_group_start + threadIdx.x / THREADS_PER_GROUP;
+                    // TODO: map threads to both the CPG loop and the ROWS loop
+                    for (int local_c_loop = 0; local_c_loop < CPG; local_c_loop += GCD_VEC_CPG) {
+                        int c = local_group_idx * CPG + local_c_loop;
+                        if (C_PER_BLOCK % CPG == 0 || (c >= block_channel_start && c < block_channel_start + C_PER_BLOCK)) {
+                            for (int src_thread_tile_y = threadIdx.x % THREADS_PER_GROUP; src_thread_tile_y < ROWS_PER_IO; src_thread_tile_y += THREADS_PER_GROUP) {
+                                int channel_idx = (c - block_channel_start) / GCD_VEC_CPG;
+                                channel_idx = channel_idx % (VEC_ELEMS / GCD_VEC_CPG) * (C_PER_BLOCK / VEC_ELEMS) + channel_idx / (VEC_ELEMS / GCD_VEC_CPG);
+                                sum_local_group.x += sum_per_channel_multi_group[channel_idx][src_thread_tile_y].x;
+                                sum_local_group.y += sum_per_channel_multi_group[channel_idx][src_thread_tile_y].y;
+                            }
+                        }
+                    }
+                }
+                static_assert(32 % THREADS_PER_GROUP == 0, "cannot shuffle");
+                for (int mask = THREADS_PER_GROUP / 2; mask > 0; mask >>= 1) {
+                    sum_local_group.x += __shfl_xor_sync(FINAL_MASK, sum_local_group.x, mask, 32);
+                    sum_local_group.y += __shfl_xor_sync(FINAL_MASK, sum_local_group.y, mask, 32);
+                }
+                if (threadIdx.x % THREADS_PER_GROUP == 0 && threadIdx.x / THREADS_PER_GROUP < MAX_NUM_GROUPS_PER_BLOCK) {
+                    if constexpr (USE_SHARED_RED_BUFFER) {
+                        static_assert(HARDWARE_CLUSTER || VIRTUAL_CLUSTER_SIZE == 1, "no distributed shared memory");
+                        if constexpr (STORE_MEAN_VAR_IN_SHARED_RED_BUFFER) {
+                            shared_red_buffer[threadIdx.x / THREADS_PER_GROUP] = compute_mean_var(sum_local_group);
+                        } else {
+                            shared_red_buffer[step * MAX_NUM_GROUPS_PER_BLOCK + threadIdx.x / THREADS_PER_GROUP] = sum_local_group;
+                        }
+                    } else {
+                        *reinterpret_cast<float2 *>(&red_buffer[((step * gridDim.y + blockIdx.y) * VIRTUAL_CLUSTER_SIZE * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                 virtual_block_idx_x * virtual_cluster_dim_y * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                 (threadIdx.x / THREADS_PER_GROUP) * virtual_cluster_dim_y +
+                                                                 virtual_block_idx_y) * 2]) = sum_local_group;
+                    }
+                }
+            }
+
+            virtual_cluster_sync<VIRTUAL_CLUSTER_SIZE, PERSISTENT, HARDWARE_CLUSTER>(barrier);
+
+            __shared__ float2 mean_var[MAX_NUM_GROUPS_PER_BLOCK];
+            if constexpr (!STORE_MEAN_VAR_IN_SHARED_RED_BUFFER) {
+                constexpr int THREADS_PER_GROUP = std::min(std::min(32U,
+                                                                    round_up_pow2(virtual_cluster_dim_y)),
+                                                                    round_up_pow2(BLOCK_DIM_X / MAX_NUM_GROUPS_PER_BLOCK / 2 + 1));
+                static_assert(BLOCK_DIM_X >= MAX_NUM_GROUPS_PER_BLOCK * THREADS_PER_GROUP, "not enough threads");
+                float2 sum_global_group = {0.f, 0.f};
+                if (threadIdx.x / THREADS_PER_GROUP < MAX_NUM_GROUPS_PER_BLOCK) {
+                    if constexpr (C_PER_BLOCK % CPG == 0) {
+                        float2 buffer[up_div(virtual_cluster_dim_y, THREADS_PER_GROUP)];
+                        for (int i = threadIdx.x % THREADS_PER_GROUP; i < virtual_cluster_dim_y; i += THREADS_PER_GROUP) {
+                            float2 val;
+                            if constexpr (USE_SHARED_RED_BUFFER) {
+                                if constexpr (VIRTUAL_CLUSTER_SIZE == 1) {
+                                    val = shared_red_buffer[step * MAX_NUM_GROUPS_PER_BLOCK + threadIdx.x / THREADS_PER_GROUP];
+                                } else {
+                                    static_assert(HARDWARE_CLUSTER, "no distributed shared memory");
+                                    float2 const *src_shared_red_buffer = cg::this_cluster().map_shared_rank(shared_red_buffer, i * virtual_cluster_dim_x + virtual_block_idx_x);
+                                    val = src_shared_red_buffer[step * MAX_NUM_GROUPS_PER_BLOCK + threadIdx.x / THREADS_PER_GROUP];
+                                }
+                            } else {
+                                val = *reinterpret_cast<float2 const *>(&red_buffer[((step * gridDim.y + blockIdx.y) * VIRTUAL_CLUSTER_SIZE * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                                     virtual_block_idx_x * virtual_cluster_dim_y * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                                     (threadIdx.x / THREADS_PER_GROUP) * virtual_cluster_dim_y +
+                                                                                     i) * 2]);
+                            }
+                            buffer[i / THREADS_PER_GROUP] = val;
+                        }
+                        for (int i = threadIdx.x % THREADS_PER_GROUP; i < virtual_cluster_dim_y; i += THREADS_PER_GROUP) {
+                            float2 val = buffer[i / THREADS_PER_GROUP];
+                            sum_global_group.x += val.x;
+                            sum_global_group.y += val.y;
+                        }
+                    } else {
+                        int local_group_idx = block_group_start + threadIdx.x / THREADS_PER_GROUP;
+                        for (int i = threadIdx.x % THREADS_PER_GROUP; i < VIRTUAL_CLUSTER_SIZE; i += THREADS_PER_GROUP) {
+                            int src_virtual_block_idx_x = i % virtual_cluster_dim_x;
+                            int src_block_channel_start = src_virtual_block_idx_x * C_PER_BLOCK + c_loop * C_PER_CLUSTER;
+                            int src_block_group_start = src_block_channel_start / CPG;
+                            int relative_group_idx = local_group_idx - src_block_group_start;
+                            if (0 <= relative_group_idx && relative_group_idx < MAX_NUM_GROUPS_PER_BLOCK) {
+                                float2 val;
+                                if constexpr (USE_SHARED_RED_BUFFER) {
+                                    static_assert(HARDWARE_CLUSTER, "no distributed shared memory");
+                                    static_assert(VIRTUAL_CLUSTER_SIZE != 1, "layout error: should not add (step * MAX_NUM_GROUPS_PER_BLOCK)");
+                                    float2 const *src_shared_red_buffer = cg::this_cluster().map_shared_rank(shared_red_buffer, i);
+                                    val = src_shared_red_buffer[step * MAX_NUM_GROUPS_PER_BLOCK + relative_group_idx];
+                                } else {
+                                    val = *reinterpret_cast<float2 const *>(&red_buffer[((step * gridDim.y + blockIdx.y) * VIRTUAL_CLUSTER_SIZE * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                                         src_virtual_block_idx_x * virtual_cluster_dim_y * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                                         relative_group_idx * virtual_cluster_dim_y +
+                                                                                         i / virtual_cluster_dim_x) * 2]);
+                                }
+                                sum_global_group.x += val.x;
+                                sum_global_group.y += val.y;
+                            }
+                        }
+                    }
+                }
+                if constexpr (USE_SHARED_RED_BUFFER && VIRTUAL_CLUSTER_SIZE > 1) {
+                    if constexpr (PERSISTENT) {
+                        if (nc_scheduler.at_end(n)) {
+                            cg::this_cluster().barrier_arrive();
+                        }
+                    } else {
+                        cg::this_cluster().barrier_arrive();
+                    }
+                }
+                static_assert(32 % THREADS_PER_GROUP == 0, "cannot shuffle");
+                for (int mask = THREADS_PER_GROUP / 2; mask > 0; mask >>= 1) {
+                    sum_global_group.x += __shfl_xor_sync(FINAL_MASK, sum_global_group.x, mask, 32);
+                    sum_global_group.y += __shfl_xor_sync(FINAL_MASK, sum_global_group.y, mask, 32);
+                }
+                if (threadIdx.x % THREADS_PER_GROUP == 0 && threadIdx.x / THREADS_PER_GROUP < MAX_NUM_GROUPS_PER_BLOCK) {
+                    mean_var[threadIdx.x / THREADS_PER_GROUP] = compute_mean_var(sum_global_group);
+                }
+                __syncthreads();
+            }
+
+            auto get_mean_var = [&](int relative_group_idx) {
+                return STORE_MEAN_VAR_IN_SHARED_RED_BUFFER ? shared_red_buffer[relative_group_idx] : mean_var[relative_group_idx];
+            };
+
+            if (mean_var_out) {
+                static_assert(MAX_NUM_GROUPS_PER_BLOCK <= BLOCK_DIM_X, "need loop");
+                if (virtual_block_idx_y == 0 && threadIdx.x < MAX_NUM_GROUPS_PER_BLOCK) {
+                    int g = block_group_start + threadIdx.x;
+                    if (C_PER_BLOCK % CPG == 0 || g < G) {
+                        *reinterpret_cast<float2 *>(&mean_var_out[(n_loop * G + g) * 2]) = get_mean_var(threadIdx.x);
+                    }
+                }
+            }
+
+            float frag_mean[VEC_ELEMS / GCD_VEC_CPG];
+            float frag_var[VEC_ELEMS / GCD_VEC_CPG];
+            for (int k = 0; k < VEC_ELEMS; k += GCD_VEC_CPG) {
+                frag_mean[k / GCD_VEC_CPG] = get_mean_var((thread_channel_start + k) / CPG - block_group_start).x;
+                frag_var[k / GCD_VEC_CPG] = get_mean_var((thread_channel_start + k) / CPG - block_group_start).y;
+            }
+
+            for (int j = 0; j < ROWS_PER_BLOCK / ROWS_PER_IO; j++) {
+                int64_t input_idx = n_loop * HW * C +
+                                    (virtual_block_idx_y * ROWS_PER_BLOCK + j * ROWS_PER_IO + threadIdx.x / (C_PER_BLOCK / VEC_ELEMS)) * C +
+                                    thread_channel_start;
+                U val;
+                if constexpr (LOAD_TWICE) {
+                    val = *reinterpret_cast<U const *>(&x[input_idx]);
+                } else {
+                    val = frag[j];
+                }
+                for (int k = 0; k < VEC_ELEMS; k++) {
+                    float f = ((float)val.data[k] - frag_mean[k / GCD_VEC_CPG]) * rsqrtf(frag_var[k / GCD_VEC_CPG] + eps) * (float)uw.data[k] + (float)ub.data[k];
+                    if constexpr (SILU) f = f / (1.f + expf(-f));
+                    val.data[k] = f;
+                }
+                *reinterpret_cast<U *>(&out[input_idx]) = val;
+            }
+
+            if constexpr (!STORE_MEAN_VAR_IN_SHARED_RED_BUFFER && USE_SHARED_RED_BUFFER && VIRTUAL_CLUSTER_SIZE > 1) {
+                if constexpr (PERSISTENT) {
+                    if (nc_scheduler.at_end(n)) {
+                        cg::this_cluster().barrier_wait();
+                    }
+                } else {
+                    cg::this_cluster().barrier_wait();
+                }
+            }
+
+            if constexpr (!PERSISTENT) {
+                break;
+            }
+            step ^= 1;
+        }
+    }
+}
+
+enum WgradSyncMethod {
+    WGRAD_ARRIVE_AND_WAIT_GRID = 0,  // grid arrive after the last virtual cluster sync
+    WGRAD_ARRIVE_AND_WAIT_GROUP,     // group arrive after the last virtual cluster sync (a group sync means synchronizing all clusters cooperative on the same groups)
+    WGRAD_REUSE_SUM_SYNC_GRID,       // grid sync together with the last virtual cluster sync
+    WGRAD_REUSE_SUM_SYNC_GROUP,      // group sync together with the last virtual cluster sync
+    WGRAD_SYNC_AT_LAST,              // add a sync at the end of NC loops
+    WGRAD_SYNC_UNSPECIFIED,
+};
+
+template<typename T, int BLOCK_DIM_X, int BLOCKS_PER_SM, int G, int CPG, int HW, bool SILU, bool REQUIRES_WGRAD, int ROWS_PER_BLOCK, int C_PER_BLOCK, int C_PER_CLUSTER, int VEC_ELEMS, bool PERSISTENT, int NUM_VIRTUAL_CLUSTERS, bool LOAD_TWICE, bool HARDWARE_CLUSTER, WgradSyncMethod wgrad_sync_method, class CompileCondition = CompileConditionAlwaysTrue>
+__global__ __launch_bounds__(BLOCK_DIM_X, BLOCKS_PER_SM) void gn_bwd_cuda_kernel(T *__restrict__ grad_input, T *__restrict__ grad_weight, T *__restrict__ grad_bias, T const *__restrict__ grad_output, T const *__restrict__ x, T const *__restrict__ w, T const *__restrict__ b, float const *__restrict__ mean_var, float eps, int64_t n, float *__restrict__ red_buffer, unsigned *__restrict__ barrier) {
+    static_assert(BLOCK_DIM_X % 32 == 0, "warp shuffle error");
+
+    constexpr int C = G * CPG;
+    static_assert(C % C_PER_CLUSTER == 0, "cannot divide channels into clusters");
+    static_assert(C_PER_CLUSTER % C_PER_BLOCK == 0, "cannot divide a cluster into blocks");
+    static_assert(C_PER_CLUSTER % CPG == 0, "no reduce between clusters, results would be wrong");
+    static_assert(!(C_PER_BLOCK % CPG == 0 && C_PER_CLUSTER != C_PER_BLOCK), "inefficient configuration, please reduce C_PER_CLUSTER");
+
+    static_assert(ROWS_PER_BLOCK * C_PER_BLOCK % BLOCK_DIM_X == 0, "cannot divide tile into threads");
+    struct alignas(VEC_ELEMS * sizeof(T)) U {
+        T data[VEC_ELEMS];
+    };
+
+    auto compute_mean_var = [&](float2 sum) {
+        float mean_dyw = sum.x / (HW * CPG);
+        float mean_xdyw = sum.y / (HW * CPG);
+        return float2{mean_dyw, mean_xdyw};
+    };
+
+    static_assert(HW % ROWS_PER_BLOCK == 0, "HW must be divisible by ROWS_PER_BLOCK to determine the number of blocks on the HW axis");
+    constexpr int MAX_NUM_GROUPS_PER_BLOCK = C_PER_BLOCK % CPG == 0 ? C_PER_BLOCK / CPG : up_div(C_PER_BLOCK - gcd(C_PER_BLOCK, CPG), CPG) + 1;
+    constexpr int VIRTUAL_CLUSTER_SIZE = (C_PER_CLUSTER / C_PER_BLOCK) * (HW / ROWS_PER_BLOCK);
+    constexpr int virtual_cluster_dim_x = C_PER_CLUSTER / C_PER_BLOCK;
+    constexpr int virtual_cluster_dim_y = HW / ROWS_PER_BLOCK;
+    int virtual_block_idx_x = (blockIdx.x % VIRTUAL_CLUSTER_SIZE) % virtual_cluster_dim_x;
+    int virtual_block_idx_y = (blockIdx.x % VIRTUAL_CLUSTER_SIZE) / virtual_cluster_dim_x;
+
+    if constexpr (CompileCondition::matches()) {
+        int step = 0;
+        constexpr bool CONSTANT_C_LOOP = PERSISTENT && NUM_VIRTUAL_CLUSTERS % (C / C_PER_CLUSTER) == 0;
+        NCScheduler<false, C, C_PER_CLUSTER, NUM_VIRTUAL_CLUSTERS, PERSISTENT> nc_scheduler(n);  // TODO: I don't know why the template specialization with CONSTANT_C_LOOP=true is slower.
+
+        [[maybe_unused]] int virtual_cluster_idx_c = blockIdx.y % (C / C_PER_CLUSTER);
+        [[maybe_unused]] cg::grid_group::arrival_token wgrad_sync_token;
+        [[maybe_unused]] float dw_thread[VEC_ELEMS];
+        [[maybe_unused]] float db_thread[VEC_ELEMS];
+        [[maybe_unused]] __shared__ union {
+            float2 dwdb_block_buffer[BLOCK_DIM_X][VEC_ELEMS];
+            struct {
+                float wgrad_buffer[BLOCK_DIM_X / 32][32];
+                float bgrad_buffer[BLOCK_DIM_X / 32][32];
+            } transpose_buffer;
+        } union_smem;
+        if constexpr (REQUIRES_WGRAD && CONSTANT_C_LOOP) {
+            for (int i = 0; i < VEC_ELEMS; i++) {
+                dw_thread[i] = 0.f;
+                db_thread[i] = 0.f;
+            }
+        }
+        float *red_buffer_wgrad = &red_buffer[(2 * NUM_VIRTUAL_CLUSTERS * VIRTUAL_CLUSTER_SIZE * MAX_NUM_GROUPS_PER_BLOCK) * 2];
+        unsigned *barrier_wgrad = barrier + NUM_VIRTUAL_CLUSTERS;
+        if constexpr (REQUIRES_WGRAD && wgrad_sync_method != WGRAD_SYNC_AT_LAST) {
+            if (nc_scheduler.at_end(n)) {
+                static_assert(PERSISTENT, "persistent is a must for reducing wgrad");
+                if constexpr (wgrad_sync_method == WGRAD_ARRIVE_AND_WAIT_GRID) {
+                    wgrad_sync_token = group_barrier_arrive<NUM_VIRTUAL_CLUSTERS * VIRTUAL_CLUSTER_SIZE, PERSISTENT>(barrier_wgrad, blockIdx.x + blockIdx.y == 0);
+                } else if constexpr (wgrad_sync_method == WGRAD_ARRIVE_AND_WAIT_GROUP) {
+                    []<bool flag = CONSTANT_C_LOOP> { static_assert(flag, "requires CONSTANT_C_LOOP"); }();
+                    wgrad_sync_token = group_barrier_arrive<NUM_VIRTUAL_CLUSTERS * VIRTUAL_CLUSTER_SIZE / (C / C_PER_CLUSTER), PERSISTENT>(barrier_wgrad + virtual_cluster_idx_c, blockIdx.x + blockIdx.y / (C / C_PER_CLUSTER) == 0);
+                } else if constexpr (wgrad_sync_method == WGRAD_REUSE_SUM_SYNC_GRID) {
+                    wgrad_sync_token = group_barrier_arrive<NUM_VIRTUAL_CLUSTERS * VIRTUAL_CLUSTER_SIZE, PERSISTENT>(barrier_wgrad, blockIdx.x + blockIdx.y == 0);
+                    group_barrier_wait(barrier_wgrad, wgrad_sync_token);
+                } else if constexpr (wgrad_sync_method == WGRAD_REUSE_SUM_SYNC_GROUP) {
+                    []<bool flag = CONSTANT_C_LOOP> { static_assert(flag, "requires CONSTANT_C_LOOP"); }();
+                    wgrad_sync_token = group_barrier_arrive<NUM_VIRTUAL_CLUSTERS * VIRTUAL_CLUSTER_SIZE / (C / C_PER_CLUSTER), PERSISTENT>(barrier_wgrad + virtual_cluster_idx_c, blockIdx.x + blockIdx.y / (C / C_PER_CLUSTER) == 0);
+                    group_barrier_wait(barrier_wgrad + virtual_cluster_idx_c, wgrad_sync_token);
+                }
+            }
+        }
+
+        while (true) {
+            if constexpr (PERSISTENT) {
+                if (nc_scheduler.at_end(n)) {
+                    break;
+                }
+            }
+            auto [n_loop, c_loop] = nc_scheduler.get_nc();
+            if constexpr (PERSISTENT) {
+                nc_scheduler.next(n);
+            }
+            static_assert(C_PER_BLOCK % VEC_ELEMS == 0, "cannot vectorize");
+            static_assert((BLOCK_DIM_X * VEC_ELEMS) % C_PER_BLOCK == 0, "each block should load one or more C_PER_BLOCK at once");
+            constexpr int ROWS_PER_IO = BLOCK_DIM_X * VEC_ELEMS / C_PER_BLOCK;
+            static_assert(ROWS_PER_BLOCK % ROWS_PER_IO == 0, "cannot determine the IO times per batch");
+            int block_channel_start = virtual_block_idx_x * C_PER_BLOCK + c_loop * C_PER_CLUSTER;
+            int block_group_start = block_channel_start / CPG;
+            int thread_channel_start = block_channel_start + threadIdx.x % (C_PER_BLOCK / VEC_ELEMS) * VEC_ELEMS;
+            U frag_x[ROWS_PER_BLOCK / ROWS_PER_IO];
+            U frag_dy[ROWS_PER_BLOCK / ROWS_PER_IO];
+
+            constexpr int GCD_VEC_CPG = gcd(VEC_ELEMS, CPG);
+            constexpr bool SINGLE_GROUP_PER_BLOCK = CPG % C_PER_BLOCK == 0;
+            [[maybe_unused]] __shared__ float2 sum_per_channel_multi_group[C_PER_BLOCK / GCD_VEC_CPG][relative_prime(128 / (int)sizeof(float2), ROWS_PER_IO)];
+            [[maybe_unused]] __shared__ float2 sum_per_channel_single_group[BLOCK_DIM_X / 32];
+
+            float frag_mean[VEC_ELEMS / GCD_VEC_CPG];
+            float frag_var[VEC_ELEMS / GCD_VEC_CPG];
+            for (int k = 0; k < VEC_ELEMS; k += GCD_VEC_CPG) {
+                float2 value = *reinterpret_cast<float2 const *>(&mean_var[(n_loop * G + (thread_channel_start + k) / CPG) * 2]);
+                frag_mean[k / GCD_VEC_CPG] = value.x;
+                frag_var[k / GCD_VEC_CPG] = value.y;
+            }
+
+            U uw = *reinterpret_cast<U const *>(&w[thread_channel_start]);
+            U ub;
+            if constexpr (SILU) {
+                ub = *reinterpret_cast<U const *>(&b[thread_channel_start]);
+            }
+            if constexpr (REQUIRES_WGRAD && !CONSTANT_C_LOOP) {
+                for (int i = 0; i < VEC_ELEMS; i++) {
+                    dw_thread[i] = 0.f;
+                    db_thread[i] = 0.f;
+                }
+            }
+
+            float2 frag_sum_per_channel[VEC_ELEMS / GCD_VEC_CPG]{};
+            if constexpr (LOAD_TWICE) {
+                for (int j = 0; j < ROWS_PER_BLOCK / ROWS_PER_IO; j++) {
+                    int64_t input_idx = n_loop * HW * C +
+                                        (virtual_block_idx_y * ROWS_PER_BLOCK + j * ROWS_PER_IO + threadIdx.x / (C_PER_BLOCK / VEC_ELEMS)) * C +
+                                        thread_channel_start;
+                    U ux = *reinterpret_cast<U const *>(&x[input_idx]);
+                    U udy = *reinterpret_cast<U const *>(&grad_output[input_idx]);
+                    for (int i = 0; i < VEC_ELEMS / GCD_VEC_CPG; i++) {
+                        float2 sum = frag_sum_per_channel[i];
+                        for (int k = 0; k < GCD_VEC_CPG; k++) {
+                            float rnorm = rsqrtf(frag_var[i] + eps);
+                            float x_norm = ((float)ux.data[i * GCD_VEC_CPG + k] - frag_mean[i]) * rnorm;  // TODO: store rsqrtf in mean_var
+                            float grad_gn = udy.data[i * GCD_VEC_CPG + k];
+                            if constexpr (SILU) {
+                                float x_gn = x_norm * (float)uw.data[i * GCD_VEC_CPG + k] + (float)ub.data[i * GCD_VEC_CPG + k];
+                                float s = 1.f / (1.f + expf(-x_gn));
+                                grad_gn *= s * (1.f + x_gn * (1.f - s));
+                            }
+                            sum.x += grad_gn * (float)uw.data[i * GCD_VEC_CPG + k];
+                            sum.y += x_norm * (grad_gn * (float)uw.data[i * GCD_VEC_CPG + k]);
+                            if constexpr (REQUIRES_WGRAD) {
+                                dw_thread[i * GCD_VEC_CPG + k] += x_norm * grad_gn;
+                                db_thread[i * GCD_VEC_CPG + k] += grad_gn;
+                            }
+                        }
+                        frag_sum_per_channel[i] = sum;
+                    }
+                }
+                for (int i = 0; i < VEC_ELEMS / GCD_VEC_CPG; i++) {
+                    if constexpr (SINGLE_GROUP_PER_BLOCK) {
+                        for (int mask = 16; mask > 0; mask >>= 1) {
+                            frag_sum_per_channel[i].x += __shfl_xor_sync(FINAL_MASK, frag_sum_per_channel[i].x, mask, 32);
+                            frag_sum_per_channel[i].y += __shfl_xor_sync(FINAL_MASK, frag_sum_per_channel[i].y, mask, 32);
+                        }
+                        static_assert(VEC_ELEMS / GCD_VEC_CPG == 1, "process only one element for each warp");
+                        if (threadIdx.x % 32 == 0) {
+                            sum_per_channel_single_group[threadIdx.x / 32] = frag_sum_per_channel[i];
+                        }
+                    } else {
+                        sum_per_channel_multi_group[i * (C_PER_BLOCK / VEC_ELEMS) + threadIdx.x % (C_PER_BLOCK / VEC_ELEMS)][threadIdx.x / (C_PER_BLOCK / VEC_ELEMS)] = frag_sum_per_channel[i];
+                    }
+                }
+                __syncthreads();
+            } else {
+                for (int j = 0; j < ROWS_PER_BLOCK / ROWS_PER_IO; j++) {
+                    int64_t input_idx = n_loop * HW * C +
+                                        (virtual_block_idx_y * ROWS_PER_BLOCK + j * ROWS_PER_IO + threadIdx.x / (C_PER_BLOCK / VEC_ELEMS)) * C +
+                                        thread_channel_start;
+                    frag_x[j] = *reinterpret_cast<U const *>(&x[input_idx]);
+                    frag_dy[j] = *reinterpret_cast<U const *>(&grad_output[input_idx]);
+                }
+
+                for (int i = 0; i < VEC_ELEMS / GCD_VEC_CPG; i++) {
+                    float2 sum = {0.f, 0.f};
+                    for (int j = 0; j < ROWS_PER_BLOCK / ROWS_PER_IO; j++) {
+                        for (int k = 0; k < GCD_VEC_CPG; k++) {
+                            float rnorm = rsqrtf(frag_var[i] + eps);
+                            float x_norm = ((float)frag_x[j].data[i * GCD_VEC_CPG + k] - frag_mean[i]) * rnorm;  // TODO: store rsqrtf in mean_var
+                            float grad_gn = frag_dy[j].data[i * GCD_VEC_CPG + k];
+                            if constexpr (SILU) {
+                                float x_gn = x_norm * (float)uw.data[i * GCD_VEC_CPG + k] + (float)ub.data[i * GCD_VEC_CPG + k];
+                                float s = 1.f / (1.f + expf(-x_gn));
+                                grad_gn *= s * (1.f + x_gn * (1.f - s));
+                            }
+                            sum.x += grad_gn * (float)uw.data[i * GCD_VEC_CPG + k];
+                            sum.y += x_norm * (grad_gn * (float)uw.data[i * GCD_VEC_CPG + k]);
+                            if constexpr (REQUIRES_WGRAD) {
+                                dw_thread[i * GCD_VEC_CPG + k] += x_norm * grad_gn;
+                                db_thread[i * GCD_VEC_CPG + k] += grad_gn;
+                            }
+                        }
+                    }
+                    if constexpr (SINGLE_GROUP_PER_BLOCK) {
+                        for (int mask = 16; mask > 0; mask >>= 1) {
+                            sum.x += __shfl_xor_sync(FINAL_MASK, sum.x, mask, 32);
+                            sum.y += __shfl_xor_sync(FINAL_MASK, sum.y, mask, 32);
+                        }
+                        static_assert(VEC_ELEMS / GCD_VEC_CPG == 1, "process only one element for each warp");
+                        if (threadIdx.x % 32 == 0) {
+                            sum_per_channel_single_group[threadIdx.x / 32] = sum;
+                        }
+                    } else {
+                        sum_per_channel_multi_group[i * (C_PER_BLOCK / VEC_ELEMS) + threadIdx.x % (C_PER_BLOCK / VEC_ELEMS)][threadIdx.x / (C_PER_BLOCK / VEC_ELEMS)] = sum;
+                    }
+                }
+                __syncthreads();
+            }
+
+            if ((CONSTANT_C_LOOP && nc_scheduler.at_end(n)) || !CONSTANT_C_LOOP) {
+                constexpr int NT_C = max_divisor(C_PER_BLOCK, BLOCK_DIM_X);  // Number of threads on the C axis
+                constexpr int NT_R = 1;  // std::min(32, (int)round_down_pow2(BLOCK_DIM_X / NT_C));  // Number of threads on the ROWS axis
+                // TODO: swizzle for NT_R
+                for (int i = 0; i < VEC_ELEMS; i++) {
+                    union_smem.dwdb_block_buffer[threadIdx.x][i ^ ((threadIdx.x / (16 / VEC_ELEMS)) & (VEC_ELEMS - 1))] = float2{dw_thread[i], db_thread[i]};
+                }
+                __syncthreads();
+                static_assert(NT_C * NT_R <= BLOCK_DIM_X, "not enough threads");
+                static_assert(C_PER_BLOCK % NT_C == 0, "need to loop once more and check c < C_PER_BLOCK");
+                for (int i = 0; i < C_PER_BLOCK / NT_C; i++) {
+                    int c = i * NT_C + threadIdx.x / NT_R;
+                    float dw_block = 0.f;
+                    float db_block = 0.f;
+                    if (BLOCK_DIM_X == NT_C * NT_R || threadIdx.x < NT_C * NT_R) {
+                        for (int j = threadIdx.x % NT_R; j < ROWS_PER_IO; j += NT_R) {
+                            int src_thread = j * (C_PER_BLOCK / VEC_ELEMS) + c / VEC_ELEMS;
+                            float2 val = union_smem.dwdb_block_buffer[src_thread][(c % VEC_ELEMS) ^ ((src_thread / (16 / VEC_ELEMS)) & (VEC_ELEMS - 1))];
+                            dw_block += val.x;
+                            db_block += val.y;
+                        }
+                    }
+                    static_assert(32 % NT_R == 0, "cannot shuffle");
+                    for (int mask = NT_R / 2; mask > 0; mask >>= 1) {
+                        dw_block += __shfl_xor_sync(FINAL_MASK, dw_block, mask, 32);
+                        db_block += __shfl_xor_sync(FINAL_MASK, db_block, mask, 32);
+                    }
+                    if (BLOCK_DIM_X == NT_C * NT_R || threadIdx.x < NT_C * NT_R) {
+                        if (threadIdx.x % NT_R == 0) {
+                            if constexpr (CONSTANT_C_LOOP) {
+                                *reinterpret_cast<float2 *>(&red_buffer_wgrad[((blockIdx.y / (C / C_PER_CLUSTER) * virtual_cluster_dim_y + virtual_block_idx_y) * C + c_loop * C_PER_CLUSTER + virtual_block_idx_x * C_PER_BLOCK + c) * 2]) = float2{dw_block, db_block};
+                            } else {
+                                *reinterpret_cast<float2 *>(&red_buffer_wgrad[((n_loop * virtual_cluster_dim_y + virtual_block_idx_y) * C + c_loop * C_PER_CLUSTER + virtual_block_idx_x * C_PER_BLOCK + c) * 2]) = float2{dw_block, db_block};
+                            }
+                        }
+                    }
+                }
+            }
+
+            constexpr bool USE_SHARED_RED_BUFFER = HARDWARE_CLUSTER || VIRTUAL_CLUSTER_SIZE == 1;
+            constexpr bool STORE_MEAN_VAR_IN_SHARED_RED_BUFFER = VIRTUAL_CLUSTER_SIZE == 1 && MAX_NUM_GROUPS_PER_BLOCK == 1;  // MAX_NUM_GROUPS_PER_BLOCK > 1 is possible but not implemented
+            [[maybe_unused]] __align__(16) __shared__ float2 shared_red_buffer[MAX_NUM_GROUPS_PER_BLOCK * (STORE_MEAN_VAR_IN_SHARED_RED_BUFFER ? 1 : 2)];
+
+            if constexpr (SINGLE_GROUP_PER_BLOCK) {
+                // block reduce
+                if (threadIdx.x < 32) {
+                    float2 sum_local_group = threadIdx.x < BLOCK_DIM_X / 32 ? sum_per_channel_single_group[threadIdx.x] : float2{0.f, 0.f};
+                    constexpr int warp_num_pow2 = round_up_pow2(BLOCK_DIM_X / 32);
+                    for (int mask = warp_num_pow2 / 2; mask > 0; mask >>= 1) {
+                        sum_local_group.x += __shfl_xor_sync(FINAL_MASK, sum_local_group.x, mask, 32);
+                        sum_local_group.y += __shfl_xor_sync(FINAL_MASK, sum_local_group.y, mask, 32);
+                    }
+                    if (threadIdx.x == 0) {
+                        if constexpr (USE_SHARED_RED_BUFFER) {
+                            if constexpr (STORE_MEAN_VAR_IN_SHARED_RED_BUFFER) {
+                                shared_red_buffer[0] = compute_mean_var(sum_local_group);
+                            } else {
+                                shared_red_buffer[step * MAX_NUM_GROUPS_PER_BLOCK + 0] = sum_local_group;
+                            }
+                        } else {
+                            *reinterpret_cast<float2 *>(&red_buffer[((step * gridDim.y + blockIdx.y) * VIRTUAL_CLUSTER_SIZE * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                     virtual_block_idx_x * virtual_cluster_dim_y * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                     // (threadIdx.x / THREADS_PER_GROUP) * virtual_cluster_dim_y +
+                                                                     virtual_block_idx_y) * 2]) = sum_local_group;
+                        }
+                    }
+                }
+            } else {
+                constexpr int THREADS_PER_GROUP = std::min(std::min(32U,
+                                                                    round_up_pow2(ROWS_PER_IO)),
+                                                                    round_up_pow2(BLOCK_DIM_X / MAX_NUM_GROUPS_PER_BLOCK / 2 + 1));
+                static_assert(BLOCK_DIM_X >= MAX_NUM_GROUPS_PER_BLOCK * THREADS_PER_GROUP, "not enough threads");
+                float2 sum_local_group = {0.f, 0.f};
+                if (threadIdx.x / THREADS_PER_GROUP < MAX_NUM_GROUPS_PER_BLOCK) {
+                    int local_group_idx = block_group_start + threadIdx.x / THREADS_PER_GROUP;
+                    // TODO: map threads to both the CPG loop and the ROWS loop
+                    for (int local_c_loop = 0; local_c_loop < CPG; local_c_loop += GCD_VEC_CPG) {
+                        int c = local_group_idx * CPG + local_c_loop;
+                        if (C_PER_BLOCK % CPG == 0 || (c >= block_channel_start && c < block_channel_start + C_PER_BLOCK)) {
+                            for (int src_thread_tile_y = threadIdx.x % THREADS_PER_GROUP; src_thread_tile_y < ROWS_PER_IO; src_thread_tile_y += THREADS_PER_GROUP) {
+                                int channel_idx = (c - block_channel_start) / GCD_VEC_CPG;
+                                channel_idx = channel_idx % (VEC_ELEMS / GCD_VEC_CPG) * (C_PER_BLOCK / VEC_ELEMS) + channel_idx / (VEC_ELEMS / GCD_VEC_CPG);
+                                sum_local_group.x += sum_per_channel_multi_group[channel_idx][src_thread_tile_y].x;
+                                sum_local_group.y += sum_per_channel_multi_group[channel_idx][src_thread_tile_y].y;
+                            }
+                        }
+                    }
+                }
+                static_assert(32 % THREADS_PER_GROUP == 0, "cannot shuffle");
+                for (int mask = THREADS_PER_GROUP / 2; mask > 0; mask >>= 1) {
+                    sum_local_group.x += __shfl_xor_sync(FINAL_MASK, sum_local_group.x, mask, 32);
+                    sum_local_group.y += __shfl_xor_sync(FINAL_MASK, sum_local_group.y, mask, 32);
+                }
+                if (threadIdx.x % THREADS_PER_GROUP == 0 && threadIdx.x / THREADS_PER_GROUP < MAX_NUM_GROUPS_PER_BLOCK) {
+                    if constexpr (USE_SHARED_RED_BUFFER) {
+                        static_assert(HARDWARE_CLUSTER || VIRTUAL_CLUSTER_SIZE == 1, "no distributed shared memory");
+                        if constexpr (STORE_MEAN_VAR_IN_SHARED_RED_BUFFER) {
+                            shared_red_buffer[threadIdx.x / THREADS_PER_GROUP] = compute_mean_var(sum_local_group);
+                        } else {
+                            shared_red_buffer[step * MAX_NUM_GROUPS_PER_BLOCK + threadIdx.x / THREADS_PER_GROUP] = sum_local_group;
+                        }
+                    } else {
+                        *reinterpret_cast<float2 *>(&red_buffer[((step * gridDim.y + blockIdx.y) * VIRTUAL_CLUSTER_SIZE * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                 virtual_block_idx_x * virtual_cluster_dim_y * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                 (threadIdx.x / THREADS_PER_GROUP) * virtual_cluster_dim_y +
+                                                                 virtual_block_idx_y) * 2]) = sum_local_group;
+                    }
+                }
+            }
+
+            if constexpr (REQUIRES_WGRAD && wgrad_sync_method != WGRAD_SYNC_AT_LAST) {
+                if (nc_scheduler.at_end(n)) {
+                    static_assert(PERSISTENT, "persistent is a must for reducing wgrad");
+                    if constexpr (wgrad_sync_method == WGRAD_ARRIVE_AND_WAIT_GRID) {
+                        virtual_cluster_sync<VIRTUAL_CLUSTER_SIZE, PERSISTENT, HARDWARE_CLUSTER>(barrier);
+                        wgrad_sync_token = group_barrier_arrive<NUM_VIRTUAL_CLUSTERS * VIRTUAL_CLUSTER_SIZE, PERSISTENT>(barrier_wgrad, blockIdx.x + blockIdx.y == 0);
+                    } else if constexpr (wgrad_sync_method == WGRAD_ARRIVE_AND_WAIT_GROUP) {
+                        []<bool flag = CONSTANT_C_LOOP> { static_assert(flag, "requires CONSTANT_C_LOOP"); }();
+                        virtual_cluster_sync<VIRTUAL_CLUSTER_SIZE, PERSISTENT, HARDWARE_CLUSTER>(barrier);
+                        wgrad_sync_token = group_barrier_arrive<NUM_VIRTUAL_CLUSTERS * VIRTUAL_CLUSTER_SIZE / (C / C_PER_CLUSTER), PERSISTENT>(barrier_wgrad + virtual_cluster_idx_c, blockIdx.x + blockIdx.y / (C / C_PER_CLUSTER) == 0);
+                    } else if constexpr (wgrad_sync_method == WGRAD_REUSE_SUM_SYNC_GRID) {
+                        wgrad_sync_token = group_barrier_arrive<NUM_VIRTUAL_CLUSTERS * VIRTUAL_CLUSTER_SIZE, PERSISTENT>(barrier_wgrad, blockIdx.x + blockIdx.y == 0);
+                        group_barrier_wait(barrier_wgrad, wgrad_sync_token);
+                    } else if constexpr (wgrad_sync_method == WGRAD_REUSE_SUM_SYNC_GROUP) {
+                        []<bool flag = CONSTANT_C_LOOP> { static_assert(flag, "requires CONSTANT_C_LOOP"); }();
+                        wgrad_sync_token = group_barrier_arrive<NUM_VIRTUAL_CLUSTERS * VIRTUAL_CLUSTER_SIZE / (C / C_PER_CLUSTER), PERSISTENT>(barrier_wgrad + virtual_cluster_idx_c, blockIdx.x + blockIdx.y / (C / C_PER_CLUSTER) == 0);
+                        group_barrier_wait(barrier_wgrad + virtual_cluster_idx_c, wgrad_sync_token);
+                    }
+                } else {
+                    virtual_cluster_sync<VIRTUAL_CLUSTER_SIZE, PERSISTENT, HARDWARE_CLUSTER>(barrier);
+                }
+            } else {
+                virtual_cluster_sync<VIRTUAL_CLUSTER_SIZE, PERSISTENT, HARDWARE_CLUSTER>(barrier);
+            }
+
+            __shared__ float2 mean_var[MAX_NUM_GROUPS_PER_BLOCK];
+            if constexpr (!STORE_MEAN_VAR_IN_SHARED_RED_BUFFER) {
+                constexpr int THREADS_PER_GROUP = std::min(std::min(32U,
+                                                                    round_up_pow2(virtual_cluster_dim_y)),
+                                                                    round_up_pow2(BLOCK_DIM_X / MAX_NUM_GROUPS_PER_BLOCK / 2 + 1));
+                static_assert(BLOCK_DIM_X >= MAX_NUM_GROUPS_PER_BLOCK * THREADS_PER_GROUP, "not enough threads");
+                float2 sum_global_group = {0.f, 0.f};
+                if (threadIdx.x / THREADS_PER_GROUP < MAX_NUM_GROUPS_PER_BLOCK) {
+                    if constexpr (C_PER_BLOCK % CPG == 0) {
+                        float2 buffer[up_div(virtual_cluster_dim_y, THREADS_PER_GROUP)];
+                        for (int i = threadIdx.x % THREADS_PER_GROUP; i < virtual_cluster_dim_y; i += THREADS_PER_GROUP) {
+                            float2 val;
+                            if constexpr (USE_SHARED_RED_BUFFER) {
+                                if constexpr (VIRTUAL_CLUSTER_SIZE == 1) {
+                                    val = shared_red_buffer[step * MAX_NUM_GROUPS_PER_BLOCK + threadIdx.x / THREADS_PER_GROUP];
+                                } else {
+                                    static_assert(HARDWARE_CLUSTER, "no distributed shared memory");
+                                    float2 const *src_shared_red_buffer = cg::this_cluster().map_shared_rank(shared_red_buffer, i * virtual_cluster_dim_x + virtual_block_idx_x);
+                                    val = src_shared_red_buffer[step * MAX_NUM_GROUPS_PER_BLOCK + threadIdx.x / THREADS_PER_GROUP];
+                                }
+                            } else {
+                                val = *reinterpret_cast<float2 const *>(&red_buffer[((step * gridDim.y + blockIdx.y) * VIRTUAL_CLUSTER_SIZE * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                                     virtual_block_idx_x * virtual_cluster_dim_y * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                                     (threadIdx.x / THREADS_PER_GROUP) * virtual_cluster_dim_y +
+                                                                                     i) * 2]);
+                            }
+                            buffer[i / THREADS_PER_GROUP] = val;
+                        }
+                        for (int i = threadIdx.x % THREADS_PER_GROUP; i < virtual_cluster_dim_y; i += THREADS_PER_GROUP) {
+                            float2 val = buffer[i / THREADS_PER_GROUP];
+                            sum_global_group.x += val.x;
+                            sum_global_group.y += val.y;
+                        }
+                    } else {
+                        int local_group_idx = block_group_start + threadIdx.x / THREADS_PER_GROUP;
+                        for (int i = threadIdx.x % THREADS_PER_GROUP; i < VIRTUAL_CLUSTER_SIZE; i += THREADS_PER_GROUP) {
+                            int src_virtual_block_idx_x = i % virtual_cluster_dim_x;
+                            int src_block_channel_start = src_virtual_block_idx_x * C_PER_BLOCK + c_loop * C_PER_CLUSTER;
+                            int src_block_group_start = src_block_channel_start / CPG;
+                            int relative_group_idx = local_group_idx - src_block_group_start;
+                            if (0 <= relative_group_idx && relative_group_idx < MAX_NUM_GROUPS_PER_BLOCK) {
+                                float2 val;
+                                if constexpr (USE_SHARED_RED_BUFFER) {
+                                    static_assert(HARDWARE_CLUSTER, "no distributed shared memory");
+                                    static_assert(VIRTUAL_CLUSTER_SIZE != 1, "layout error: should not add (step * MAX_NUM_GROUPS_PER_BLOCK)");
+                                    float2 const *src_shared_red_buffer = cg::this_cluster().map_shared_rank(shared_red_buffer, i);
+                                    val = src_shared_red_buffer[step * MAX_NUM_GROUPS_PER_BLOCK + relative_group_idx];
+                                } else {
+                                    val = *reinterpret_cast<float2 const *>(&red_buffer[((step * gridDim.y + blockIdx.y) * VIRTUAL_CLUSTER_SIZE * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                                            src_virtual_block_idx_x * virtual_cluster_dim_y * MAX_NUM_GROUPS_PER_BLOCK +
+                                                                                            relative_group_idx * virtual_cluster_dim_y +
+                                                                                            i / virtual_cluster_dim_x) * 2]);
+                                }
+                                sum_global_group.x += val.x;
+                                sum_global_group.y += val.y;
+                            }
+                        }
+                    }
+                }
+                if constexpr (USE_SHARED_RED_BUFFER && VIRTUAL_CLUSTER_SIZE > 1) {
+                    if constexpr (PERSISTENT) {
+                        if (nc_scheduler.at_end(n)) {
+                            cg::this_cluster().barrier_arrive();
+                        }
+                    } else {
+                        cg::this_cluster().barrier_arrive();
+                    }
+                }
+                static_assert(32 % THREADS_PER_GROUP == 0, "cannot shuffle");
+                for (int mask = THREADS_PER_GROUP / 2; mask > 0; mask >>= 1) {
+                    sum_global_group.x += __shfl_xor_sync(FINAL_MASK, sum_global_group.x, mask, 32);
+                    sum_global_group.y += __shfl_xor_sync(FINAL_MASK, sum_global_group.y, mask, 32);
+                }
+                if (threadIdx.x % THREADS_PER_GROUP == 0 && threadIdx.x / THREADS_PER_GROUP < MAX_NUM_GROUPS_PER_BLOCK) {
+                    mean_var[threadIdx.x / THREADS_PER_GROUP] = compute_mean_var(sum_global_group);
+                }
+                __syncthreads();
+            }
+
+            auto get_mean_var = [&](int relative_group_idx) {
+                return STORE_MEAN_VAR_IN_SHARED_RED_BUFFER ? shared_red_buffer[relative_group_idx] : mean_var[relative_group_idx];
+            };
+
+            float frag_dyw[VEC_ELEMS / GCD_VEC_CPG];
+            float frag_xdyw[VEC_ELEMS / GCD_VEC_CPG];
+            for (int k = 0; k < VEC_ELEMS; k += GCD_VEC_CPG) {
+                frag_dyw[k / GCD_VEC_CPG] = get_mean_var((thread_channel_start + k) / CPG - block_group_start).x;
+                frag_xdyw[k / GCD_VEC_CPG] = get_mean_var((thread_channel_start + k) / CPG - block_group_start).y;
+            }
+
+            for (int j = 0; j < ROWS_PER_BLOCK / ROWS_PER_IO; j++) {
+                int64_t input_idx = n_loop * HW * C +
+                                    (virtual_block_idx_y * ROWS_PER_BLOCK + j * ROWS_PER_IO + threadIdx.x / (C_PER_BLOCK / VEC_ELEMS)) * C +
+                                    thread_channel_start;
+                U ux;
+                U udy;
+                if constexpr (LOAD_TWICE) {
+                    ux = *reinterpret_cast<U const *>(&x[input_idx]);
+                    udy = *reinterpret_cast<U const *>(&grad_output[input_idx]);
+                } else {
+                    ux = frag_x[j];
+                    udy = frag_dy[j];
+                }
+                U val;
+                for (int k = 0; k < VEC_ELEMS; k++) {
+                    float rnorm = rsqrtf(frag_var[k / GCD_VEC_CPG] + eps);
+                    float x_norm = ((float)ux.data[k] - frag_mean[k / GCD_VEC_CPG]) * rnorm;  // TODO: store rsqrtf in mean_var
+                    float grad_gn = udy.data[k];
+                    if constexpr (SILU) {
+                        float x_gn = x_norm * (float)uw.data[k] + (float)ub.data[k];
+                        float s = 1.f / (1.f + expf(-x_gn));
+                        grad_gn *= s * (1.f + x_gn * (1.f - s));
+                    }
+                    val.data[k] = (grad_gn * (float)uw.data[k] - frag_dyw[k / GCD_VEC_CPG] - frag_xdyw[k / GCD_VEC_CPG] * x_norm) * rnorm;
+                }
+                *reinterpret_cast<U *>(&grad_input[input_idx]) = val;
+            }
+
+            if constexpr (!STORE_MEAN_VAR_IN_SHARED_RED_BUFFER && USE_SHARED_RED_BUFFER && VIRTUAL_CLUSTER_SIZE > 1) {
+                if constexpr (PERSISTENT) {
+                    if (nc_scheduler.at_end(n)) {
+                        cg::this_cluster().barrier_wait();
+                    }
+                } else {
+                    cg::this_cluster().barrier_wait();
+                }
+            }
+
+            if constexpr (!PERSISTENT) {
+                break;
+            }
+            step ^= 1;
+        }
+
+        if constexpr (REQUIRES_WGRAD) {
+            static_assert(PERSISTENT, "cannot reduce wgrad");
+            static_assert(C % 32 == 0, "cannot reduce wgrad");
+            if constexpr (wgrad_sync_method == WGRAD_ARRIVE_AND_WAIT_GRID) {
+                group_barrier_wait(barrier_wgrad, wgrad_sync_token);
+            } else if constexpr (wgrad_sync_method == WGRAD_ARRIVE_AND_WAIT_GROUP) {
+                []<bool flag = CONSTANT_C_LOOP> { static_assert(flag, "requires CONSTANT_C_LOOP"); }();
+                group_barrier_wait(barrier_wgrad + virtual_cluster_idx_c, wgrad_sync_token);
+            } else if constexpr (wgrad_sync_method == WGRAD_SYNC_AT_LAST) {
+                cg::this_grid().sync();
+            }
+            constexpr bool split_channels = wgrad_sync_method == WGRAD_ARRIVE_AND_WAIT_GROUP || wgrad_sync_method == WGRAD_REUSE_SUM_SYNC_GROUP;
+            for (int c = split_channels ?
+                            virtual_cluster_idx_c * C_PER_CLUSTER + 32 * (blockIdx.y / (C / C_PER_CLUSTER) * VIRTUAL_CLUSTER_SIZE + blockIdx.x) :
+                            32 * (blockIdx.y * VIRTUAL_CLUSTER_SIZE + blockIdx.x);
+                    split_channels ?
+                            c < (virtual_cluster_idx_c + 1) * C_PER_CLUSTER :
+                            c < C;
+                    c += split_channels ?
+                            32 * (NUM_VIRTUAL_CLUSTERS / (C / C_PER_CLUSTER) * VIRTUAL_CLUSTER_SIZE) :
+                            32 * (NUM_VIRTUAL_CLUSTERS * VIRTUAL_CLUSTER_SIZE)) {
+                int64_t rows = (CONSTANT_C_LOOP ? std::min(n, (int64_t)NUM_VIRTUAL_CLUSTERS / (C / C_PER_CLUSTER)) : n) * virtual_cluster_dim_y;
+                float sum_wgrad = 0.f;
+                float sum_bgrad = 0.f;
+                if ((split_channels && (C_PER_CLUSTER % 32 == 0 || c + threadIdx.x % 32 < (virtual_cluster_idx_c + 1) * C_PER_CLUSTER)) ||
+                        (!split_channels && (C % 32 == 0 || c + threadIdx.x % 32 < C))) {
+                    for (int64_t i = threadIdx.x / 32; i < rows; i += BLOCK_DIM_X / 32) {
+                        float2 val = *reinterpret_cast<float2 const *>(&red_buffer_wgrad[(i * C + c + threadIdx.x % 32) * 2]);
+                        sum_wgrad += val.x;
+                        sum_bgrad += val.y;
+                    }
+                }
+                constexpr int warp_num_pow2 = round_up_pow2(BLOCK_DIM_X / 32);
+                union_smem.transpose_buffer.wgrad_buffer[threadIdx.x / 32][(threadIdx.x % 32) ^ ((threadIdx.x / 32) * (32 / warp_num_pow2))] = sum_wgrad;
+                union_smem.transpose_buffer.bgrad_buffer[threadIdx.x / 32][(threadIdx.x % 32) ^ ((threadIdx.x / 32) * (32 / warp_num_pow2))] = sum_bgrad;
+                __syncthreads();
+                for (int i = threadIdx.x / warp_num_pow2;
+                        i < 32 && ((split_channels && (C_PER_CLUSTER % 32 == 0 || c + i < (virtual_cluster_idx_c + 1) * C_PER_CLUSTER)) ||
+                                   (!split_channels && (C % 32 == 0 || c + i < C)));
+                        i += BLOCK_DIM_X / warp_num_pow2) {
+                    int j = threadIdx.x % warp_num_pow2;
+                    float sum_wgrad = j < BLOCK_DIM_X / 32 ? union_smem.transpose_buffer.wgrad_buffer[j][i ^ (j * (32 / warp_num_pow2))] : 0.f;
+                    float sum_bgrad = j < BLOCK_DIM_X / 32 ? union_smem.transpose_buffer.bgrad_buffer[j][i ^ (j * (32 / warp_num_pow2))] : 0.f;
+                    for (int mask = warp_num_pow2 / 2; mask > 0; mask >>= 1) {
+                        sum_wgrad += __shfl_xor_sync((uint64_t(1) << warp_num_pow2) - 1, sum_wgrad, mask, warp_num_pow2);
+                        sum_bgrad += __shfl_xor_sync((uint64_t(1) << warp_num_pow2) - 1, sum_bgrad, mask, warp_num_pow2);
+                    }
+                    if (j == 0) {
+                        grad_weight[c + i] = sum_wgrad;
+                        grad_bias[c + i] = sum_bgrad;
+                    }
+                }
+                __syncthreads();
+            }
+        }
+    }
+}
+
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_dispatch_hw_c.hpp
+++ b/apex/contrib/csrc/group_norm_v2/gn_dispatch_hw_c.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#define DISPATCH_HW_C(hw, c, HW, C, ...) [&] { \
+    if (hw == 64 && c == 1280) { constexpr int HW = 64, C = 1280; return __VA_ARGS__(); } \
+    if (hw == 64 && c == 2560) { constexpr int HW = 64, C = 2560; return __VA_ARGS__(); } \
+    if (hw == 256 && c == 640) { constexpr int HW = 256, C = 640; return __VA_ARGS__(); } \
+    if (hw == 256 && c == 1280) { constexpr int HW = 256, C = 1280; return __VA_ARGS__(); } \
+    if (hw == 256 && c == 1920) { constexpr int HW = 256, C = 1920; return __VA_ARGS__(); } \
+    if (hw == 256 && c == 2560) { constexpr int HW = 256, C = 2560; return __VA_ARGS__(); } \
+    if (hw == 1024 && c == 320) { constexpr int HW = 1024, C = 320; return __VA_ARGS__(); } \
+    if (hw == 1024 && c == 640) { constexpr int HW = 1024, C = 640; return __VA_ARGS__(); } \
+    if (hw == 1024 && c == 960) { constexpr int HW = 1024, C = 960; return __VA_ARGS__(); } \
+    if (hw == 1024 && c == 1280) { constexpr int HW = 1024, C = 1280; return __VA_ARGS__(); } \
+    if (hw == 1024 && c == 1920) { constexpr int HW = 1024, C = 1920; return __VA_ARGS__(); } \
+    if (hw == 4096 && c == 320) { constexpr int HW = 4096, C = 320; return __VA_ARGS__(); } \
+    if (hw == 4096 && c == 640) { constexpr int HW = 4096, C = 640; return __VA_ARGS__(); } \
+    if (hw == 4096 && c == 960) { constexpr int HW = 4096, C = 960; return __VA_ARGS__(); } \
+    throw std::invalid_argument("DISPATCH_HW_C " + std::to_string(hw) + " " + std::to_string(c)); \
+    }()

--- a/apex/contrib/csrc/group_norm_v2/gn_utils.cpp
+++ b/apex/contrib/csrc/group_norm_v2/gn_utils.cpp
@@ -20,4 +20,4 @@ cudaDeviceProp const &get_device_prop(int device_id) {
     return device_props.at(device_id);
 }
 
-}
+}  // namespace group_norm_v2

--- a/apex/contrib/csrc/group_norm_v2/gn_utils.cpp
+++ b/apex/contrib/csrc/group_norm_v2/gn_utils.cpp
@@ -1,0 +1,23 @@
+#include "gn_utils.hpp"
+
+#include <mutex>
+#include <vector>
+
+
+namespace group_norm_v2 {
+
+cudaDeviceProp const &get_device_prop(int device_id) {
+    static std::vector<cudaDeviceProp> device_props;
+    static std::once_flag flag;
+    std::call_once(flag, [&] {
+        int count;
+        CUDA_CHECK(cudaGetDeviceCount(&count));
+        device_props.resize(count);
+        for (int i = 0; i < count; i++) {
+            CUDA_CHECK(cudaGetDeviceProperties(&device_props[i], i));
+        }
+    });
+    return device_props.at(device_id);
+}
+
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_utils.hpp
+++ b/apex/contrib/csrc/group_norm_v2/gn_utils.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+
+#include <cuda_runtime.h>
+
+#include "gn.hpp"
+
+
+// Definition of CUDA_CHECK macro
+#define CUDA_CHECK(call)                                                    \
+do {                                                                        \
+    cudaError_t err_ = call;                                                \
+    if (err_ != cudaSuccess) {                                              \
+        fprintf(stderr, "CUDA error at %s:%d code=%d(%s) \"%s\" \n",        \
+                __FILE__, __LINE__, err_, cudaGetErrorString(err_), #call); \
+        exit(EXIT_FAILURE);                                                 \
+    }                                                                       \
+} while (0)
+
+
+#define GN_CUDA_HOST_PARAMS(T) T *out, T *x, T *w, T *b, float eps, bool silu, int64_t n, int64_t hw, int num_groups, int channels_per_group, float *mean_var_out, float *red_buffer, unsigned *barrier, int sm_margin, cudaStream_t stream, int device_id, Meta *meta_ptr, bool meta_only
+
+#define GN_BWD_CUDA_HOST_PARAMS(T) T *grad_input, T *grad_weight, T *grad_bias, T *grad_output, T *x, T *w, T *b, float *mean_var, float eps, bool silu, int64_t n, int64_t hw, int num_groups, int channels_per_group, float *red_buffer, unsigned *barrier, int sm_margin, cudaStream_t stream, int device_id, Meta *meta_ptr, bool meta_only
+
+#define GN_CUDA_HOST_ARGS out, x, w, b, eps, silu, n, hw, num_groups, channels_per_group, mean_var_out, red_buffer, barrier, sm_margin, stream, device_id, meta_ptr, meta_only
+
+#define GN_BWD_CUDA_HOST_ARGS grad_input, grad_weight, grad_bias, grad_output, x, w, b, mean_var, eps, silu, n, hw, num_groups, channels_per_group, red_buffer, barrier, sm_margin, stream, device_id, meta_ptr, meta_only
+
+
+namespace group_norm_v2 {
+
+cudaDeviceProp const &get_device_prop(int device_id);
+
+#ifdef __CUDA_ARCH__
+
+template<class ...Ts>
+__host__ __device__ inline int print_rank_0(char const *fmt, Ts &&...args) {
+    if (threadIdx.x + threadIdx.y + threadIdx.z == 0 && blockIdx.x + blockIdx.y + blockIdx.z == 0) {
+        return printf(fmt, std::forward<Ts>(args)...);
+    }
+    return 0;
+}
+
+#endif
+
+}

--- a/apex/contrib/csrc/group_norm_v2/gn_utils.hpp
+++ b/apex/contrib/csrc/group_norm_v2/gn_utils.hpp
@@ -46,4 +46,4 @@ __host__ __device__ inline int print_rank_0(char const *fmt, Ts &&...args) {
 
 #endif
 
-}
+}  // namespace group_norm_v2

--- a/apex/contrib/group_norm/group_norm.py
+++ b/apex/contrib/group_norm/group_norm.py
@@ -192,6 +192,10 @@ def cuda_group_norm_nhwc_two_pass(x, G, weight, bias, eps, act=None):
     y, _ = group_norm_nhwc_fprop(x, G, weight, bias, eps, act, passes=2)
     return y
 
+def cuda_group_norm_v2_nhwc(x, G, weight, bias, eps, act=None):
+    y, _ = group_norm_nhwc_fprop(x, G, weight, bias, eps, act, use_group_norm_v2=True)
+    return y
+
 # We do not direct inherit from torch.nn.GroupNorm since several fusers don't
 # support inheritance. Extends:
 # https://github.com/pytorch/pytorch/blob/main/torch/nn/modules/normalization.py

--- a/apex/contrib/group_norm/group_norm.py
+++ b/apex/contrib/group_norm/group_norm.py
@@ -15,14 +15,16 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import functools
+import os
 import torch
 import torch.nn.functional as F
 import torch.nn.init as init
 import group_norm_cuda
+import group_norm_v2_cuda
 
 from torch import Tensor
 from torch.nn.parameter import Parameter
-from functools import partial
 
 __all__ = ['GroupNorm']
 
@@ -30,6 +32,15 @@ def one_time_warning(msg: str):
     if not hasattr(one_time_warning, 'has_been_called'):
         one_time_warning.has_been_called = True
         print(f'\033[93m{msg}\033[0m')  # hightlight with yellow color
+
+
+@functools.cache
+def get_cc_and_sm_count(device_index: int):
+    props = torch.cuda.get_device_properties(device_index)
+    CC = (props.major, props.minor)
+    SM_COUNT = props.multi_processor_count
+    return CC, SM_COUNT
+
 
 # pytorch group norm requires same input type
 def torch_group_norm(x, g, w, b, eps, act=""):
@@ -52,6 +63,7 @@ def group_norm_nhwc_fprop(
     eps: float,
     act: str | None=None,
     passes: int=1,
+    use_group_norm_v2: bool=False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     # sanity check
     act = act.lower() if act else act
@@ -64,14 +76,25 @@ def group_norm_nhwc_fprop(
     assert passes in [1, 2], "Invalid number of passes for algorithm."
 
     with_swish = act in ("silu", "swish")
+    sm_margin = int(os.environ.get("APEX_GROUP_NORM_FPROP_SM_MARGIN", "0"))
 
     # enqueue fprop kernel
-    y, sums = group_norm_cuda.forward(x, G, weight, bias, eps, passes,
+    if use_group_norm_v2:
+        sums = torch.empty(x.shape[0] * G * 2, device=x.device)
+        y = group_norm_v2_cuda.gn(x, weight, bias,
+                                  eps, with_swish, G, mean_var_out=sums,
+                                  sm_margin=sm_margin)
+    else:
+        if sm_margin:
+            raise NotImplementedError(
+                "sm_margin is not supported for GroupNorm v1"
+            )
+        y, sums = group_norm_cuda.forward(x, G, weight, bias, eps, passes,
                                           with_swish)
     return y, sums
 
 @group_norm_nhwc_fprop.register_fake
-def fake_group_norm_nhwc_fprop(x, G, weight, bias, eps, act=None, passes=1):
+def fake_group_norm_nhwc_fprop(x, G, weight, bias, eps, act=None, passes=1, use_group_norm_v2=False):
     # sanity check
     act = act.lower() if act else act
     assert x.is_contiguous(memory_format=torch.channels_last), \
@@ -97,6 +120,7 @@ def group_norm_nhwc_bprop(
     eps: float,
     act: str | None=None,
     passes: int=1,
+    use_group_norm_v2: bool=False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     # sanity check
     if not grad_output.is_contiguous(memory_format=torch.channels_last):
@@ -111,14 +135,24 @@ def group_norm_nhwc_bprop(
 
     act = act.lower() if act else act
     with_swish = (act in ["silu", "swish"])
+    sm_margin = int(os.environ.get("APEX_GROUP_NORM_BPROP_SM_MARGIN", "0"))
 
-    dx, dw, db = group_norm_cuda.backward(grad_output, sums, x, G,
-                                          weight, bias, eps,
-                                          passes, with_swish)
+    if use_group_norm_v2:
+        dx, dw, db = group_norm_v2_cuda.gn_bwd(grad_output, x, weight, bias,
+                                               sums, eps, with_swish, G,
+                                               sm_margin=sm_margin)
+    else:
+        if sm_margin:
+            raise NotImplementedError(
+                "sm_margin is not supported for GroupNorm v1"
+            )
+        dx, dw, db = group_norm_cuda.backward(grad_output, sums, x, G,
+                                              weight, bias, eps,
+                                              passes, with_swish)
     return dx, dw, db
 
 @group_norm_nhwc_bprop.register_fake
-def fake_group_norm_nhwc_bprop(grad_output, sums, x, G, weight, bias, eps, act=None, passes=1):
+def fake_group_norm_nhwc_bprop(grad_output, sums, x, G, weight, bias, eps, act=None, passes=1, use_group_norm_v2=False):
     dx = torch.empty_like(x)
     dw = torch.empty_like(weight)
     db = torch.empty_like(bias)
@@ -131,13 +165,14 @@ def backward(ctx, grad_output, grad_sums):
     eps = ctx.eps
     passes = ctx.passes
     act = ctx.act
+    use_group_norm_v2 = ctx.use_group_norm_v2
 
     dx, dw, db = group_norm_nhwc_bprop(grad_output, sums, x, G, w, b, eps,
-                                       act, passes)
-    return dx, None, dw, db, None, None, None
+                                       act, passes, use_group_norm_v2)
+    return dx, None, dw, db, None, None, None, None
 
 def setup_context(ctx, inputs, output):
-    x, G, weight, bias, eps, act, passes = inputs
+    x, G, weight, bias, eps, act, passes, use_group_norm_v2 = inputs
     y, sums = output
     # save for backward
     ctx.save_for_backward(x, weight, bias, sums)
@@ -145,6 +180,7 @@ def setup_context(ctx, inputs, output):
     ctx.eps = eps
     ctx.passes = passes
     ctx.act = act
+    ctx.use_group_norm_v2 = use_group_norm_v2
 
 group_norm_nhwc_fprop.register_autograd(backward, setup_context=setup_context)
 
@@ -229,6 +265,36 @@ class GroupNorm(torch.nn.Module):
         (torch.bfloat16, torch.float16),
         (torch.bfloat16, torch.float32),
         ])
+    GN_V2_SUPPORTED_CHANNELS = frozenset([
+        # (HW, C)
+        (8 * 8, 1280),
+        (8 * 8, 2560),
+        (16 * 16, 640),
+        (16 * 16, 1280),
+        (16 * 16, 1920),
+        (16 * 16, 2560),
+        (32 * 32, 320),
+        (32 * 32, 640),
+        (32 * 32, 960),
+        (32 * 32, 1280),
+        (32 * 32, 1920),
+        (64 * 64, 320),
+        (64 * 64, 640),
+        (64 * 64, 960),
+        ])
+    GN_V2_SUPPORTED_DTYPES = frozenset([
+        # (input dtype, parameter dtype)
+        (torch.float16, torch.float16),
+        (torch.bfloat16, torch.bfloat16),
+        ])
+    GN_V2_SUPPORTED_GROUPS_SWISH = frozenset([
+        # (num_groups, with_swish)
+        (16, True),
+        (32, False),
+        ])
+    GN_V2_SUPPORTED_LOWER_BOUND_SM_COUNT = {
+        (10, 0): 148,
+        }
 
     def __init__(self,
                  num_groups: int,
@@ -283,6 +349,26 @@ class GroupNorm(torch.nn.Module):
         else:
             return False
 
+    def _check_v2_legality(self, input: Tensor) -> bool:
+        is_legal_channels = (
+            (input.shape[2] * input.shape[3], self.num_channels)
+            in self.GN_V2_SUPPORTED_CHANNELS)
+        is_supported_groups_swish_combination = (
+            (self.num_groups, self.act in ['silu', 'swish'])
+            in self.GN_V2_SUPPORTED_GROUPS_SWISH)
+        is_supported_dtype_combination = self.affine and \
+            (input.dtype, self.weight.dtype) in self.GN_V2_SUPPORTED_DTYPES
+        cc, sm_count = get_cc_and_sm_count(input.device.index)
+        is_supported_sm_count = (
+            cc in self.GN_V2_SUPPORTED_LOWER_BOUND_SM_COUNT
+            and sm_count >= self.GN_V2_SUPPORTED_LOWER_BOUND_SM_COUNT[cc])
+
+        if is_legal_channels and is_supported_groups_swish_combination and \
+                is_supported_dtype_combination and is_supported_sm_count:
+            return True
+        else:
+            return False
+
     def forward(self, input: Tensor) -> Tensor:
         can_use_nhwc_group_norm = self._check_legality(input)
 
@@ -297,8 +383,10 @@ class GroupNorm(torch.nn.Module):
                 passes = 2
             else:
                 passes = 1
+            use_group_norm_v2 = self._check_v2_legality(input)
             y, _ = group_norm_nhwc_fprop(input, self.num_groups, self.weight,
-                                         self.bias, self.eps, self.act, passes)
+                                         self.bias, self.eps, self.act,
+                                         passes, use_group_norm_v2)
             return y
         else:
             return torch_group_norm(input, self.num_groups, self.weight,

--- a/apex/contrib/test/group_norm/test_group_norm.py
+++ b/apex/contrib/test/group_norm/test_group_norm.py
@@ -15,6 +15,9 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import functools
+import importlib
+import pathlib
 import torch
 import unittest
 
@@ -22,10 +25,41 @@ SKIP_TEST = None
 try:
     from apex.contrib.group_norm.group_norm import cuda_group_norm_nhwc_one_pass
     from apex.contrib.group_norm.group_norm import cuda_group_norm_nhwc_two_pass
-    from apex.contrib.group_norm.group_norm import torch_group_norm
+    from apex.contrib.group_norm.group_norm import cuda_group_norm_v2_nhwc
+    from apex.contrib.group_norm.group_norm import get_cc_and_sm_count
     from apex.contrib.group_norm import GroupNorm
 except ImportError as e:
     SKIP_TEST = e
+
+
+def torch_group_norm_high_precision(x, g, w, b, eps, act="", *, compute_type):
+    xdtype = x.dtype
+    y = torch.nn.functional.group_norm(
+        x.to(compute_type),
+        g,
+        w.to(compute_type),
+        b.to(compute_type),
+        eps,
+    )
+    if act in ["silu", "swish"]:
+        y = torch.nn.functional.silu(y)
+    y = y.to(dtype=xdtype)
+    return y
+
+
+torch_group_norm_high_precision_fp64 = functools.partial(
+    torch_group_norm_high_precision,
+    compute_type=torch.float64,
+)
+
+
+@functools.cache
+def relative_ulp(dtype, device):
+    # Unit in the Last Place
+    one = torch.tensor(1., dtype=dtype, device=device)
+    two = torch.tensor(2., dtype=dtype, device=device)
+    return (torch.nextafter(one, two) - one).item()
+
 
 @unittest.skipIf(torch.cuda.get_device_properties().multi_processor_count < 16, "GroupNorm is unsupported on low SM count devices")
 @unittest.skipIf(SKIP_TEST, f"{SKIP_TEST}")
@@ -42,7 +76,7 @@ class GroupNormTest(unittest.TestCase):
                           H=256,
                           W=256,
                           G=32,
-                          ref_func=torch_group_norm,
+                          ref_func=torch_group_norm_high_precision_fp64,
                           xdtype=torch.float16,
                           wdtype=torch.float32,
                           eps=1e-5,
@@ -89,10 +123,10 @@ class GroupNormTest(unittest.TestCase):
             dx_tst, dw_tst, db_tst = [t.grad.clone() for t in [x, weight, bias]]
 
         # compare
-        torch.testing.assert_close(y_tst, y_ref, atol=4e-2, rtol=0)
-        torch.testing.assert_close(dx_tst, dx_ref, atol=4e-2, rtol=0)
-        torch.testing.assert_close(dw_tst, dw_ref, atol=4e-2, rtol=0)
-        torch.testing.assert_close(db_tst, db_ref, atol=4e-2, rtol=0)
+        torch.testing.assert_close(y_tst, y_ref, atol=1e-2, rtol=relative_ulp(y_ref.dtype, y_ref.device))
+        torch.testing.assert_close(dx_tst, dx_ref, atol=1e-2, rtol=relative_ulp(dx_ref.dtype, dx_ref.device))
+        torch.testing.assert_close(dw_tst, dw_ref, atol=1e-2, rtol=relative_ulp(dw_ref.dtype, dw_ref.device))
+        torch.testing.assert_close(db_tst, db_ref, atol=1e-2, rtol=relative_ulp(db_ref.dtype, db_ref.device))
 
     def test_fp16_one_pass_algo(self):
         self.verify_group_norm(cuda_group_norm_nhwc_one_pass, act="")
@@ -199,6 +233,113 @@ class GroupNormTest(unittest.TestCase):
                                xdtype=torch.float16,
                                wdtype=torch.float16,
                                act="swish")
+
+    @staticmethod
+    @functools.cache
+    def get_v2_hw_c_list():
+        srcpath = pathlib.Path(__file__).parent.absolute()
+        gen_module_path = srcpath / ".." / ".." / "csrc" / "group_norm_v2" / "generate_gn_cuda_inst.py"
+        spec = importlib.util.spec_from_file_location("generate_gn_cuda_inst", gen_module_path)
+        generate_gn_cuda_inst = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(generate_gn_cuda_inst)
+        return generate_gn_cuda_inst.hw_c_list
+
+    def check_v2_cc_and_sm_count(self):
+        cc, sm_count = get_cc_and_sm_count(torch.cuda.current_device())
+        return (
+            cc in GroupNorm.GN_V2_SUPPORTED_LOWER_BOUND_SM_COUNT
+            and sm_count >= GroupNorm.GN_V2_SUPPORTED_LOWER_BOUND_SM_COUNT[cc]
+        )
+
+    def skip_if_v2_not_supported(self):
+        if not self.check_v2_cc_and_sm_count():
+            cc, sm_count = get_cc_and_sm_count(torch.cuda.current_device())
+            self.skipTest(f"SM count {sm_count} is not supported for compute capability {cc[0]}.{cc[1]}")
+
+    def test_check_v2_legality(self):
+        gn = GroupNorm(
+            num_groups=16,
+            num_channels=640,
+            device="cuda",
+            dtype=torch.float16,
+            act="swish")
+        self.skip_if_v2_not_supported()
+        # Correct
+        x = torch.empty(8, 640, 32, 32, dtype=torch.float16, device="cuda", memory_format=torch.channels_last)
+        self.assertTrue(gn._check_legality(x) and gn._check_v2_legality(x))
+        # Wrong layout
+        x = torch.empty(8, 640, 32, 32, dtype=torch.float16, device="cuda")
+        self.assertFalse(gn._check_legality(x) and gn._check_v2_legality(x))
+        # Wrong shape
+        x = torch.empty(8, 640, 32, 24, dtype=torch.float16, device="cuda", memory_format=torch.channels_last)
+        self.assertFalse(gn._check_legality(x) and gn._check_v2_legality(x))
+        # Wrong dtype
+        x = torch.empty(8, 640, 32, 32, dtype=torch.float32, device="cuda", memory_format=torch.channels_last)
+        self.assertFalse(gn._check_legality(x) and gn._check_v2_legality(x))
+
+    def test_fp16_v2_32_groups(self):
+        self.skip_if_v2_not_supported()
+        for n in [1, 2, 4, 8, 16, 32]:
+            for hw, c in self.get_v2_hw_c_list():
+                h = w = int(hw ** .5)
+                assert hw == h * w
+                self.verify_group_norm(cuda_group_norm_v2_nhwc,
+                                       N=n,
+                                       C=c,
+                                       H=h,
+                                       W=w,
+                                       G=32,
+                                       xdtype=torch.float16,
+                                       wdtype=torch.float16,
+                                       act="")
+
+    def test_fp16_v2_16_groups_with_swish(self):
+        self.skip_if_v2_not_supported()
+        for n in [1, 2, 4, 8, 16, 32]:
+            for hw, c in self.get_v2_hw_c_list():
+                h = w = int(hw ** .5)
+                assert hw == h * w
+                self.verify_group_norm(cuda_group_norm_v2_nhwc,
+                                       N=n,
+                                       C=c,
+                                       H=h,
+                                       W=w,
+                                       G=16,
+                                       xdtype=torch.float16,
+                                       wdtype=torch.float16,
+                                       act="swish")
+
+    def test_bf16_v2_32_groups(self):
+        self.skip_if_v2_not_supported()
+        for n in [1, 2, 4, 8, 16, 32]:
+            for hw, c in self.get_v2_hw_c_list():
+                h = w = int(hw ** .5)
+                assert hw == h * w
+                self.verify_group_norm(cuda_group_norm_v2_nhwc,
+                                       N=n,
+                                       C=c,
+                                       H=h,
+                                       W=w,
+                                       G=32,
+                                       xdtype=torch.bfloat16,
+                                       wdtype=torch.bfloat16,
+                                       act="")
+
+    def test_bf16_v2_16_groups_with_swish(self):
+        self.skip_if_v2_not_supported()
+        for n in [1, 2, 4, 8, 16, 32]:
+            for hw, c in self.get_v2_hw_c_list():
+                h = w = int(hw ** .5)
+                assert hw == h * w
+                self.verify_group_norm(cuda_group_norm_v2_nhwc,
+                                       N=n,
+                                       C=c,
+                                       H=h,
+                                       W=w,
+                                       G=16,
+                                       xdtype=torch.bfloat16,
+                                       wdtype=torch.bfloat16,
+                                       act="swish")
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -506,9 +506,9 @@ if "--group_norm" in sys.argv:
                 "apex/contrib/csrc/group_norm_v2/gn_utils.cpp",
             ] + glob.glob("apex/contrib/csrc/group_norm_v2/gn_cuda_inst_*.cu"),
             extra_compile_args={
-                "cxx": ["-O2", "-std=c++20"] + version_dependent_macros,
+                "cxx": ["-O2"] + version_dependent_macros,
                 "nvcc": [
-                    "-O2", "-std=c++20", "--use_fast_math", "--ftz=false",
+                    "-O2", "--use_fast_math", "--ftz=false",
                     "-U__CUDA_NO_HALF_CONVERSIONS__",
                     "-U__CUDA_NO_HALF_OPERATORS__",
                     "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",

--- a/setup.py
+++ b/setup.py
@@ -491,6 +491,33 @@ if "--group_norm" in sys.argv:
         )
     )
 
+    # CUDA group norm V2 is tested on SM100
+    if bare_metal_version >= Version("12.7"):
+        arch_flags = ["-gencode=arch=compute_100,code=sm_100"]
+    else:
+        arch_flags = ["-gencode=arch=compute_90,code=compute_90"]
+
+    ext_modules.append(
+        CUDAExtension(
+            name="group_norm_v2_cuda",
+            sources=[
+                "apex/contrib/csrc/group_norm_v2/gn.cpp",
+                "apex/contrib/csrc/group_norm_v2/gn_cuda.cu",
+                "apex/contrib/csrc/group_norm_v2/gn_utils.cpp",
+            ] + glob.glob("apex/contrib/csrc/group_norm_v2/gn_cuda_inst_*.cu"),
+            extra_compile_args={
+                "cxx": ["-O2", "-std=c++20"] + version_dependent_macros,
+                "nvcc": [
+                    "-O2", "-std=c++20", "--use_fast_math", "--ftz=false",
+                    "-U__CUDA_NO_HALF_CONVERSIONS__",
+                    "-U__CUDA_NO_HALF_OPERATORS__",
+                    "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+                    "-U__CUDA_NO_BFLOAT16_OPERATORS__",
+                ] + arch_flags + version_dependent_macros,
+            },
+        )
+    )
+
 if "--index_mul_2d" in sys.argv:
     sys.argv.remove("--index_mul_2d")
     raise_if_cuda_home_none("--index_mul_2d")

--- a/setup.py
+++ b/setup.py
@@ -492,7 +492,7 @@ if "--group_norm" in sys.argv:
     )
 
     # CUDA group norm V2 is tested on SM100
-    if bare_metal_version >= Version("12.7"):
+    if bare_metal_version >= Version("12.8"):
         arch_flags = ["-gencode=arch=compute_100,code=sm_100"]
     else:
         arch_flags = ["-gencode=arch=compute_90,code=compute_90"]


### PR DESCRIPTION
GroupNorm v2 outperforms the original GroupNorm extension by utilizing coalesced memory access, tested on B200 with a set of shapes.