### PR TITLE
fix missing standard headers in group_norm_v2 host template

### DIFF
--- a/apex/contrib/csrc/group_norm_v2/gn_cuda_host_template.cuh
+++ b/apex/contrib/csrc/group_norm_v2/gn_cuda_host_template.cuh
@@ -4,8 +4,11 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
+#include <algorithm>
 #include <cstdio>
 #include <stdexcept>
+#include <string>
+#include <tuple>
 
 #include "gn_cuda_kernel.cuh"
 #include "gn_utils.hpp"


### PR DESCRIPTION
APEX_GROUP_NORM=1 builds group_norm_v2_cuda on CUDA >= 12.4. With CUDA 12.8 / GCC 11, compilation fails in gn_cuda_host_template.cuh because std::tuple/std::get/std::make_tuple are used without including <tuple>.

This patch adds the standard headers used directly by the file.