### PR TITLE
Finish cleaning up usage of VERSION_GE_1_1/1_3/1_5 macros

### DIFF
--- a/csrc/layer_norm_cuda.cpp
+++ b/csrc/layer_norm_cuda.cpp
@@ -6,11 +6,7 @@
 namespace {
 void compute_n1_n2(
     at::Tensor input,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     int& n1,
     int& n2)
 {
@@ -27,11 +23,7 @@ void compute_n1_n2(
 }
 
 void check_args(
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor gamma,
     at::Tensor beta
     )
@@ -41,11 +33,7 @@ void check_args(
 }
 
 void check_args(
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor gamma
     )
 {
@@ -55,11 +43,7 @@ void check_args(
 
 void check_args(
     at::Tensor input,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     int& n1,
     int& n2
     )
@@ -94,11 +78,7 @@ void check_args(
 
 void check_args(
     at::Tensor input,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor gamma,
     at::Tensor beta,
     int& n1,
@@ -111,11 +91,7 @@ void check_args(
 
 void check_args(
     at::Tensor input,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor gamma,
     int& n1,
     int& n2
@@ -133,11 +109,7 @@ void cuda_layer_norm(
     at::Tensor* input,
     int n1,
     int n2,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor* gamma,
     at::Tensor* beta,
     double epsilon);
@@ -148,11 +120,7 @@ void cuda_layer_norm(
 
 std::vector<at::Tensor> layer_norm(
     at::Tensor input,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     double epsilon) {
   CHECK_INPUT(input);
   int n1,n2;
@@ -167,11 +135,7 @@ std::vector<at::Tensor> layer_norm(
 
 std::vector<at::Tensor> layer_norm_affine(
     at::Tensor input,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor gamma,
     at::Tensor beta,
     double epsilon) {
@@ -191,11 +155,7 @@ std::vector<at::Tensor> layer_norm_affine(
 
 std::vector<at::Tensor> layer_norm_affine_mixed_dtypes(
     at::Tensor input,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor gamma,
     at::Tensor beta,
     double epsilon) {
@@ -217,11 +177,7 @@ void cuda_layer_norm_gradient(
     at::Tensor* input_or_output,
     int n1,
     int n2,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor* gamma,
     at::Tensor* beta,
     double epsilon,
@@ -236,11 +192,7 @@ at::Tensor layer_norm_gradient(
     c10::optional<at::Tensor> mean_,
     at::Tensor invvar,
     at::Tensor input_or_output,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     double epsilon,
     bool memory_efficient) {
   CHECK_INPUT(dout);
@@ -266,11 +218,7 @@ std::vector<at::Tensor> layer_norm_gradient_affine(
     c10::optional<at::Tensor> mean_,
     at::Tensor invvar,
     at::Tensor input_or_output,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor gamma,
     at::Tensor beta,
     double epsilon,
@@ -304,11 +252,7 @@ void cuda_rms_norm(
     at::Tensor* input,
     int n1,
     int n2,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor* gamma,
     double epsilon);
 
@@ -318,11 +262,7 @@ void cuda_rms_norm(
 
 std::vector<at::Tensor> rms_norm(
     at::Tensor input,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     double epsilon) {
   CHECK_INPUT(input);
   int n1,n2;
@@ -336,11 +276,7 @@ std::vector<at::Tensor> rms_norm(
 
 std::vector<at::Tensor> rms_norm_affine(
     at::Tensor input,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor gamma,
     double epsilon) {
   CHECK_INPUT(input);
@@ -357,11 +293,7 @@ std::vector<at::Tensor> rms_norm_affine(
 
 std::vector<at::Tensor> rms_norm_affine_mixed_dtypes(
     at::Tensor input,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor gamma,
     double epsilon) {
   CHECK_INPUT(input);
@@ -381,11 +313,7 @@ void cuda_rms_norm_gradient(
     at::Tensor* input_or_output,
     int n1,
     int n2,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor* gamma,
     double epsilon,
     at::Tensor* grad_input,
@@ -396,11 +324,7 @@ at::Tensor rms_norm_gradient(
     at::Tensor dout,
     at::Tensor invvar,
     at::Tensor input_or_output,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     double epsilon,
     bool memory_efficient) {
   CHECK_INPUT(dout);
@@ -419,11 +343,7 @@ std::vector<at::Tensor> rms_norm_gradient_affine(
     at::Tensor dout,
     at::Tensor invvar,
     at::Tensor input_or_output,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor gamma,
     double epsilon,
     bool memory_efficient) {

--- a/csrc/layer_norm_cuda_kernel.cu
+++ b/csrc/layer_norm_cuda_kernel.cu
@@ -975,11 +975,7 @@ void cuda_layer_norm(
     at::Tensor* input,
     int n1,
     int n2,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor* gamma,
     at::Tensor* beta,
     double epsilon)
@@ -1006,11 +1002,7 @@ void cuda_rms_norm(
     at::Tensor* input,
     int n1,
     int n2,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor* gamma,
     double epsilon)
 {
@@ -1211,11 +1203,7 @@ void cuda_layer_norm_gradient(
     at::Tensor* input_or_output,
     int n1,
     int n2,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor* gamma,
     at::Tensor* beta,
     double epsilon,
@@ -1253,11 +1241,7 @@ void cuda_rms_norm_gradient(
     at::Tensor* input_or_output,
     int n1,
     int n2,
-    #ifdef VERSION_GE_1_1
     at::IntArrayRef normalized_shape,
-    #else
-    at::IntList normalized_shape,
-    #endif
     at::Tensor* gamma,
     double epsilon,
     at::Tensor* grad_input,

--- a/csrc/multi_tensor_apply.cuh
+++ b/csrc/multi_tensor_apply.cuh
@@ -59,9 +59,7 @@ void multi_tensor_apply(
     {
       // TODO:  Print which tensor fails.
       bool contiguous_memory = tensor_lists[l][t].is_contiguous();
-#ifdef VERSION_GE_1_5
       contiguous_memory = (contiguous_memory || tensor_lists[l][t].is_contiguous(at::MemoryFormat::ChannelsLast) || tensor_lists[l][t].is_contiguous(at::MemoryFormat::ChannelsLast3d));
-#endif
       TORCH_CHECK(contiguous_memory, "A tensor was not contiguous.");
       TORCH_CHECK(tensor_lists[l][t].device() == ref_device, "A tensor was not on the same device as the first tensor");
       TORCH_CHECK(tensor_lists[l][t].numel() == tensor_lists[0][t].numel(), "Size mismatch");


### PR DESCRIPTION
When @crcrpar  deletes the code related to VERSION_GE_1_1/3/5 in setup.py #1918 , some definitions and usages related to VERSION_GE_1_1/3/5 remain undeleted in the following files, as listed:
- csrc/layer_norm_cuda.cpp
- csrc/layer_norm_cuda_kernel.cu
- csrc/multi_tensor_apply.cuh

When I installed Apex on October 26, 2025, the following exception occurred:
```
/home/sourceroc/Downloads/apex/csrc/layer_norm_cuda.cpp:15:12: warning: ‘using IntList = class c10::ArrayRef<long int>’ is deprecated: This alias is deprecated because it doesn't make ownership semantics obvious. Use IntArrayRef instead! [-Wdeprecated-declarations]
```
So I submitted this merge.