### PR TITLE
[contrib/torchsched] Refactor cross-stream dependency handling

### DIFF
--- a/apex/contrib/torchsched/__init__.py
+++ b/apex/contrib/torchsched/__init__.py
@@ -13,8 +13,8 @@ from torch._inductor.compile_fx import compile_fx_inner
 from .backend import get_backend
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import Any
-    from typing import Callable
 
     from torch._ops import OpOverload
 
@@ -50,7 +50,7 @@ def set_default_backend(backend: str) -> None:
     Parameters:
         backend (str): The backend to use as the default for torch.compile.
     """
-    global _SUPPORTED_BACKENDS, _DEFAULT_BACKEND
+    global _DEFAULT_BACKEND
     assert backend in _SUPPORTED_BACKENDS, f"Unknown backend {backend}"
     _DEFAULT_BACKEND = backend
 

--- a/apex/contrib/torchsched/backend.py
+++ b/apex/contrib/torchsched/backend.py
@@ -288,9 +288,9 @@ def get_backend(
 
     # [NOTE] Disable buffer reuse and inplace buffers to avoid inter-stream conflicts.
     #
-    # In Inductor, the safety of buffer reuse and inplace buffer update is backed by the single-
-    # stream serial execution of the program. That is, if op2 is launched only if op1 has finished
-    # execution, then these cases are safe:
+    # In PyTorch Inductor, the safety of buffer reuse and in-place buffer update is ensured by the
+    # program's single-stream, serial execution. That is, if op2 is launched only after op1 has
+    # completed execution, then these cases are safe:
     #
     #   Case 1: Safe to reuse buffer `workspace1` as `op2`'s workspace.
     #

--- a/apex/contrib/torchsched/backend.py
+++ b/apex/contrib/torchsched/backend.py
@@ -5,27 +5,23 @@ from __future__ import annotations
 import functools
 from copy import copy
 from typing import TYPE_CHECKING
-from typing import Callable
 from typing import ParamSpec
 from typing import TypeVar
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from types import NotImplementedType
 
 import torch
 from torch import Tensor
 from torch import _TorchCompileInductorWrapper
 from torch._dynamo import lookup_backend
-from torch._inductor.codegen.common import register_backend_for_device
-from torch._inductor.codegen.cuda_combined_scheduling import CUDACombinedScheduling
-from torch._inductor.codegen.wrapper import PythonWrapperCodegen
 from torch._inductor.compile_fx import compile_fx
 from torch._inductor.compile_fx import compile_fx_inner
 from torch._inductor.decomposition import select_decomp_table
 
 import apex.contrib.torchsched.config as config
 from apex.contrib.torchsched.inductor import patch_graph_lowering
-from apex.contrib.torchsched.inductor.wrapper import MultiStreamWrapperCodegen
 from apex.contrib.torchsched.passes import pre_grad_custom_pass
 
 aten = torch.ops.aten
@@ -43,21 +39,9 @@ def enable_multi_stream_scheduling(compile_fn: Callable[P, R]) -> Callable[P, R]
 
     @functools.wraps(compile_fn)
     def _compile_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-        register_backend_for_device("cuda", CUDACombinedScheduling, MultiStreamWrapperCodegen)
         patch_graph_lowering(patch=True)
-
-        # torch.compile explicitly calls `write_get_raw_stream` via wrapper's class method in its
-        # lowering process to walk around the wrapper-stream LRU cache mechanism. To be compatible
-        # with this, we got to patch wrapper's class method as well.
-        _origin_write_get_raw_stream = PythonWrapperCodegen.write_get_raw_stream
-        PythonWrapperCodegen.write_get_raw_stream = MultiStreamWrapperCodegen._write_get_raw_stream
-
         compile_results = compile_fn(*args, **kwargs)
-
-        register_backend_for_device("cuda", CUDACombinedScheduling, PythonWrapperCodegen)
         patch_graph_lowering(patch=False)
-        PythonWrapperCodegen.write_get_raw_stream = _origin_write_get_raw_stream
-
         return compile_results
 
     return _compile_wrapper
@@ -302,11 +286,49 @@ def get_backend(
     if backend == "torch":
         return lookup_backend("inductor")
 
+    # [NOTE] Disable buffer reuse and inplace buffers to avoid inter-stream conflicts.
+    #
+    # In Inductor, the safety of buffer reuse and inplace buffer update is backed by the single-
+    # stream serial execution of the program. That is, if op2 is launched only if op1 has finished
+    # execution, then these cases are safe:
+    #
+    #   Case 1: Safe to reuse buffer `workspace1` as `op2`'s workspace.
+    #
+    #         op1   ->   op2              op1   ->   op2
+    #          ↕          ↕       ⇒        ↕          ↑
+    #     workspace1 workspace2       workspace1 ←----┘
+    #
+    #   Case 2: Safe to inpalace `op1`'s output to `buf1` then send to `op2` as input.
+    #
+    #     buf1 -> op1 -> buf2 -> op2  ⇒  buf1 ↔	op1
+    #                                     └-------> op2
+    #
+    # However, if operators are dispatched to distinct CUDA Streams and execute in parallel, above
+    # cases are not safe any more:
+    #
+    #   Counter example 1: Case 1 is not safe if op1 and op2 are in parallel.
+    #
+    #        op1
+    #         ↕
+    #     workspace1 (Buffer modified concurrently by op1 and op2.)
+    #         ↕
+    #        op2
+    #
+    #   Counter example 2: Case 2 is not safe if op1 and op2 are in parallel.
+    #
+    #     buf1 <-->	op1
+    #      └------> op2 (Op2 could read op1's input data.)
+    #
+    # Thus currently we disable both buffer reuse and inplace buffer update to ensure multi-stream
+    # correctness.
+    #
+    # TODO(@davidli): Add cross-stream dependency to Inductor scheduling's dependency system so we
+    # can safely reuse and inplace update buffers even in multi-stream scenario.
+
     if scheme == "dwb":
         return DecompositionsWrapper(
             mode="default",
-            # TODO(@davidli): Elegantly solve cross-stream buffer reusing conflicts.
-            options={"allow_buffer_reuse": False},
+            options={"allow_buffer_reuse": False, "inplace_buffers": False},
             dynamic=False,
             decompositions={
                 aten.convolution_backward.default: convolution_backward_decomp_dwb,
@@ -315,7 +337,7 @@ def get_backend(
     elif scheme == "wbd":
         return DecompositionsWrapper(
             mode="default",
-            options={"allow_buffer_reuse": False},
+            options={"allow_buffer_reuse": False, "inplace_buffers": False},
             dynamic=False,
             decompositions={
                 aten.convolution_backward.default: convolution_backward_decomp_wbd,

--- a/apex/contrib/torchsched/config.py
+++ b/apex/contrib/torchsched/config.py
@@ -49,7 +49,7 @@ reuse_cuda_event: bool = os.getenv("TORCH_SCHED_REUSE_CUDA_EVENT", "1") == "1"
 
 @functools.lru_cache
 def __get_dump_code_backends_and_dir(dump_code: str | None) -> tuple[list[str], str | None]:
-    pattern = r"(?:\+(?P<backend>\w+),)?(?P<dir>[\w\/\.]+)"
+    pattern = r"(?:\+(?P<backend>\w+),)?(?P<dir>[\w\/\.\-\s@#~]+)"
     backends, dir = ["torchsched"], None
     if dump_code and (match := re.match(pattern, dump_code)):
         if backend := match.group("backend"):

--- a/apex/contrib/torchsched/config.py
+++ b/apex/contrib/torchsched/config.py
@@ -1,6 +1,8 @@
 """Configurations for graph scheduler."""
 
+import functools
 import os
+import re
 import sys
 
 # Debug info and dump grpahs
@@ -16,6 +18,56 @@ pre_grad_pass_options: list[str] = ["cudnn_layer_norm"]
 # The first stream will be critical path stream, operators on non-critical path will be
 # scheduled to other streams in a round-robin way.
 num_streams = int(os.getenv("TORCH_SCHED_NUM_STREAMS", "8"))
+
+
+def _get_skip_post_grad_graph_ids() -> set[int]:
+    if ids := os.environ.get("TORCH_SCHED_SKIP_GRAPH_IDS"):
+        result: set[int] = set()
+        for part in ids.split(","):
+            if "-" in part:
+                start, end = map(int, part.split("-"))
+                result.update(range(start, end + 1))
+            else:
+                result.add(int(part))
+        return result
+    else:
+        return set()
+
+
+# IDs of post AOT-autograd graphs that should be skipped for multi-stream scheduling. Can be
+# specified via TORCH_SCHED_SKIP_GRAPH_IDS environment variable in a SLURM-like scheme, e.g.,
+# TORCH_SCHED_SKIP_GRAPH_IDS=1,2,3-5,7-10
+skip_post_grad_graph_ids: set[int] = _get_skip_post_grad_graph_ids()
+
+# Reduce the number of allocated CUDA Events in the generated program by:
+# 1. Track reference count of each CUDA Event in the scheduling phase. Skip generating CUDA Events
+#    that have no reference counts, i.e., have not been waited by other streams;
+# 2. Reuse allocated CUDA Events when feasible.
+# This option is enable by default.
+reuse_cuda_event: bool = os.getenv("TORCH_SCHED_REUSE_CUDA_EVENT", "1") == "1"
+
+
+@functools.lru_cache
+def __get_dump_code_backends_and_dir(dump_code: str | None) -> tuple[list[str], str | None]:
+    pattern = r"(?:\+(?P<backend>\w+),)?(?P<dir>[\w\/\.]+)"
+    backends, dir = ["torchsched"], None
+    if dump_code and (match := re.match(pattern, dump_code)):
+        if backend := match.group("backend"):
+            backends.append(backend)
+        dir = os.path.abspath(match.group("dir"))
+    return backends, dir
+
+
+# Specify dump code backend types and output directory by::
+#
+#   TORCH_SCHED_DUMP_CODE='+inductor,/dir/to/save/code'
+#
+# Where `+inductor` enables dump both Inductor and torchsched code. If omitted, only dump
+# torchsched code. `/dir/to/save/code` specifies a directory to dump code to.
+(
+    dump_code_backends,
+    dump_code_dir,
+) = __get_dump_code_backends_and_dir(os.getenv("TORCH_SCHED_DUMP_CODE"))
 
 from torch.utils._config_module import install_config_module  # noqa: E402
 

--- a/apex/contrib/torchsched/inductor/_utils.py
+++ b/apex/contrib/torchsched/inductor/_utils.py
@@ -26,7 +26,7 @@ EVENT_NAME_TEMPLATE: str = "event{event_idx:d}"
 STREAM_NAME_TEMPLATE: str = "stream{stream_idx:d}"
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def get_stream_name(stream_idx: int) -> str:
     """Generate CUDA Stream name from stream index number.
 

