### PR TITLE
Guard CUDA probe when CUDA_HOME is unset

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,8 @@ if has_flag("--cpp_ext", "APEX_CPP_EXT"):
     ext_modules.append(CppExtension("apex_C", ["csrc/flatten_unflatten.cpp"]))
 
 
-_, bare_metal_version = get_cuda_bare_metal_version(CUDA_HOME)
+if CUDA_HOME is not None:
+    _, bare_metal_version = get_cuda_bare_metal_version(CUDA_HOME)
 
 if has_flag("--distributed_adam", "APEX_DISTRIBUTED_ADAM"):
     if "--distributed_adam" in sys.argv:


### PR DESCRIPTION
## Summary
- guard the unconditional `get_cuda_bare_metal_version(CUDA_HOME)` call in `setup.py`
- avoid touching `nvcc` during metadata generation or Python-only installs when `CUDA_HOME` is unset

## Why
The repo still documents a Python-only install path, but `setup.py` always probes the CUDA toolkit version at import time. That makes metadata generation fail before any CUDA extension was requested.

This follows the same intent as #1499, which guarded one `CUDA_HOME` path earlier in `setup.py`, but leaves the later unconditional probe untouched. It also matches the still-open no-CUDA build report in #1498 and the metadata-generation failure reported in #1702.

## Validation
- `python3 -m py_compile setup.py`
