### PR TITLE
Fix GroupNorm test: properly check graph breaks

### DIFF
--- a/apex/contrib/test/group_norm/test_group_norm.py
+++ b/apex/contrib/test/group_norm/test_group_norm.py
@@ -18,6 +18,7 @@
 import functools
 import importlib
 import pathlib
+import sys
 import torch
 import unittest
 
@@ -202,7 +203,12 @@ class GroupNormTest(unittest.TestCase):
             y.backward(dy)
 
         from torch._dynamo.utils import counters
-        self.assertNotIn('graph_break', counters, "Shouldn't see any graph breaks.")
+        # TODO: Remove this when 3.9 is no longer supported
+        if sys.version_info < (3, 10):
+            num_graph_breaks = sum(counters["graph_break"].values())
+        else:
+            num_graph_breaks = counters["graph_break"].total()
+        self.assertEqual(num_graph_breaks, 0, "Shouldn't see any graph breaks.")
         self.assertEqual(counters['stats']['unique_graphs'], 1, "Expect only one graph.")
 
     def test_16_groups(self):


### PR DESCRIPTION
We should check `counters["graph_break"].total()` instead of `"graph_break" in counters` to determine whether there is any graph break.

The reason that the test **cannot pass the latest PyTorch** (but can pass old versions of PyTorch) is that after https://github.com/pytorch/pytorch/pull/146537 , `counters["graph_break"]` may be visited internally, so the origin `assertNotIn` may fail even if there is no graph breaks.