### PR TITLE
Fix traceback formatting in permutation_lib.py

### DIFF
--- a/apex/contrib/sparsity/permutation_lib.py
+++ b/apex/contrib/sparsity/permutation_lib.py
@@ -2012,7 +2012,7 @@ class Permutation:
                     print(
                         "".join(
                             traceback.format_exception(
-                                etype=type(ex), value=ex, tb=ex.__traceback__
+                                value=ex, tb=ex.__traceback__
                             )
                         )
                     )

--- a/apex/contrib/sparsity/permutation_lib.py
+++ b/apex/contrib/sparsity/permutation_lib.py
@@ -2009,13 +2009,7 @@ class Permutation:
             if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
                 if cls.__verbosity > 0:
                     print(ex)
-                    print(
-                        "".join(
-                            traceback.format_exception(
-                                value=ex, tb=ex.__traceback__
-                            )
-                        )
-                    )
+                    print("".join(traceback.format_exception(value=ex, tb=ex.__traceback__)))
                     print(
                         "\n[print_raw_fx_graph] Meet the fatal fault when trying to symbolic trace the model with Torch.FX"
                     )


### PR DESCRIPTION
Python 3.10+ no longer supports etype:

```
TypeError: format_exception() got an unexpected keyword argument 'etype'
```