### PR TITLE
Group norm v2: add missing include

### DIFF
--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_kernel.cuh
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_kernel.cuh
@@ -2,6 +2,8 @@
 
 #include <cooperative_groups.h>
 
+#include <tuple>
+
 #include "gn_utils.hpp"
 
 namespace group_norm_v2 {


### PR DESCRIPTION
The group norm v2 extension could not be compile on my system without this issue (which makes sense to me).