--- a/apex/contrib/torchsched/inductor/event.py
+++ b/apex/contrib/torchsched/inductor/event.py
@@ -51,11 +51,9 @@ class CudaEventSym:
 
     def __lt__(self, rhs: CudaEventSym) -> bool:
         """Whether the current event is generated before the rhs event."""
-        return (
-            self.idx < rhs.idx
-            and self.originate_stream_idx == rhs.originate_stream_idx
-            and self.factory is rhs.factory
-        )
+        if self.factory is not rhs.factory:
+            return NotImplemented
+        return (self.idx, self.originate_stream_idx) < (rhs.idx, rhs.originate_stream_idx)
 
     def __eq__(self, rhs: object) -> bool:
         """Whether the current event is identical to the rhs event."""

--- a/apex/contrib/torchsched/inductor/graph.py
+++ b/apex/contrib/torchsched/inductor/graph.py
@@ -3,37 +3,99 @@
 from __future__ import annotations
 
 import functools
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+import torch
+from torch._inductor.codegen.common import get_scheduling_for_device
+from torch._inductor.codegen.common import get_wrapper_codegen_for_device
+from torch._inductor.codegen.common import register_backend_for_device
+from torch._inductor.codegen.wrapper import PythonWrapperCodegen
 from torch._inductor.graph import GraphLowering
 from torch._inductor.scheduler import Scheduler
 from torch._inductor.virtualized import V
 
 if TYPE_CHECKING:
