### PR TITLE
Fix E721 type comparisons

### DIFF
--- a/apex/contrib/gpu_direct_storage/__init__.py
+++ b/apex/contrib/gpu_direct_storage/__init__.py
@@ -4,8 +4,8 @@ from contextlib import contextmanager
 
 @contextmanager
 def GDSFile(filename, mode):
-    assert type(filename) == str
-    assert type(mode) == str
+    assert isinstance(filename, str)
+    assert isinstance(mode, str)
     try:
         from apex import deprecated_warning
 

--- a/apex/contrib/optimizers/fused_adam.py
+++ b/apex/contrib/optimizers/fused_adam.py
@@ -106,7 +106,7 @@ class FusedAdam(torch.optim.Optimizer):
         # assuming a list/generator of parameter means single group
         elif isinstance(grads, types.GeneratorType):
             grads_group = [grads]
-        elif type(grads[0]) != list:
+        elif not isinstance(grads[0], list):
             grads_group = [grads]
         else:
             grads_group = grads
@@ -115,7 +115,7 @@ class FusedAdam(torch.optim.Optimizer):
             output_params_group = [None] * len(self.param_groups)
         elif isinstance(output_params, types.GeneratorType):
             output_params_group = [output_params]
-        elif type(output_params[0]) != list:
+        elif not isinstance(output_params[0], list):
             output_params_group = [output_params]
         else:
             output_params_group = output_params

--- a/apex/contrib/optimizers/fused_sgd.py
+++ b/apex/contrib/optimizers/fused_sgd.py
@@ -157,7 +157,7 @@ class FusedSGD(Optimizer):
         # assuming a list/generator of parameter means single group
         elif isinstance(grads, types.GeneratorType):
             grads_group = [grads]
-        elif type(grads[0]) != list:
+        elif not isinstance(grads[0], list):
             grads_group = [grads]
         else:
             grads_group = grads
@@ -170,7 +170,7 @@ class FusedSGD(Optimizer):
             )
         elif isinstance(output_params, types.GeneratorType):
             output_params_group = [output_params]
-        elif type(output_params[0]) != list:
+        elif not isinstance(output_params[0], list):
             output_params_group = [output_params]
         else:
             output_params_group = output_params

--- a/apex/contrib/test/openfold_triton/test_sync_triton_auto_tune_cache_across_gpus.py
+++ b/apex/contrib/test/openfold_triton/test_sync_triton_auto_tune_cache_across_gpus.py
@@ -45,9 +45,9 @@ class SyncTritonAutoTuneCacheTest(MultiProcessTestCase):
 
     def _create_process_group_nccl(self):
         def maybe_export(env, val):
-            if not type(env) == str:
+            if not isinstance(env, str):
                 raise ValueError(f"Type of type of env is expected to be str, but got {type(env)}")
-            if not type(val) == str:
+            if not isinstance(val, str):
                 raise ValueError(f"Type of type of val is expected to be str, but got {type(val)}")
             if os.getenv(env) is None:
                 os.environ[env] = val

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ line-length = 100
 ignore = [
     # Sorted by occurrence count (ascending) - easier to fix first
     "E731",  # lambda assignment (6 occurrences)
-    "E721",  # type comparison should use isinstance (8 occurrences)
     "E741",  # ambiguous variable name (8 occurrences)
     "E712",  # comparison to True/False (9 occurrences)
     "F403",  # star imports used (9 occurrences)


### PR DESCRIPTION
This fixes one ignored Ruff rule from #1964.

**Changes:**
- Replaces direct type comparisons with `isinstance` or `not isinstance`.
- Removes `E721` from the Ruff ignore list.
- Leaves all other ignored Ruff rules untouched.

**Validation:**
```
python -m ruff check . --select E721
python -m ruff check .
```

Both pass.