### PR TITLE
Exclude apex.transformer if distributed is not available

### DIFF
--- a/apex/__init__.py
+++ b/apex/__init__.py
@@ -13,27 +13,27 @@ import torch
 # load time) the error message is timely and visible.
 from . import optimizers
 from . import normalization
-from . import transformer
 
+if torch.distributed.is_available():
+    from . import transformer
+    __all__ = ["optimizers", "normalization", "transformer"]
 
-__all__ = ["optimizers", "normalization", "transformer"]
+    # Logging utilities for apex.transformer module
+    class RankInfoFormatter(logging.Formatter):
 
+        def format(self, record):
+            from apex.transformer.parallel_state import get_rank_info
+            record.rank_info = get_rank_info()
+            return super().format(record)
 
-# Logging utilities for apex.transformer module
-class RankInfoFormatter(logging.Formatter):
-
-    def format(self, record):
-        from apex.transformer.parallel_state import get_rank_info
-        record.rank_info = get_rank_info()
-        return super().format(record)
-
-
-_library_root_logger = logging.getLogger(__name__)
-handler = logging.StreamHandler()
-handler.setFormatter(RankInfoFormatter("%(asctime)s - PID:%(process)d - rank:%(rank_info)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s", "%y-%m-%d %H:%M:%S"))
-_library_root_logger.addHandler(handler)
-_library_root_logger.propagate = False
-
+    _library_root_logger = logging.getLogger(__name__)
+    handler = logging.StreamHandler()
+    handler.setFormatter(RankInfoFormatter("%(asctime)s - PID:%(process)d - rank:%(rank_info)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s", "%y-%m-%d %H:%M:%S"))
+    _library_root_logger.addHandler(handler)
+    _library_root_logger.propagate = False
+else:
+    # Transformers require PyTorch built with distributed support
+    __all__ = ["optimizers", "normalization"]
 
 def check_cudnn_version_and_warn(global_option: str, required_cudnn_version: int) -> bool:
     cudnn_available = torch.backends.cudnn.is_available()


### PR DESCRIPTION
We need to gate against `torch.distributed.is_available()` check because otherwise it will fail on import:

```
$ python -c "import apex"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.12/dist-packages/apex/__init__.py", line 16, in <module>
    from . import transformer
  File "/usr/local/lib/python3.12/dist-packages/apex/transformer/__init__.py", line 4, in <module>
    from apex.transformer import pipeline_parallel
  File "/usr/local/lib/python3.12/dist-packages/apex/transformer/pipeline_parallel/__init__.py", line 1, in <module>
    from apex.transformer.pipeline_parallel.schedules import get_forward_backward_func
  File "/usr/local/lib/python3.12/dist-packages/apex/transformer/pipeline_parallel/schedules/__init__.py", line 3, in <module>
    from apex.transformer.pipeline_parallel.schedules.fwd_bwd_no_pipelining import (
  File "/usr/local/lib/python3.12/dist-packages/apex/transformer/pipeline_parallel/schedules/fwd_bwd_no_pipelining.py", line 10, in <module>
    from apex.transformer.pipeline_parallel.schedules.common import Batch
  File "/usr/local/lib/python3.12/dist-packages/apex/transformer/pipeline_parallel/schedules/common.py", line 9, in <module>
    from apex.transformer.pipeline_parallel.p2p_communication import FutureTensor
  File "/usr/local/lib/python3.12/dist-packages/apex/transformer/pipeline_parallel/p2p_communication.py", line 25, in <module>
    from apex.transformer.utils import split_tensor_into_1d_equal_chunks
  File "/usr/local/lib/python3.12/dist-packages/apex/transformer/utils.py", line 11, in <module>
    torch.distributed.all_gather_into_tensor = torch.distributed._all_gather_base
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'torch.distributed' has no attribute '_all_gather_base'
```

cc @crcrpar 