-    from torch.fx.node import Node
+    from torch._inductor.utils import ValueWithLineMap
 
+from apex.contrib.torchsched import config as torchsched_config
 from apex.contrib.torchsched.inductor.scheduler import MultiCudaStreamScheduler
+from apex.contrib.torchsched.inductor.wrapper import MultiStreamWrapperCodegen
+
+_inductor_codegen = GraphLowering.codegen
+patching_device_type = "cuda"
+schedule_log = torch._logging.getArtifactLogger(__name__, "schedule")
 
 
 @functools.wraps(GraphLowering.codegen)
-def _codegen(graph: GraphLowering) -> tuple[str, list[tuple[int, Node]]]:
-    graph.init_wrapper_code()
-
-    if graph.device_type == "cuda":
-        graph.scheduler = MultiCudaStreamScheduler(graph.operations)
+def _torchsched_codegen(graph: GraphLowering) -> tuple[ValueWithLineMap, ValueWithLineMap]:
+    # Move patching logic here as post_grad_graph_id was not available until now.
+    cpp_wrapper_cls = get_wrapper_codegen_for_device(patching_device_type, cpp_wrapper=True)
+    only_cpu = len(graph.device_types - {"cpu", "meta"}) == 0
+    scheduling_cls = get_scheduling_for_device(patching_device_type)
+    wrapper_cls = get_wrapper_codegen_for_device(patching_device_type)
+    write_get_raw_stream = PythonWrapperCodegen.write_get_raw_stream
+    if not only_cpu and graph.post_grad_graph_id not in torchsched_config.skip_post_grad_graph_ids:
+        patched_scheduler_cls = MultiCudaStreamScheduler
+        patched_wrapper_cls = MultiStreamWrapperCodegen
+        # torch.compile explicitly calls `write_get_raw_stream` via wrapper's class method in its
+        # lowering process to walk around the wrapper-stream LRU cache mechanism. To be compatible
+        # with this, we got to patch wrapper's class method as well.
+        PythonWrapperCodegen.write_get_raw_stream = MultiStreamWrapperCodegen._write_get_raw_stream
     else:
