### PR TITLE
Remove group norm C++ standard override

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -531,10 +531,9 @@ if has_flag("--group_norm", "APEX_GROUP_NORM"):
             + glob.glob("apex/contrib/csrc/group_norm/*.cu"),
             include_dirs=[os.path.join(this_dir, "csrc")],
             extra_compile_args={
-                "cxx": ["-O3", "-std=c++17"],
+                "cxx": ["-O3"],
                 "nvcc": [
                     "-O3",
-                    "-std=c++17",
                     "--use_fast_math",
                     "--ftz=false",
                 ],


### PR DESCRIPTION
Let torch.utils.cpp_extension choose the C++ standard for group_norm_cuda instead of forcing C++17, which is incompatible with newer PyTorch headers using C++20 helpers.

Authored with gpt-5 xhigh