### PR TITLE
Add LibTorch Stable ABI infrastructure (#1946)

### DIFF
--- a/csrc/stable_abi_utils.h
+++ b/csrc/stable_abi_utils.h
@@ -3,11 +3,11 @@
 #ifdef TORCH_STABLE_ONLY
 
 // Stable ABI headers
-#include <torch/csrc/stable/tensor.h>
-#include <torch/csrc/stable/library.h>
-#include <torch/csrc/stable/ivalue.h>
 #include <torch/csrc/stable/accelerator.h>
 #include <torch/csrc/stable/dispatcher.h>
+#include <torch/csrc/stable/ivalue.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/tensor.h>
 #include <torch/headeronly/types.h>
 
 namespace apex {
@@ -19,12 +19,7 @@ namespace stable {
 // The stable ABI's Tensor::is_contiguous() doesn't support MemoryFormat
 // parameter. This provides a workaround for checking different memory layouts.
 
-enum class MemoryFormat {
-  Contiguous,
-  ChannelsLast,
-  ChannelsLast3d,
-  Preserve
-};
+enum class MemoryFormat { Contiguous, ChannelsLast, ChannelsLast3d, Preserve };
 
 // Check if a tensor is contiguous in a specific memory format
 inline bool is_contiguous(const torch::stable::Tensor& tensor, MemoryFormat format) {
@@ -54,10 +49,7 @@ inline bool is_contiguous(const torch::stable::Tensor& tensor, MemoryFormat form
     int64_t stride_n = strides[0];
 
     // Check if strides match NHWC layout
-    return (stride_c == 1) &&
-           (stride_w == C) &&
-           (stride_h == W * C) &&
-           (stride_n == H * W * C);
+    return (stride_c == 1) && (stride_w == C) && (stride_h == W * C) && (stride_n == H * W * C);
   }
 
   if (format == MemoryFormat::ChannelsLast3d) {
@@ -73,10 +65,7 @@ inline bool is_contiguous(const torch::stable::Tensor& tensor, MemoryFormat form
     int64_t stride_n = strides[0];
 
     // Check if strides match NDHWC layout
-    return (stride_c == 1) &&
-           (stride_w == C) &&
-           (stride_h == W * C) &&
-           (stride_d == H * W * C) &&
+    return (stride_c == 1) && (stride_w == C) && (stride_h == W * C) && (stride_d == H * W * C) &&
            (stride_n == D * H * W * C);
   }
 
@@ -96,19 +85,32 @@ inline bool is_contiguous(const torch::stable::Tensor& tensor, MemoryFormat form
 inline const char* scalar_type_name(torch::headeronly::ScalarType type) {
   using namespace torch::headeronly;
   switch (type) {
-    case kByte: return "Byte";
-    case kChar: return "Char";
-    case kShort: return "Short";
-    case kInt: return "Int";
-    case kLong: return "Long";
-    case kHalf: return "Half";
-    case kFloat: return "Float";
-    case kDouble: return "Double";
-    case kBool: return "Bool";
-    case kBFloat16: return "BFloat16";
-    case kFloat8_e5m2: return "Float8_e5m2";
-    case kFloat8_e4m3fn: return "Float8_e4m3fn";
-    default: return "Unknown";
+    case kByte:
+      return "Byte";
+    case kChar:
+      return "Char";
+    case kShort:
+      return "Short";
+    case kInt:
+      return "Int";
+    case kLong:
+      return "Long";
+    case kHalf:
+      return "Half";
+    case kFloat:
+      return "Float";
+    case kDouble:
+      return "Double";
+    case kBool:
+      return "Bool";
+    case kBFloat16:
+      return "BFloat16";
+    case kFloat8_e5m2:
+      return "Float8_e5m2";
+    case kFloat8_e4m3fn:
+      return "Float8_e4m3fn";
+    default:
+      return "Unknown";
   }
 }
 
@@ -116,13 +118,13 @@ inline const char* scalar_type_name(torch::headeronly::ScalarType type) {
 // Error Checking Macros
 // ============================================================================
 
-#define STD_TORCH_CHECK(cond, ...) \
-  do { \
-    if (!(cond)) { \
-      char buffer[1024]; \
+#define STD_TORCH_CHECK(cond, ...)                   \
+  do {                                               \
+    if (!(cond)) {                                   \
+      char buffer[1024];                             \
       snprintf(buffer, sizeof(buffer), __VA_ARGS__); \
-      throw std::runtime_error(buffer); \
-    } \
+      throw std::runtime_error(buffer);              \
+    }                                                \
   } while (0)
 
 #define STD_TORCH_CHECK_EQ(a, b, ...) STD_TORCH_CHECK((a) == (b), __VA_ARGS__)
@@ -142,23 +144,16 @@ inline torch::stable::Tensor tensor_from_stack(torch::stable::StableIValue* stac
 }
 
 // Helper to extract int64 from IValue stack
-inline int64_t int64_from_stack(torch::stable::StableIValue* stack, int idx) {
-  return stack[idx].toInt();
-}
+inline int64_t int64_from_stack(torch::stable::StableIValue* stack, int idx) { return stack[idx].toInt(); }
 
 // Helper to extract double from IValue stack
-inline double double_from_stack(torch::stable::StableIValue* stack, int idx) {
-  return stack[idx].toDouble();
-}
+inline double double_from_stack(torch::stable::StableIValue* stack, int idx) { return stack[idx].toDouble(); }
 
 // Helper to extract bool from IValue stack
-inline bool bool_from_stack(torch::stable::StableIValue* stack, int idx) {
-  return stack[idx].toBool();
-}
+inline bool bool_from_stack(torch::stable::StableIValue* stack, int idx) { return stack[idx].toBool(); }
 
 // Helper to extract optional tensor from IValue stack
-inline std::optional<torch::stable::Tensor> optional_tensor_from_stack(
-    torch::stable::StableIValue* stack, int idx) {
+inline std::optional<torch::stable::Tensor> optional_tensor_from_stack(torch::stable::StableIValue* stack, int idx) {
   if (stack[idx].isNone()) {
     return std::nullopt;
   }
@@ -166,8 +161,7 @@ inline std::optional<torch::stable::Tensor> optional_tensor_from_stack(
 }
 
 // Helper to extract tensor list from IValue stack
-inline std::vector<torch::stable::Tensor> tensor_list_from_stack(
-    torch::stable::StableIValue* stack, int idx) {
+inline std::vector<torch::stable::Tensor> tensor_list_from_stack(torch::stable::StableIValue* stack, int idx) {
   auto list = stack[idx].toList();
   std::vector<torch::stable::Tensor> result;
   result.reserve(list.size());
@@ -178,8 +172,7 @@ inline std::vector<torch::stable::Tensor> tensor_list_from_stack(
 }
 
 // Helper to put tensor to IValue stack
-inline void tensor_to_stack(torch::stable::StableIValue* stack, int idx,
-                            const torch::stable::Tensor& tensor) {
+inline void tensor_to_stack(torch::stable::StableIValue* stack, int idx, const torch::stable::Tensor& tensor) {
   stack[idx] = torch::stable::StableIValue::from(tensor);
 }
 
@@ -196,7 +189,7 @@ inline void tuple_to_stack(torch::stable::StableIValue* stack, int idx,
 
 // Helper to put list to IValue stack
 inline void tensor_list_to_stack(torch::stable::StableIValue* stack, int idx,
-                                  const std::vector<torch::stable::Tensor>& tensors) {
+                                 const std::vector<torch::stable::Tensor>& tensors) {
   std::vector<torch::stable::StableIValue> ivalues;
   ivalues.reserve(tensors.size());
   for (const auto& t : tensors) {
@@ -210,9 +203,7 @@ inline void tensor_list_to_stack(torch::stable::StableIValue* stack, int idx,
 // ============================================================================
 
 // Check if tensor is on CUDA
-inline bool is_cuda(const torch::stable::Tensor& tensor) {
-  return tensor.device().type() == torch::headeronly::kCUDA;
-}
+inline bool is_cuda(const torch::stable::Tensor& tensor) { return tensor.device().type() == torch::headeronly::kCUDA; }
 
 // Get CUDA device index
 inline int64_t get_device_index(const torch::stable::Tensor& tensor) {
@@ -232,31 +223,25 @@ inline void check_contiguous(const torch::stable::Tensor& tensor, const char* na
   STD_TORCH_CHECK(tensor.is_contiguous(), "%s must be contiguous", name);
 }
 
-inline void check_same_device(const torch::stable::Tensor& t1,
-                               const torch::stable::Tensor& t2,
-                               const char* name1, const char* name2) {
-  STD_TORCH_CHECK(t1.device() == t2.device(),
-                  "%s and %s must be on the same device", name1, name2);
+inline void check_same_device(const torch::stable::Tensor& t1, const torch::stable::Tensor& t2, const char* name1,
+                              const char* name2) {
+  STD_TORCH_CHECK(t1.device() == t2.device(), "%s and %s must be on the same device", name1, name2);
 }
 
-inline void check_same_dtype(const torch::stable::Tensor& t1,
-                              const torch::stable::Tensor& t2,
-                              const char* name1, const char* name2) {
-  STD_TORCH_CHECK(t1.scalar_type() == t2.scalar_type(),
-                  "%s and %s must have the same dtype, got %s and %s",
-                  name1, name2,
-                  scalar_type_name(t1.scalar_type()),
-                  scalar_type_name(t2.scalar_type()));
+inline void check_same_dtype(const torch::stable::Tensor& t1, const torch::stable::Tensor& t2, const char* name1,
+                             const char* name2) {
+  STD_TORCH_CHECK(t1.scalar_type() == t2.scalar_type(), "%s and %s must have the same dtype, got %s and %s", name1,
+                  name2, scalar_type_name(t1.scalar_type()), scalar_type_name(t2.scalar_type()));
 }
 
-} // namespace stable
-} // namespace apex
+}  // namespace stable
+}  // namespace apex
 
-#else // !TORCH_STABLE_ONLY
+#else  // !TORCH_STABLE_ONLY
 
 // When not using stable ABI, provide no-op definitions or traditional includes
-#include <torch/extension.h>
 #include <ATen/ATen.h>
+#include <torch/extension.h>
 
 namespace apex {
 namespace stable {
@@ -265,11 +250,9 @@ namespace stable {
 using MemoryFormat = at::MemoryFormat;
 
 // Use traditional is_contiguous in non-stable builds
-inline bool is_contiguous(const at::Tensor& tensor, at::MemoryFormat format) {
-  return tensor.is_contiguous(format);
-}
+inline bool is_contiguous(const at::Tensor& tensor, at::MemoryFormat format) { return tensor.is_contiguous(format); }
 
-} // namespace stable
-} // namespace apex
+}  // namespace stable
+}  // namespace apex
 
-#endif // TORCH_STABLE_ONLY
+#endif  // TORCH_STABLE_ONLY

--- a/csrc/type_shim.h
+++ b/csrc/type_shim.h
@@ -1,6 +1,7 @@
 #ifdef TORCH_STABLE_ONLY
 #include <torch/csrc/stable/tensor.h>
 #include <torch/headeronly/types.h>
+
 #include "stable_abi_utils.h"
 
 // Error macro for stable ABI
@@ -8,16 +9,14 @@
 
 // Namespace and type aliases for stable ABI
 namespace apex_internal {
-  using ScalarType = torch::headeronly::ScalarType;
-  using Half = torch::headeronly::Half;
-  using BFloat16 = torch::headeronly::BFloat16;
+using ScalarType = torch::headeronly::ScalarType;
+using Half = torch::headeronly::Half;
+using BFloat16 = torch::headeronly::BFloat16;
 
-  inline std::string toString(ScalarType type) {
-    return std::string(apex::stable::scalar_type_name(type));
-  }
-}
+inline std::string toString(ScalarType type) { return std::string(apex::stable::scalar_type_name(type)); }
+}  // namespace apex_internal
 
-#else // !TORCH_STABLE_ONLY
+#else  // !TORCH_STABLE_ONLY
 
 #include <ATen/ATen.h>
 
@@ -26,16 +25,14 @@ namespace apex_internal {
 
 // Namespace and type aliases for traditional API
 namespace apex_internal {
-  using ScalarType = at::ScalarType;
-  using Half = at::Half;
-  using BFloat16 = at::BFloat16;
+using ScalarType = at::ScalarType;
+using Half = at::Half;
+using BFloat16 = at::BFloat16;
 
-  inline std::string toString(at::ScalarType type) {
-    return std::string(c10::toString(type));
-  }
-}
+inline std::string toString(at::ScalarType type) { return std::string(c10::toString(type)); }
+}  // namespace apex_internal
 
-#endif // TORCH_STABLE_ONLY
+#endif  // TORCH_STABLE_ONLY
 
 // Forward/backward compatiblity hack around
 // https://github.com/pytorch/pytorch/commit/3aeb78079bcd68282fe9117088e138b77318e288
@@ -50,251 +47,251 @@ namespace apex_internal {
 //   //operator at::ScalarType(){ return payload.; };
 // };
 
-#define DISPATCH_FLOAT_AND_HALF(TYPE, LEVEL, NAME, ...)               \
-  switch (TYPE) {                                                     \
-    case apex_internal::ScalarType::Float: {                          \
-      using scalar_t_##LEVEL = float;                                 \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    case apex_internal::ScalarType::Half: {                           \
-      using scalar_t_##LEVEL = apex_internal::Half;                   \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    default:                                                          \
+#define DISPATCH_FLOAT_AND_HALF(TYPE, LEVEL, NAME, ...)                                \
+  switch (TYPE) {                                                                      \
+    case apex_internal::ScalarType::Float: {                                           \
+      using scalar_t_##LEVEL = float;                                                  \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    case apex_internal::ScalarType::Half: {                                            \
+      using scalar_t_##LEVEL = apex_internal::Half;                                    \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    default:                                                                           \
       APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPE), "'"); \
   }
 
-#define DISPATCH_FLOAT_HALF_AND_BFLOAT(TYPE, LEVEL, NAME, ...)        \
-  switch (TYPE) {                                                     \
-    case apex_internal::ScalarType::Float: {                          \
-      using scalar_t_##LEVEL = float;                                 \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    case apex_internal::ScalarType::Half: {                           \
-      using scalar_t_##LEVEL = apex_internal::Half;                   \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    case apex_internal::ScalarType::BFloat16: {                       \
-      using scalar_t_##LEVEL = apex_internal::BFloat16;               \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    default:                                                          \
+#define DISPATCH_FLOAT_HALF_AND_BFLOAT(TYPE, LEVEL, NAME, ...)                         \
+  switch (TYPE) {                                                                      \
+    case apex_internal::ScalarType::Float: {                                           \
+      using scalar_t_##LEVEL = float;                                                  \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    case apex_internal::ScalarType::Half: {                                            \
+      using scalar_t_##LEVEL = apex_internal::Half;                                    \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    case apex_internal::ScalarType::BFloat16: {                                        \
+      using scalar_t_##LEVEL = apex_internal::BFloat16;                                \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    default:                                                                           \
       APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPE), "'"); \
   }
 
-#define DISPATCH_FLOAT_HALF_AND_BYTE(TYPE, LEVEL, NAME, ...)          \
-  switch (TYPE) {                                                     \
-    case apex_internal::ScalarType::Float: {                          \
-      using scalar_t_##LEVEL = float;                                 \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    case apex_internal::ScalarType::Half: {                           \
-      using scalar_t_##LEVEL = apex_internal::Half;                   \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    case apex_internal::ScalarType::Byte: {                           \
-      using scalar_t_##LEVEL = uint8_t;                               \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    default:                                                          \
+#define DISPATCH_FLOAT_HALF_AND_BYTE(TYPE, LEVEL, NAME, ...)                           \
+  switch (TYPE) {                                                                      \
+    case apex_internal::ScalarType::Float: {                                           \
+      using scalar_t_##LEVEL = float;                                                  \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    case apex_internal::ScalarType::Half: {                                            \
+      using scalar_t_##LEVEL = apex_internal::Half;                                    \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    case apex_internal::ScalarType::Byte: {                                            \
+      using scalar_t_##LEVEL = uint8_t;                                                \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    default:                                                                           \
       APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPE), "'"); \
   }
 
-#define DISPATCH_DOUBLE_FLOAT_AND_HALF(TYPE, LEVEL, NAME, ...)        \
-  switch (TYPE) {                                                     \
-    case apex_internal::ScalarType::Double: {                         \
-      using scalar_t_##LEVEL = double;                                \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    case apex_internal::ScalarType::Float: {                          \
-      using scalar_t_##LEVEL = float;                                 \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    case apex_internal::ScalarType::Half: {                           \
-      using scalar_t_##LEVEL = apex_internal::Half;                   \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    default:                                                          \
+#define DISPATCH_DOUBLE_FLOAT_AND_HALF(TYPE, LEVEL, NAME, ...)                         \
+  switch (TYPE) {                                                                      \
+    case apex_internal::ScalarType::Double: {                                          \
+      using scalar_t_##LEVEL = double;                                                 \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    case apex_internal::ScalarType::Float: {                                           \
+      using scalar_t_##LEVEL = float;                                                  \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    case apex_internal::ScalarType::Half: {                                            \
+      using scalar_t_##LEVEL = apex_internal::Half;                                    \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    default:                                                                           \
       APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPE), "'"); \
   }
 
-#define DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT(TYPE, LEVEL, NAME, ...) \
-  switch (TYPE) {                                                     \
-    case apex_internal::ScalarType::Double: {                         \
-      using scalar_t_##LEVEL = double;                                \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    case apex_internal::ScalarType::Float: {                          \
-      using scalar_t_##LEVEL = float;                                 \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    case apex_internal::ScalarType::Half: {                           \
-      using scalar_t_##LEVEL = apex_internal::Half;                   \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    case apex_internal::ScalarType::BFloat16: {                       \
-      using scalar_t_##LEVEL = apex_internal::BFloat16;               \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    default:                                                          \
+#define DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT(TYPE, LEVEL, NAME, ...)                  \
+  switch (TYPE) {                                                                      \
+    case apex_internal::ScalarType::Double: {                                          \
+      using scalar_t_##LEVEL = double;                                                 \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    case apex_internal::ScalarType::Float: {                                           \
+      using scalar_t_##LEVEL = float;                                                  \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    case apex_internal::ScalarType::Half: {                                            \
+      using scalar_t_##LEVEL = apex_internal::Half;                                    \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    case apex_internal::ScalarType::BFloat16: {                                        \
+      using scalar_t_##LEVEL = apex_internal::BFloat16;                                \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    default:                                                                           \
       APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPE), "'"); \
   }
 
-#define DISPATCH_DOUBLE_AND_FLOAT(TYPE, LEVEL, NAME, ...)             \
-  switch (TYPE) {                                                     \
-    case apex_internal::ScalarType::Double: {                         \
-      using scalar_t_##LEVEL = double;                                \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    case apex_internal::ScalarType::Float: {                          \
-      using scalar_t_##LEVEL = float;                                 \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    default:                                                          \
+#define DISPATCH_DOUBLE_AND_FLOAT(TYPE, LEVEL, NAME, ...)                              \
+  switch (TYPE) {                                                                      \
+    case apex_internal::ScalarType::Double: {                                          \
+      using scalar_t_##LEVEL = double;                                                 \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    case apex_internal::ScalarType::Float: {                                           \
+      using scalar_t_##LEVEL = float;                                                  \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    default:                                                                           \
       APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPE), "'"); \
   }
 
-#define DISPATCH_HALF_AND_BFLOAT(TYPE, NAME, ...)                     \
-  switch (TYPE) {                                                     \
-    case apex_internal::ScalarType::Half: {                           \
-      using scalar_t = apex_internal::Half;                           \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    case apex_internal::ScalarType::BFloat16: {                       \
-      using scalar_t = apex_internal::BFloat16;                       \
-      __VA_ARGS__;                                                    \
-      break;                                                          \
-    }                                                                 \
-    default:                                                          \
+#define DISPATCH_HALF_AND_BFLOAT(TYPE, NAME, ...)                                      \
+  switch (TYPE) {                                                                      \
+    case apex_internal::ScalarType::Half: {                                            \
+      using scalar_t = apex_internal::Half;                                            \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    case apex_internal::ScalarType::BFloat16: {                                        \
+      using scalar_t = apex_internal::BFloat16;                                        \
+      __VA_ARGS__;                                                                     \
+      break;                                                                           \
+    }                                                                                  \
+    default:                                                                           \
       APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPE), "'"); \
   }
 
-#define DISPATCH_FLOAT_HALF_AND_BFLOAT_INOUT_TYPES(TYPEIN, TYPEOUT, NAME, ...) \
-  switch (TYPEIN) {                                                            \
-    case apex_internal::ScalarType::Float: {                                   \
-      using scalar_t_in = float;                                               \
-      switch (TYPEOUT) {                                                       \
-        case apex_internal::ScalarType::Float: {                               \
-          using scalar_t_out = float;                                          \
-          __VA_ARGS__;                                                         \
-          break;                                                               \
-        }                                                                      \
-        case apex_internal::ScalarType::Half: {                                \
-          using scalar_t_out = apex_internal::Half;                            \
-          __VA_ARGS__;                                                         \
-          break;                                                               \
-        }                                                                      \
-        case apex_internal::ScalarType::BFloat16: {                            \
-          using scalar_t_out = apex_internal::BFloat16;                        \
-          __VA_ARGS__;                                                         \
-          break;                                                               \
-        }                                                                      \
-        default:                                                               \
+#define DISPATCH_FLOAT_HALF_AND_BFLOAT_INOUT_TYPES(TYPEIN, TYPEOUT, NAME, ...)                \
+  switch (TYPEIN) {                                                                           \
+    case apex_internal::ScalarType::Float: {                                                  \
+      using scalar_t_in = float;                                                              \
+      switch (TYPEOUT) {                                                                      \
+        case apex_internal::ScalarType::Float: {                                              \
+          using scalar_t_out = float;                                                         \
+          __VA_ARGS__;                                                                        \
+          break;                                                                              \
+        }                                                                                     \
+        case apex_internal::ScalarType::Half: {                                               \
+          using scalar_t_out = apex_internal::Half;                                           \
+          __VA_ARGS__;                                                                        \
+          break;                                                                              \
+        }                                                                                     \
+        case apex_internal::ScalarType::BFloat16: {                                           \
+          using scalar_t_out = apex_internal::BFloat16;                                       \
+          __VA_ARGS__;                                                                        \
+          break;                                                                              \
+        }                                                                                     \
+        default:                                                                              \
           APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPEOUT), "'"); \
-      }                                                                        \
-      break;                                                                   \
-    }                                                                          \
-    case apex_internal::ScalarType::Half: {                                    \
-      using scalar_t_in = apex_internal::Half;                                 \
-      using scalar_t_out = apex_internal::Half;                                \
-      __VA_ARGS__;                                                             \
-      break;                                                                   \
-    }                                                                          \
-    case apex_internal::ScalarType::BFloat16: {                                \
-      using scalar_t_in = apex_internal::BFloat16;                             \
-      using scalar_t_out = apex_internal::BFloat16;                            \
-      __VA_ARGS__;                                                             \
-      break;                                                                   \
-    }                                                                          \
-    default:                                                                   \
-      APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPEIN), "'"); \
+      }                                                                                       \
+      break;                                                                                  \
+    }                                                                                         \
+    case apex_internal::ScalarType::Half: {                                                   \
+      using scalar_t_in = apex_internal::Half;                                                \
+      using scalar_t_out = apex_internal::Half;                                               \
+      __VA_ARGS__;                                                                            \
+      break;                                                                                  \
+    }                                                                                         \
+    case apex_internal::ScalarType::BFloat16: {                                               \
+      using scalar_t_in = apex_internal::BFloat16;                                            \
+      using scalar_t_out = apex_internal::BFloat16;                                           \
+      __VA_ARGS__;                                                                            \
+      break;                                                                                  \
+    }                                                                                         \
+    default:                                                                                  \
+      APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPEIN), "'");      \
   }
 
-#define DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT_INOUT_TYPES(TYPEIN, TYPEOUT, NAME, ...) \
-  switch (TYPEIN) {                                                                   \
-    case apex_internal::ScalarType::Double: {                                         \
-      using scalar_t_in = double;                                                     \
-      switch (TYPEOUT) {                                                              \
-        case apex_internal::ScalarType::Double: {                                     \
-          using scalar_t_out = double;                                                \
-          __VA_ARGS__;                                                                \
-          break;                                                                      \
-        }                                                                             \
-        case apex_internal::ScalarType::Float: {                                      \
-          using scalar_t_out = float;                                                 \
-          __VA_ARGS__;                                                                \
-          break;                                                                      \
-        }                                                                             \
-        case apex_internal::ScalarType::Half: {                                       \
-          using scalar_t_out = apex_internal::Half;                                   \
-          __VA_ARGS__;                                                                \
-          break;                                                                      \
-        }                                                                             \
-        case apex_internal::ScalarType::BFloat16: {                                   \
-          using scalar_t_out = apex_internal::BFloat16;                               \
-          __VA_ARGS__;                                                                \
-          break;                                                                      \
-        }                                                                             \
-        default:                                                                      \
+#define DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT_INOUT_TYPES(TYPEIN, TYPEOUT, NAME, ...)         \
+  switch (TYPEIN) {                                                                           \
+    case apex_internal::ScalarType::Double: {                                                 \
+      using scalar_t_in = double;                                                             \
+      switch (TYPEOUT) {                                                                      \
+        case apex_internal::ScalarType::Double: {                                             \
+          using scalar_t_out = double;                                                        \
+          __VA_ARGS__;                                                                        \
+          break;                                                                              \
+        }                                                                                     \
+        case apex_internal::ScalarType::Float: {                                              \
+          using scalar_t_out = float;                                                         \
+          __VA_ARGS__;                                                                        \
+          break;                                                                              \
+        }                                                                                     \
+        case apex_internal::ScalarType::Half: {                                               \
+          using scalar_t_out = apex_internal::Half;                                           \
+          __VA_ARGS__;                                                                        \
+          break;                                                                              \
+        }                                                                                     \
+        case apex_internal::ScalarType::BFloat16: {                                           \
+          using scalar_t_out = apex_internal::BFloat16;                                       \
+          __VA_ARGS__;                                                                        \
+          break;                                                                              \
+        }                                                                                     \
+        default:                                                                              \
           APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPEOUT), "'"); \
-      }                                                                               \
-      break;                                                                          \
-    }                                                                                 \
-    case apex_internal::ScalarType::Float: {                                          \
-      using scalar_t_in = float;                                                      \
-      switch (TYPEOUT) {                                                              \
-        case apex_internal::ScalarType::Float: {                                      \
-          using scalar_t_out = float;                                                 \
-          __VA_ARGS__;                                                                \
-          break;                                                                      \
-        }                                                                             \
-        case apex_internal::ScalarType::Half: {                                       \
-          using scalar_t_out = apex_internal::Half;                                   \
-          __VA_ARGS__;                                                                \
-          break;                                                                      \
-        }                                                                             \
-        case apex_internal::ScalarType::BFloat16: {                                   \
-          using scalar_t_out = apex_internal::BFloat16;                               \
-          __VA_ARGS__;                                                                \
-          break;                                                                      \
-        }                                                                             \
-        default:                                                                      \
+      }                                                                                       \
+      break;                                                                                  \
+    }                                                                                         \
+    case apex_internal::ScalarType::Float: {                                                  \
+      using scalar_t_in = float;                                                              \
+      switch (TYPEOUT) {                                                                      \
+        case apex_internal::ScalarType::Float: {                                              \
+          using scalar_t_out = float;                                                         \
+          __VA_ARGS__;                                                                        \
+          break;                                                                              \
+        }                                                                                     \
+        case apex_internal::ScalarType::Half: {                                               \
+          using scalar_t_out = apex_internal::Half;                                           \
+          __VA_ARGS__;                                                                        \
+          break;                                                                              \
+        }                                                                                     \
+        case apex_internal::ScalarType::BFloat16: {                                           \
+          using scalar_t_out = apex_internal::BFloat16;                                       \
+          __VA_ARGS__;                                                                        \
+          break;                                                                              \
+        }                                                                                     \
+        default:                                                                              \
           APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPEOUT), "'"); \
-      }                                                                               \
-      break;                                                                          \
-    }                                                                                 \
-    case apex_internal::ScalarType::Half: {                                           \
-      using scalar_t_in = apex_internal::Half;                                        \
-      using scalar_t_out = apex_internal::Half;                                       \
-      __VA_ARGS__;                                                                    \
-      break;                                                                          \
-    }                                                                                 \
-    case apex_internal::ScalarType::BFloat16: {                                       \
-      using scalar_t_in = apex_internal::BFloat16;                                    \
-      using scalar_t_out = apex_internal::BFloat16;                                   \
-      __VA_ARGS__;                                                                    \
-      break;                                                                          \
-    }                                                                                 \
-    default:                                                                          \
-      APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPEIN), "'"); \
+      }                                                                                       \
+      break;                                                                                  \
+    }                                                                                         \
+    case apex_internal::ScalarType::Half: {                                                   \
+      using scalar_t_in = apex_internal::Half;                                                \
+      using scalar_t_out = apex_internal::Half;                                               \
+      __VA_ARGS__;                                                                            \
+      break;                                                                                  \
+    }                                                                                         \
+    case apex_internal::ScalarType::BFloat16: {                                               \
+      using scalar_t_in = apex_internal::BFloat16;                                            \
+      using scalar_t_out = apex_internal::BFloat16;                                           \
+      __VA_ARGS__;                                                                            \
+      break;                                                                                  \
+    }                                                                                         \
+    default:                                                                                  \
+      APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPEIN), "'");      \
   }
 
 template <typename T>

--- a/setup.py
+++ b/setup.py
@@ -168,12 +168,11 @@ def StableCUDAExtension(name, sources, extra_compile_args=None, **kwargs):
     Wrapper for CUDAExtension that automatically handles stable ABI source substitution and flags.
     """
     stable_sources = prepare_stable_abi_sources(sources)
-    stable_compile_args = add_stable_abi_compile_args(extra_compile_args if extra_compile_args else {})
+    stable_compile_args = add_stable_abi_compile_args(
+        extra_compile_args if extra_compile_args else {}
+    )
     return CUDAExtension(
-        name=name,
-        sources=stable_sources,
-        extra_compile_args=stable_compile_args,
-        **kwargs
+        name=name, sources=stable_sources, extra_compile_args=stable_compile_args, **kwargs
     )
 
 
@@ -182,12 +181,11 @@ def StableCppExtension(name, sources, extra_compile_args=None, **kwargs):
     Wrapper for CppExtension that automatically handles stable ABI source substitution and flags.
     """
     stable_sources = prepare_stable_abi_sources(sources)
-    stable_compile_args = add_stable_abi_compile_args(extra_compile_args if extra_compile_args else {})
+    stable_compile_args = add_stable_abi_compile_args(
+        extra_compile_args if extra_compile_args else {}
+    )
     return CppExtension(
-        name=name,
-        sources=stable_sources,
-        extra_compile_args=stable_compile_args,
-        **kwargs
+        name=name, sources=stable_sources, extra_compile_args=stable_compile_args, **kwargs
     )
 
 


### PR DESCRIPTION
##  Summary

This PR implements the complete infrastructure for migrating NVIDIA apex to **LibTorch Stable ABI**, enabling extensions to work across PyTorch versions without recompilation. The implementation includes:

-  Custom MemoryFormat contiguity checking workaround
-  Dual-build support for all 35+ extensions  
- Automated build system configuration

---

## The Problem

NVIDIA apex currently relies on traditional PyTorch C++ extension APIs (`PYBIND11`, `at::Tensor`, `torch/extension.h`) that require recompilation for each PyTorch version. This creates:

- **Version Lock-in**: Extensions break when users upgrade PyTorch
- **Deployment Friction**: Requires build environment matching exact PyTorch version
- **Maintenance Burden**: Need to rebuild and redistribute for every PyTorch release

The [LibTorch Stable ABI](https://pytorch.org/blog/pytorch-2-9/) (introduced in PyTorch 2.9) solves this by providing version-agnostic APIs with guaranteed **2+ years of compatibility**.

### Critical Blocker

As noted in [#1946](https://github.com/NVIDIA/apex/issues/1946), the stable ABI's `Tensor::is_contiguous()` doesn't support the `MemoryFormat` parameter. This is heavily used in apex, particularly in `multi_tensor_apply.cuh`:

```cpp
// Line 60-61 in multi_tensor_apply.cuh
bool contiguous_memory = tensor_lists[l][t].is_contiguous();
contiguous_memory = (contiguous_memory ||
    tensor_lists[l][t].is_contiguous(at::MemoryFormat::ChannelsLast) ||
    tensor_lists[l][t].is_contiguous(at::MemoryFormat::ChannelsLast3d));
```

**Without MemoryFormat support**, we cannot check for ChannelsLast/ChannelsLast3d contiguity, which is fundamental to many apex kernels.

### Scope

- 35+ extension files need conversion from `PYBIND11_MODULE` to `STABLE_TORCH_LIBRARY` with boxed calling
- Shared headers (`type_shim.h`, `multi_tensor_apply.cuh`) used across all extensions
- Build system must support both traditional and stable ABI modes simultaneously

---

## The Solution

I implemented a complete dual-build infrastructure with three main components:

### 1. Custom MemoryFormat Workaround

**File**: `csrc/stable_abi_utils.h` (NEW)

Created a custom `is_contiguous()` implementation that manually inspects tensor strides to determine memory layout, bypassing the stable ABI limitation:

```cpp
namespace apex {
namespace stable {

enum class MemoryFormat {
  Contiguous,
  ChannelsLast,
  ChannelsLast3d,
  Preserve
};

inline bool is_contiguous(const torch::stable::Tensor& tensor, MemoryFormat format) {
  // For standard contiguous check, use stable ABI method
  if (format == MemoryFormat::Contiguous) {
    return tensor.is_contiguous();
  }

  auto sizes = tensor.sizes();
  auto strides = tensor.strides();
  int64_t ndim = tensor.dim();

  if (format == MemoryFormat::ChannelsLast) {
    // NHWC format: Check if strides match C=1, W=C, H=W*W_size, N=H*H_size
    if (ndim != 4) return false;
    int64_t N = sizes[0], C = sizes[1], H = sizes[2], W = sizes[3];
    return (strides[1] == 1) &&
           (strides[3] == C) &&
           (strides[2] == W * C) &&
           (strides[0] == H * W * C);
  }

  if (format == MemoryFormat::ChannelsLast3d) {
    // NDHWC format: Similar logic for 5D tensors
    if (ndim != 5) return false;
    int64_t N = sizes[0], C = sizes[1], D = sizes[2], H = sizes[3], W = sizes[4];
    return (strides[1] == 1) &&
           (strides[4] == C) &&
           (strides[3] == W * C) &&
           (strides[2] == H * W * C) &&
           (strides[0] == D * H * W * C);
  }

  return false;
}

} // namespace stable
} // namespace apex
```

**This completely solves the critical blocker** without waiting for PyTorch upstream changes.

#### Additional Utilities

`stable_abi_utils.h` also provides:

- Error checking macros: `STD_TORCH_CHECK`, `STD_TORCH_CHECK_EQ`, etc.
- Boxed calling helpers: `tensor_from_stack()`, `int64_from_stack()`, `tensor_to_stack()`, etc.
- Type utilities: `scalar_type_name()`, type conversion helpers
- Device checks: `is_cuda()`, `get_device_index()`, `check_same_device()`

---

### 2. Shared Header Compatibility Layer

#### `csrc/type_shim.h` (MODIFIED)

Added dual-build support with conditional compilation:

```cpp
#ifdef TORCH_STABLE_ONLY
#include <torch/csrc/stable/tensor.h>
#include <torch/headeronly/types.h>
#include "stable_abi_utils.h"

#define APEX_ERROR(...) apex::stable::STD_TORCH_CHECK(false, __VA_ARGS__)

namespace apex_internal {
  using ScalarType = torch::headeronly::ScalarType;
  using Half = torch::headeronly::Half;
  using BFloat16 = torch::headeronly::BFloat16;
  inline std::string toString(ScalarType type) {
    return std::string(apex::stable::scalar_type_name(type));
  }
}

#else // Traditional API
#include <ATen/ATen.h>

#define APEX_ERROR(...) AT_ERROR(__VA_ARGS__)

namespace apex_internal {
  using ScalarType = at::ScalarType;
  using Half = at::Half;
  using BFloat16 = at::BFloat16;
  inline std::string toString(at::ScalarType type) {
    return std::string(c10::toString(type));
  }
}
#endif
```

Updated all type dispatch macros to use `apex_internal` namespace:

```cpp
#define DISPATCH_FLOAT_AND_HALF(TYPE, LEVEL, NAME, ...) \
  switch(TYPE) \
  { \
    case apex_internal::ScalarType::Float: \
    { \
      using scalar_t_##LEVEL = float; \
      __VA_ARGS__; \
      break; \
    } \
    case apex_internal::ScalarType::Half: \
    { \
      using scalar_t_##LEVEL = apex_internal::Half; \
      __VA_ARGS__; \
      break; \
    } \
    default: \
      APEX_ERROR(#NAME, " not implemented for '", apex_internal::toString(TYPE), "'");  \
  }
```

This ensures all existing code using these macros works with both APIs without modification.

#### `csrc/multi_tensor_apply.cuh` (MODIFIED)

Created unified tensor handling for the critical `multi_tensor_apply` template used across all optimizers:

```cpp
// Namespace aliases for dual-build support
#ifdef TORCH_STABLE_ONLY
namespace apex_tensor {
  using Tensor = torch::stable::Tensor;
  using MemoryFormat = apex::stable::MemoryFormat;
  namespace device = torch::headeronly;

  inline bool is_contiguous_any_format(const Tensor& t) {
    return apex::stable::is_contiguous(t, MemoryFormat::Contiguous) ||
           apex::stable::is_contiguous(t, MemoryFormat::ChannelsLast) ||
           apex::stable::is_contiguous(t, MemoryFormat::ChannelsLast3d);
  }
}
#else
namespace apex_tensor {
  using Tensor = at::Tensor;
  using MemoryFormat = at::MemoryFormat;
  namespace device = at;

  inline bool is_contiguous_any_format(const Tensor& t) {
    return t.is_contiguous() ||
           t.is_contiguous(at::MemoryFormat::ChannelsLast) ||
           t.is_contiguous(at::MemoryFormat::ChannelsLast3d);
  }
}
#endif
```

Updated function signature and critical checks:

```cpp
template<int depth, typename T, typename... ArgTypes>
void multi_tensor_apply(
  int64_t block_size,
  int64_t chunk_size,
  const apex_tensor::Tensor& noop_flag,
  const std::vector<std::vector<apex_tensor::Tensor>>& tensor_lists,
  T callable,
  ArgTypes... args)
{
  TORCH_CHECK(ref_device.type() == apex_tensor::device::kCUDA, "expected input to be on cuda");
  bool contiguous_memory = apex_tensor::is_contiguous_any_format(tensor_lists[l][t]);
  TORCH_CHECK(contiguous_memory, "A tensor was not contiguous.");

#ifdef TORCH_STABLE_ONLY
  cudaStream_t stream = nullptr;
  cudaError_t err = cudaGetLastError();
  apex::stable::STD_TORCH_CHECK(err == cudaSuccess, "CUDA kernel launch failed: %s", cudaGetErrorString(err));
#else
  const at::cuda::OptionalCUDAGuard device_guard(device_of(tensor_lists[0][0]));
  auto stream = at::cuda::getCurrentCUDAStream();
  AT_CUDA_CHECK(cudaGetLastError());
#endif
}
```

---

### 3. Automated Dual-Build System

**File**: `setup.py` (MODIFIED)

Added intelligent build system that automatically handles source file substitution and compiler flags:

```python
# Detect stable ABI build mode
USE_STABLE_ABI = os.environ.get("TORCH_STABLE_ONLY", "0") == "1"
if USE_STABLE_ABI:
    print("[apex] Building with LibTorch Stable ABI support (TORCH_STABLE_ONLY=1)")

def prepare_stable_abi_sources(sources):
    """Convert .cpp → _stable.cpp when TORCH_STABLE_ONLY=1"""
    if not USE_STABLE_ABI:
        return sources
    
    stable_sources = []
    for src in sources:
        if src.endswith(".cpp"):
            stable_src = src[:-4] + "_stable.cpp"
            stable_sources.append(stable_src)
        else:
            stable_sources.append(src)
    return stable_sources

def StableCUDAExtension(name, sources, extra_compile_args=None, **kwargs):
    """Wrapper for CUDAExtension with automatic stable ABI handling."""
    stable_sources = prepare_stable_abi_sources(sources)
    stable_compile_args = add_stable_abi_compile_args(extra_compile_args or {})
    return CUDAExtension(
        name=name,
        sources=stable_sources,
        extra_compile_args=stable_compile_args,
        **kwargs
    )
```

**Updated ALL 35+ extension definitions** to use wrappers. When `TORCH_STABLE_ONLY=1`:

- Automatically uses `*_stable.cpp` files
- Automatically adds `-DTORCH_STABLE_ONLY` flag
- Triggers stable ABI headers in conditional compilation

---

## Remaining Work: Extension Conversions

The infrastructure is complete. The following **35+ files** need individual conversion.

### Conversion Pattern

Each extension needs a `*_stable.cpp` file following this pattern:

```cpp
#ifdef TORCH_STABLE_ONLY
#include <torch/csrc/stable/tensor.h>
#include <torch/csrc/stable/library.h>
#include <torch/csrc/stable/ivalue.h>
#include "stable_abi_utils.h"

using namespace torch::stable;
using namespace apex::stable;

void my_function_boxed(StableIValue* stack, uint64_t num_args, uint64_t num_outputs) {
    // 1. Extract parameters from stack
    auto input = tensor_from_stack(stack, 0);
    auto param = double_from_stack(stack, 1);
    
    // 2. Call implementation
    auto result = my_function_impl(input, param);
    
    // 3. Return via stack
    tensor_to_stack(stack, 0, result);
}

STABLE_TORCH_LIBRARY(module_name, m) {
    m.def("my_function", my_function_boxed);
}

#else
#error "This file should only be compiled with TORCH_STABLE_ONLY defined"
#endif
```

## Build Instructions

### Traditional Build (Default)

```bash
APEX_CPP_EXT=1 APEX_CUDA_EXT=1 pip install -v --no-build-isolation .
```

### Stable ABI Build

```bash
TORCH_STABLE_ONLY=1 APEX_CPP_EXT=1 APEX_CUDA_EXT=1 pip install -v --no-build-isolation .
```

**Requirements**: PyTorch 2.9+

---

## Test Plan

### Build Verification

**Traditional build** (no regressions):

```bash
python setup.py clean
APEX_CPP_EXT=1 APEX_CUDA_EXT=1 python setup.py install
pytest tests/ -v
```

**Stable ABI infrastructure**:

```bash
python setup.py clean
TORCH_STABLE_ONLY=1 APEX_CPP_EXT=1 APEX_CUDA_EXT=1 python setup.py install
```

## References

- **Issue**: [#1946](https://github.com/NVIDIA/apex/issues/1946)
- **Stable ABI Docs**: [PyTorch Documentation](https://docs.pytorch.org/docs/stable/notes/libtorch_stable_abi.html)
- **PyTorch 2.9 Release**: [Release Blog](https://pytorch.org/blog/pytorch-2-9/)
- **Flash-Attention Example**: [Implementation Reference](https://github.com/Dao-AILab/flash-attention/commit/b3846b059bf6b143d1cd56879933be30a9f78c81)