-        graph.scheduler = Scheduler(graph.operations)
-    V.debug.draw_orig_fx_graph(graph.orig_gm, graph.scheduler.nodes)
+        patched_scheduler_cls = Scheduler
+        patched_wrapper_cls = PythonWrapperCodegen
+    register_backend_for_device(
+        device=patching_device_type,
+        device_scheduling=scheduling_cls,
+        device_wrapper_codegen=patched_wrapper_cls,
+        device_cpp_wrapper_codegen=cpp_wrapper_cls,
+    )
 
+    graph.init_wrapper_code()
+    graph.scheduler = patched_scheduler_cls(graph.operations)
+    V.debug.draw_orig_fx_graph(graph.orig_gm, graph.scheduler.nodes)
     graph.wrapper_code.push_codegened_graph(graph)
     graph.scheduler.codegen()
     result = graph.wrapper_code.generate(graph.is_inference)
     graph.wrapper_code.pop_codegened_graph()
 
+    PythonWrapperCodegen.write_get_raw_stream = write_get_raw_stream
+    register_backend_for_device(
+        device=patching_device_type,
+        device_scheduling=scheduling_cls,
+        device_wrapper_codegen=wrapper_cls,
+        device_cpp_wrapper_codegen=cpp_wrapper_cls,
+    )
+
     return result
 
 
-_origin_codegen = GraphLowering.codegen
+@functools.wraps(GraphLowering.codegen)
+def _mixed_codegen(graph: GraphLowering) -> tuple[ValueWithLineMap, ValueWithLineMap]:
+    assert torchsched_config.dump_code_dir
+    output_code_per_backend: dict[str, tuple[ValueWithLineMap, ValueWithLineMap]] = {}
+
+    for backend in torchsched_config.dump_code_backends:
+        if backend == "torchsched":
+            codegen = _torchsched_codegen
+        elif backend == "inductor":
+            codegen = _inductor_codegen
+        else:
+            raise ValueError(f"Unknown {backend=} from {torchsched_config.dump_code_backends=}")
+        wrapper_code, kernel_code = codegen(graph)
+        output_code_per_backend[backend] = (wrapper_code, kernel_code)
+
+    for backend, (wrapper_code, kernel_code) in output_code_per_backend.items():
+        backend_dir = Path(torchsched_config.dump_code_dir) / backend
+        backend_dir.mkdir(parents=True, exist_ok=True)
+        graph_id = graph.post_grad_graph_id
+        (backend_dir / f"graph_{graph_id}_wrapper_code.py").write_text(wrapper_code.value)
+        if kernel_code.value.strip():
+            # Kernel_code is only available in AOTInductor mode.
+            (backend_dir / f"graph_{graph_id}_kernel_code.py").write_text(kernel_code.value)
+
+    return output_code_per_backend["torchsched"]
 
 
 def patch_graph_lowering(patch: bool = True) -> None:
@@ -53,7 +115,9 @@ def patch_graph_lowering(patch: bool = True) -> None:
             scheduler. Set to `False` to restore the default `torch.compile`
             behavior. (default: `True`)
     """
-    if patch:
-        GraphLowering.codegen = _codegen
+    if patch and torchsched_config.dump_code_dir:
+        GraphLowering.codegen = _mixed_codegen
+    elif patch:
+        GraphLowering.codegen = _torchsched_codegen
     else:
-        GraphLowering.codegen = _origin_codegen
+        GraphLowering.codegen = _inductor_codegen

--- a/apex/contrib/torchsched/ops/layer_norm.py
+++ b/apex/contrib/torchsched/ops/layer_norm.py
@@ -8,7 +8,6 @@ Please refer to:
 from __future__ import annotations
 
 import math
-from typing import Sequence
 
 import cudnn
 import torch
@@ -269,7 +268,7 @@ class LayerNormGraphFactory:
 @torch.library.custom_op("cudnn::layer_norm", mutates_args=(), device_types="cuda")
 def layer_norm(
     x: torch.Tensor,
-    normalized_shape: Sequence[int],
+    normalized_shape: list[int],
     weight: torch.Tensor,
     bias: torch.Tensor,
     eps: float = 1e-05,
@@ -336,7 +335,7 @@ def layer_norm(
 @layer_norm.register_fake
 def layer_norm_fake(
     x: torch.Tensor,
-    normalized_shape: Sequence[int],
+    normalized_shape: list[int],
     weight: torch.Tensor,
     bias: torch.Tensor,
     eps: float = 1e-05,
@@ -359,7 +358,7 @@ def layer_norm_backward(
     x_mean: torch.Tensor,
     x_invstd: torch.Tensor,
     x: torch.Tensor,
-    normalized_shape: Sequence[int],
+    normalized_shape: list[int],
     weight: torch.Tensor,
     bias: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -414,7 +413,7 @@ def layer_norm_backward_fake(
     x_mean: torch.Tensor,
     x_invstd: torch.Tensor,
     x: torch.Tensor,
-    normalized_shape: Sequence[int],
+    normalized_shape: list[int],
     weight: torch.Tensor,
     bias: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:

--- a/apex/contrib/torchsched/passes/pre_grad_passes.py
+++ b/apex/contrib/torchsched/passes/pre_grad_passes.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import logging
-from typing import Callable
-from typing import Sequence
+from typing import TYPE_CHECKING
 
 import torch
 from torch._dynamo.utils import counters
 from torch.fx import replace_pattern
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from collections.abc import Sequence
 
 from apex.contrib.torchsched import config
 
@@ -95,7 +98,6 @@ def pre_grad_custom_pass(graph: torch.fx.Graph) -> None:
     Args:
         graph (torch.fx.Graph): The FX graph to be optimized.
     """
-    global PRE_GRAD_PASS_PATTERNS
     passes = config.pre_grad_pass_options
     for pass_name in passes:
         assert pass_name in PRE_GRAD_PASS_PATTERNS, f"Unknown pre_grad pass: {pass_name}"


### PR DESCRIPTION
## Why?
- Currently the `contrib.torchsched` module sometimes generate incomplete cross-stream dependencies, causing multi-stream execution yield incorrect results on certain cases

## What?
- Refactored cross-stream dependency handling logic in `contrib.torchsched` submodule
- Add debug knobs that can skip certain subgraph(s) and dump generated code