### PR TITLE
extend 64bit indexing for other multi tensor ops

### DIFF
--- a/csrc/multi_tensor_adagrad.cu
+++ b/csrc/multi_tensor_adagrad.cu
@@ -21,14 +21,14 @@ typedef enum {
 
 using MATH_T = float;
 
-template <typename T>
+template <typename T, typename index_t>
 struct AdagradFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<3>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<3>& tl,
                                              const float epsilon, const float lr, adagradMode_t mode,
                                              const float weight_decay) {
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     T* g = (T*)tl.addresses[0][tensor_loc];
     g += chunk_idx * chunk_size;
@@ -42,13 +42,13 @@ struct AdagradFunctor {
     n -= chunk_idx * chunk_size;
 
     // see note in multi_tensor_scale_kernel.cu
-    for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+    for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
       MATH_T r_g[ILP];
       MATH_T r_p[ILP];
       MATH_T r_h[ILP];
 #pragma unroll
       for (int ii = 0; ii < ILP; ii++) {
-        int i = i_start + threadIdx.x + ii * blockDim.x;
+        index_t i = i_start + threadIdx.x + ii * blockDim.x;
         if (i < n && i < chunk_size) {
           r_g[ii] = g[i];
           r_p[ii] = p[i];
@@ -72,7 +72,7 @@ struct AdagradFunctor {
       }
 #pragma unroll
       for (int ii = 0; ii < ILP; ii++) {
-        int i = i_start + threadIdx.x + ii * blockDim.x;
+        index_t i = i_start + threadIdx.x + ii * blockDim.x;
         if (i < n && i < chunk_size) {
           p[i] = r_p[ii];
           h[i] = r_h[ii];
@@ -86,11 +86,30 @@ void multi_tensor_adagrad_cuda(int chunk_size, at::Tensor noop_flag, std::vector
                                const float lr, const float epsilon, const int mode, const float weight_decay) {
   using namespace at;
 
-  // Assume single type across p,g,h now
-  DISPATCH_DOUBLE_FLOAT_AND_HALF(
-      tensor_lists[0][0].scalar_type(), 0, "adagrad",
-      multi_tensor_apply<3>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, AdagradFunctor<scalar_t_0>(), epsilon, lr,
-                            (adagradMode_t)mode, weight_decay);)
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
+  if (requires_64bit_indexing) {
+    // Assume single type across p,g,h now
+    DISPATCH_DOUBLE_FLOAT_AND_HALF(
+        tensor_lists[0][0].scalar_type(), 0, "adagrad",
+        multi_tensor_apply<3>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                              AdagradFunctor<scalar_t_0, int64_t>(), epsilon, lr, (adagradMode_t)mode, weight_decay);)
+  } else {
+    // Assume single type across p,g,h now
+    DISPATCH_DOUBLE_FLOAT_AND_HALF(
+        tensor_lists[0][0].scalar_type(), 0, "adagrad",
+        multi_tensor_apply<3>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, AdagradFunctor<scalar_t_0, int32_t>(),
+                              epsilon, lr, (adagradMode_t)mode, weight_decay);)
+  }
 
   AT_CUDA_CHECK(cudaGetLastError());
 }

--- a/csrc/multi_tensor_adam.cu
+++ b/csrc/multi_tensor_adam.cu
@@ -107,9 +107,9 @@ struct AdamFunctor {
   }
 };
 
-template <typename T, typename FULL_T>
+template <typename T, typename FULL_T, typename index_t>
 struct AdamCapturableFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<4>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<4>& tl,
                                              const float beta1, const float beta2, const int* step,
                                              const int bias_correction, const float epsilon, const float* lr,
                                              adamMode_t mode, const float decay, const float* inv_scale) {
@@ -121,13 +121,13 @@ struct AdamCapturableFunctor {
       beta2_correction = 1 - pow(beta2, *step);
     }
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
 
     // potentially use to pass in list of scalar
     // int tensor_num = tl.start_tensor_this_launch + tensor_loc;
 
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     T* g = (T*)tl.addresses[0][tensor_loc];
     g += chunk_idx * chunk_size;
@@ -144,14 +144,14 @@ struct AdamCapturableFunctor {
     n -= chunk_idx * chunk_size;
 
     // see note in multi_tensor_scale_kernel.cu
-    for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+    for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
       MATH_T r_g[ILP];
       MATH_T r_p[ILP];
       MATH_T r_m[ILP];
       MATH_T r_v[ILP];
 #pragma unroll
       for (int ii = 0; ii < ILP; ii++) {
-        int i = i_start + threadIdx.x + ii * blockDim.x;
+        index_t i = i_start + threadIdx.x + ii * blockDim.x;
         if (i < n && i < chunk_size) {
           r_g[ii] = static_cast<MATH_T>(g[i]) * (*inv_scale);
           g[i] = static_cast<T>(r_g[ii]);
@@ -188,7 +188,7 @@ struct AdamCapturableFunctor {
       }
 #pragma unroll
       for (int ii = 0; ii < ILP; ii++) {
-        int i = i_start + threadIdx.x + ii * blockDim.x;
+        index_t i = i_start + threadIdx.x + ii * blockDim.x;
         if (i < n && i < chunk_size) {
           p[i] = static_cast<T>(r_p[ii]);
           m[i] = static_cast<T>(r_m[ii]);
@@ -199,9 +199,9 @@ struct AdamCapturableFunctor {
   }
 };
 
-template <typename T, typename FULL_T>
+template <typename T, typename FULL_T, typename index_t>
 struct AdamCapturableMasterFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<5>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<5>& tl,
                                              const float beta1, const float beta2, const int* step,
                                              const int bias_correction, const float epsilon, const float* lr,
                                              adamMode_t mode, const float decay, const float* inv_scale) {
@@ -213,13 +213,13 @@ struct AdamCapturableMasterFunctor {
       beta2_correction = 1 - pow(beta2, *step);
     }
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
 
     // potentially use to pass in list of scalar
     // int tensor_num = tl.start_tensor_this_launch + tensor_loc;
 
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     T* g = (T*)tl.addresses[0][tensor_loc];
     g += chunk_idx * chunk_size;
@@ -239,14 +239,14 @@ struct AdamCapturableMasterFunctor {
     n -= chunk_idx * chunk_size;
 
     // see note in multi_tensor_scale_kernel.cu
-    for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+    for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
       MATH_T r_g[ILP];
       MATH_T r_p[ILP];
       MATH_T r_m[ILP];
       MATH_T r_v[ILP];
 #pragma unroll
       for (int ii = 0; ii < ILP; ii++) {
-        int i = i_start + threadIdx.x + ii * blockDim.x;
+        index_t i = i_start + threadIdx.x + ii * blockDim.x;
         if (i < n && i < chunk_size) {
           r_g[ii] = static_cast<MATH_T>(g[i]) * (*inv_scale);
           g[i] = static_cast<T>(r_g[ii]);
@@ -283,7 +283,7 @@ struct AdamCapturableMasterFunctor {
       }
 #pragma unroll
       for (int ii = 0; ii < ILP; ii++) {
-        int i = i_start + threadIdx.x + ii * blockDim.x;
+        index_t i = i_start + threadIdx.x + ii * blockDim.x;
         if (i < n && i < chunk_size) {
           p[i] = static_cast<T>(r_p[ii]);
           p_master[i] = static_cast<FULL_T>(r_p[ii]);
@@ -349,11 +349,32 @@ void multi_tensor_adam_capturable_cuda(int chunk_size, at::Tensor noop_flag,
                                        at::Tensor inv_scale) {
   using namespace at;
 
-  DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT(
-      tensor_lists[0][0].scalar_type(), 0, "adam",
-      multi_tensor_apply<4>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, AdamCapturableFunctor<scalar_t_0, float>(),
-                            beta1, beta2, step.data_ptr<int>(), bias_correction, epsilon, lr.data_ptr<float>(),
-                            (adamMode_t)mode, weight_decay, inv_scale.data_ptr<float>());)
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
+  if (requires_64bit_indexing) {
+    DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT(
+        tensor_lists[0][0].scalar_type(), 0, "adam",
+        multi_tensor_apply<4>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                              AdamCapturableFunctor<scalar_t_0, float, int64_t>(), beta1, beta2, step.data_ptr<int>(),
+                              bias_correction, epsilon, lr.data_ptr<float>(), (adamMode_t)mode, weight_decay,
+                              inv_scale.data_ptr<float>());)
+  } else {
+    DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT(
+        tensor_lists[0][0].scalar_type(), 0, "adam",
+        multi_tensor_apply<4>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
+                              AdamCapturableFunctor<scalar_t_0, float, int32_t>(), beta1, beta2, step.data_ptr<int>(),
+                              bias_correction, epsilon, lr.data_ptr<float>(), (adamMode_t)mode, weight_decay,
+                              inv_scale.data_ptr<float>());)
+  }
 
   AT_CUDA_CHECK(cudaGetLastError());
 }
@@ -365,12 +386,32 @@ void multi_tensor_adam_capturable_master_cuda(int chunk_size, at::Tensor noop_fl
                                               const float weight_decay, at::Tensor inv_scale) {
   using namespace at;
 
-  DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT(
-      tensor_lists[0][0].scalar_type(), 0, "adam",
-      multi_tensor_apply<5>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
-                            AdamCapturableMasterFunctor<scalar_t_0, float>(), beta1, beta2, step.data_ptr<int>(),
-                            bias_correction, epsilon, lr.data_ptr<float>(), (adamMode_t)mode, weight_decay,
-                            inv_scale.data_ptr<float>());)
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
+  if (requires_64bit_indexing) {
+    DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT(
+        tensor_lists[0][0].scalar_type(), 0, "adam",
+        multi_tensor_apply<5>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                              AdamCapturableMasterFunctor<scalar_t_0, float, int64_t>(), beta1, beta2,
+                              step.data_ptr<int>(), bias_correction, epsilon, lr.data_ptr<float>(), (adamMode_t)mode,
+                              weight_decay, inv_scale.data_ptr<float>());)
+  } else {
+    DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT(
+        tensor_lists[0][0].scalar_type(), 0, "adam",
+        multi_tensor_apply<5>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
+                              AdamCapturableMasterFunctor<scalar_t_0, float, int32_t>(), beta1, beta2,
+                              step.data_ptr<int>(), bias_correction, epsilon, lr.data_ptr<float>(), (adamMode_t)mode,
+                              weight_decay, inv_scale.data_ptr<float>());)
+  }
 
   AT_CUDA_CHECK(cudaGetLastError());
 }

--- a/csrc/multi_tensor_axpby_kernel.cu
+++ b/csrc/multi_tensor_axpby_kernel.cu
@@ -24,17 +24,17 @@ __device__ __forceinline__ void load_store(T* dst, T* src, int dst_offset, int s
   ((LT*)dst)[dst_offset] = ((LT*)src)[src_offset];
 }
 
-template <typename x_t, typename y_t, typename out_t>
+template <typename x_t, typename y_t, typename out_t, typename index_t>
 struct AxpbyFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<3>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<3>& tl,
                                              float a, float b, int arg_to_check) {
     // I'd like this kernel to propagate infs/nans.
     // if(*noop_gmem == 1)
     //   return;
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     x_t* x = (x_t*)tl.addresses[0][tensor_loc];
     x += chunk_idx * chunk_size;
@@ -54,7 +54,7 @@ struct AxpbyFunctor {
 
     // to make things simple, we put aligned case in a different code path
     if (n % ILP == 0 && chunk_size % ILP == 0 && is_aligned(x) && is_aligned(y) && is_aligned(out)) {
-      for (int i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
+      for (index_t i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
         // load
         load_store(r_x, x, 0, i_start);
         load_store(r_y, y, 0, i_start);
@@ -70,12 +70,12 @@ struct AxpbyFunctor {
       }
     } else {
       // Non-divergent exit condition for __syncthreads, not necessary here
-      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+      for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
           r_x[ii] = 0;
           r_y[ii] = 0;
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             r_x[ii] = x[i];
             r_y[ii] = y[i];
@@ -91,7 +91,7 @@ struct AxpbyFunctor {
         // see note in multi_tensor_scale_kernel.cu
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) out[i] = r_out[ii];
         }
       }
@@ -107,14 +107,37 @@ void multi_tensor_axpby_cuda(int chunk_size, at::Tensor noop_flag, std::vector<s
   // If build times suffer, think about where to put this dispatch,
   // and what logic should be moved out of multi_tensor_apply.
 
-  DISPATCH_FLOAT_AND_HALF(
-      tensor_lists[0][0].scalar_type(), 0, "multi_tensor_axpby_cuda",
-      DISPATCH_FLOAT_AND_HALF(
-          tensor_lists[1][0].scalar_type(), 1, "multi_tensor_axpby_cuda",
-          DISPATCH_FLOAT_AND_HALF(
-              tensor_lists[2][0].scalar_type(), 2, "multi_tensor_axpby_cuda",
-              multi_tensor_apply<3>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
-                                    AxpbyFunctor<scalar_t_0, scalar_t_1, scalar_t_2>(), a, b, arg_to_check);)))
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
+  if (requires_64bit_indexing) {
+    DISPATCH_FLOAT_AND_HALF(
+        tensor_lists[0][0].scalar_type(), 0, "multi_tensor_axpby_cuda",
+        DISPATCH_FLOAT_AND_HALF(
+            tensor_lists[1][0].scalar_type(), 1, "multi_tensor_axpby_cuda",
+            DISPATCH_FLOAT_AND_HALF(
+                tensor_lists[2][0].scalar_type(), 2, "multi_tensor_axpby_cuda",
+                multi_tensor_apply<3>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                                      AxpbyFunctor<scalar_t_0, scalar_t_1, scalar_t_2, int64_t>(), a, b,
+                                      arg_to_check);)))
+  } else {
+    DISPATCH_FLOAT_AND_HALF(
+        tensor_lists[0][0].scalar_type(), 0, "multi_tensor_axpby_cuda",
+        DISPATCH_FLOAT_AND_HALF(
+            tensor_lists[1][0].scalar_type(), 1, "multi_tensor_axpby_cuda",
+            DISPATCH_FLOAT_AND_HALF(tensor_lists[2][0].scalar_type(), 2, "multi_tensor_axpby_cuda",
+                                    multi_tensor_apply<3>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
+                                                          AxpbyFunctor<scalar_t_0, scalar_t_1, scalar_t_2, int32_t>(),
+                                                          a, b, arg_to_check);)))
+  }
 
   AT_CUDA_CHECK(cudaGetLastError());
 

--- a/csrc/multi_tensor_l2norm_kernel.cu
+++ b/csrc/multi_tensor_l2norm_kernel.cu
@@ -25,18 +25,18 @@ __device__ __forceinline__ void load_store(T* dst, T* src, int dst_offset, int s
   ((LT*)dst)[dst_offset] = ((LT*)src)[src_offset];
 }
 
-template <typename x_t>
+template <typename x_t, typename index_t>
 struct L2NormFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<1>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<1>& tl,
                                              float* output, float* output_per_tensor, bool per_tensor,
                                              int max_chunks_per_tensor) {
     // I'd like this kernel to propagate infs/nans.
     // if(*noop_gmem == 1)
     //   return;
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     x_t* x = (x_t*)tl.addresses[0][tensor_loc];
     x += chunk_idx * chunk_size;
@@ -54,7 +54,7 @@ struct L2NormFunctor {
 
     // to make things simple, we put aligned case in a different code path
     if (n % ILP == 0 && chunk_size % ILP == 0 && is_aligned(x)) {
-      for (int i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
+      for (index_t i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
         // load
         load_store(r_x, x, 0, i_start);
 #pragma unroll
@@ -64,10 +64,10 @@ struct L2NormFunctor {
         }
       }
     } else {
-      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+      for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             float next = static_cast<float>(x[i]);
             vals[ii] += next * next;
@@ -90,18 +90,18 @@ struct L2NormFunctor {
   }
 };
 
-template <typename x_t>
+template <typename x_t, typename index_t>
 struct UnscaleL2NormFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<1>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<1>& tl,
                                              const float* inv_scale, float* output, float* output_per_tensor,
                                              bool per_tensor, int max_chunks_per_tensor) {
     // I'd like this kernel to propagate infs/nans.
     // if(*noop_gmem == 1)
     //   return;
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     x_t* x = (x_t*)tl.addresses[0][tensor_loc];
     x += chunk_idx * chunk_size;
@@ -119,7 +119,7 @@ struct UnscaleL2NormFunctor {
 
     // to make things simple, we put aligned case in a different code path
     if (n % ILP == 0 && chunk_size % ILP == 0 && is_aligned(x)) {
-      for (int i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
+      for (index_t i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
         // load
         load_store(r_x, x, 0, i_start);
 #pragma unroll
@@ -129,10 +129,10 @@ struct UnscaleL2NormFunctor {
         }
       }
     } else {
-      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+      for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             float next = static_cast<float>(x[i]) * (*inv_scale);
             vals[ii] += next * next;
@@ -156,18 +156,18 @@ struct UnscaleL2NormFunctor {
 };
 
 // Probably better to template, but since we are not likely to support other norm
-template <typename x_t>
+template <typename x_t, typename index_t>
 struct MaxNormFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<1>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<1>& tl,
                                              float* output, float* output_per_tensor, bool per_tensor,
                                              int max_chunks_per_tensor) {
     // I'd like this kernel to propagate infs/nans.
     // if(*noop_gmem == 1)
     //   return;
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     x_t* x = (x_t*)tl.addresses[0][tensor_loc];
     x += chunk_idx * chunk_size;
@@ -185,7 +185,7 @@ struct MaxNormFunctor {
 
     // to make things simple, we put aligned case in a different code path
     if (n % ILP == 0 && chunk_size % ILP == 0 && is_aligned(x)) {
-      for (int i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
+      for (index_t i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
         // load
         load_store(r_x, x, 0, i_start);
 #pragma unroll
@@ -195,10 +195,10 @@ struct MaxNormFunctor {
         }
       }
     } else {
-      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+      for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             float next = static_cast<float>(x[i]);
             vals[ii] = fmaxf(fabsf(vals[ii]), fabsf(next));
@@ -312,11 +312,31 @@ std::tuple<at::Tensor, at::Tensor> multi_tensor_l2norm_cuda(int chunk_size, at::
     ret_per_tensor = at::empty({0}, float_options);
   }
 
-  DISPATCH_FLOAT_HALF_AND_BFLOAT(
-      tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_cuda",
-      multi_tensor_apply<1>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, L2NormFunctor<scalar_t_0>(),
-                            output.data_ptr<float>(), per_tensor ? output_per_tensor.data_ptr<float>() : nullptr,
-                            per_tensor, max_chunks_per_tensor);)
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
+  if (requires_64bit_indexing) {
+    DISPATCH_FLOAT_HALF_AND_BFLOAT(
+        tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_cuda",
+        multi_tensor_apply<1>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                              L2NormFunctor<scalar_t_0, int64_t>(), output.data_ptr<float>(),
+                              per_tensor ? output_per_tensor.data_ptr<float>() : nullptr, per_tensor,
+                              max_chunks_per_tensor);)
+  } else {
+    DISPATCH_FLOAT_HALF_AND_BFLOAT(
+        tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_cuda",
+        multi_tensor_apply<1>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, L2NormFunctor<scalar_t_0, int32_t>(),
+                              output.data_ptr<float>(), per_tensor ? output_per_tensor.data_ptr<float>() : nullptr,
+                              per_tensor, max_chunks_per_tensor);)
+  }
 
   AT_CUDA_CHECK(cudaGetLastError());
   // AT_CUDA_CHECK(cudaDeviceSynchronize());
@@ -360,12 +380,32 @@ std::tuple<at::Tensor, at::Tensor> multi_tensor_unscale_l2norm_cuda(int chunk_si
     ret_per_tensor = at::empty({0}, float_options);
   }
 
-  DISPATCH_FLOAT_HALF_AND_BFLOAT(
-      tensor_lists[0][0].scalar_type(), 0, "multi_tensor_unscale_l2norm_cuda",
-      multi_tensor_apply<1>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, UnscaleL2NormFunctor<scalar_t_0>(),
-                            inv_scale.data_ptr<float>(), output.data_ptr<float>(),
-                            per_tensor ? output_per_tensor.data_ptr<float>() : nullptr, per_tensor,
-                            max_chunks_per_tensor);)
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
+  if (requires_64bit_indexing) {
+    DISPATCH_FLOAT_HALF_AND_BFLOAT(
+        tensor_lists[0][0].scalar_type(), 0, "multi_tensor_unscale_l2norm_cuda",
+        multi_tensor_apply<1>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                              UnscaleL2NormFunctor<scalar_t_0, int64_t>(), inv_scale.data_ptr<float>(),
+                              output.data_ptr<float>(), per_tensor ? output_per_tensor.data_ptr<float>() : nullptr,
+                              per_tensor, max_chunks_per_tensor);)
+  } else {
+    DISPATCH_FLOAT_HALF_AND_BFLOAT(
+        tensor_lists[0][0].scalar_type(), 0, "multi_tensor_unscale_l2norm_cuda",
+        multi_tensor_apply<1>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
+                              UnscaleL2NormFunctor<scalar_t_0, int32_t>(), inv_scale.data_ptr<float>(),
+                              output.data_ptr<float>(), per_tensor ? output_per_tensor.data_ptr<float>() : nullptr,
+                              per_tensor, max_chunks_per_tensor);)
+  }
 
   AT_CUDA_CHECK(cudaGetLastError());
   // AT_CUDA_CHECK(cudaDeviceSynchronize());
@@ -409,17 +449,43 @@ void multi_tensor_norm_out_cuda(int chunk_size, at::Tensor noop_flag, std::vecto
   // Since tailing element also participate cleanup
   output_per_tensor = at::zeros({ntensors * max_chunks_per_tensor}, float_options);
 
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
   if (norm_type == 0) {
-    DISPATCH_FLOAT_AND_HALF(tensor_lists[0][0].scalar_type(), 0, "multi_tensor_maxnorm_cuda",
-                            multi_tensor_apply<1>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
-                                                  MaxNormFunctor<scalar_t_0>(), output.data_ptr<float>(),
-                                                  output_per_tensor.data_ptr<float>(), true, max_chunks_per_tensor);)
+    if (requires_64bit_indexing) {
+      DISPATCH_FLOAT_AND_HALF(tensor_lists[0][0].scalar_type(), 0, "multi_tensor_maxnorm_cuda",
+                              multi_tensor_apply<1>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                                                    MaxNormFunctor<scalar_t_0, int64_t>(), output.data_ptr<float>(),
+                                                    output_per_tensor.data_ptr<float>(), true, max_chunks_per_tensor);)
+    } else {
+      DISPATCH_FLOAT_AND_HALF(tensor_lists[0][0].scalar_type(), 0, "multi_tensor_maxnorm_cuda",
+                              multi_tensor_apply<1>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
+                                                    MaxNormFunctor<scalar_t_0, int32_t>(), output.data_ptr<float>(),
+                                                    output_per_tensor.data_ptr<float>(), true, max_chunks_per_tensor);)
+    }
   } else {
-    DISPATCH_FLOAT_HALF_AND_BFLOAT(
-        tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_cuda",
-        multi_tensor_apply<1>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, L2NormFunctor<scalar_t_0>(),
-                              output.data_ptr<float>(), output_per_tensor.data_ptr<float>(), true,
-                              max_chunks_per_tensor);)
+    if (requires_64bit_indexing) {
+      DISPATCH_FLOAT_HALF_AND_BFLOAT(
+          tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_cuda",
+          multi_tensor_apply<1>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                                L2NormFunctor<scalar_t_0, int64_t>(), output.data_ptr<float>(),
+                                output_per_tensor.data_ptr<float>(), true, max_chunks_per_tensor);)
+    } else {
+      DISPATCH_FLOAT_HALF_AND_BFLOAT(
+          tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_cuda",
+          multi_tensor_apply<1>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, L2NormFunctor<scalar_t_0, int32_t>(),
+                                output.data_ptr<float>(), output_per_tensor.data_ptr<float>(), true,
+                                max_chunks_per_tensor);)
+    }
   }
   AT_CUDA_CHECK(cudaGetLastError());
 

--- a/csrc/multi_tensor_l2norm_kernel_mp.cu
+++ b/csrc/multi_tensor_l2norm_kernel_mp.cu
@@ -25,18 +25,18 @@ __device__ __forceinline__ void load_store(T* dst, T* src, int dst_offset, int s
   ((LT*)dst)[dst_offset] = ((LT*)src)[src_offset];
 }
 
-template <typename x_t>
+template <typename x_t, typename index_t>
 struct L2NormFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<1>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<1>& tl,
                                              float* output, float* output_per_tensor, bool per_tensor,
                                              int max_chunks_per_tensor) {
     if (*noop_gmem) {
       return;
     }
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     x_t* x = (x_t*)tl.addresses[0][tensor_loc];
     x += chunk_idx * chunk_size;
@@ -54,7 +54,7 @@ struct L2NormFunctor {
 
     // to make things simple, we put aligned case in a different code path
     if (n % ILP == 0 && chunk_size % ILP == 0 && is_aligned(x)) {
-      for (int i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
+      for (index_t i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
         // load
         load_store(r_x, x, 0, i_start);
 #pragma unroll
@@ -64,10 +64,10 @@ struct L2NormFunctor {
         }
       }
     } else {
-      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+      for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             float next = static_cast<float>(x[i]);
             vals[ii] += next * next;
@@ -143,11 +143,31 @@ std::tuple<at::Tensor, at::Tensor> multi_tensor_l2norm_mp_cuda(int chunk_size, a
     ret_per_tensor = at::empty({0}, float_options);
   }
 
-  DISPATCH_FLOAT_HALF_AND_BFLOAT(
-      tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_mp_cuda",
-      multi_tensor_apply<1>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, L2NormFunctor<scalar_t_0>(),
-                            output.data_ptr<float>(), per_tensor ? output_per_tensor.data_ptr<float>() : nullptr,
-                            per_tensor, max_chunks_per_tensor);)
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
+  if (requires_64bit_indexing) {
+    DISPATCH_FLOAT_HALF_AND_BFLOAT(
+        tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_mp_cuda",
+        multi_tensor_apply<1>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                              L2NormFunctor<scalar_t_0, int64_t>(), output.data_ptr<float>(),
+                              per_tensor ? output_per_tensor.data_ptr<float>() : nullptr, per_tensor,
+                              max_chunks_per_tensor);)
+  } else {
+    DISPATCH_FLOAT_HALF_AND_BFLOAT(
+        tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_mp_cuda",
+        multi_tensor_apply<1>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, L2NormFunctor<scalar_t_0, int32_t>(),
+                              output.data_ptr<float>(), per_tensor ? output_per_tensor.data_ptr<float>() : nullptr,
+                              per_tensor, max_chunks_per_tensor);)
+  }
 
   AT_CUDA_CHECK(cudaGetLastError());
   // AT_CUDA_CHECK(cudaDeviceSynchronize());

--- a/csrc/multi_tensor_l2norm_scale_kernel.cu
+++ b/csrc/multi_tensor_l2norm_scale_kernel.cu
@@ -25,18 +25,18 @@ __device__ __forceinline__ void load_store(T* dst, T* src, int dst_offset, int s
   ((LT*)dst)[dst_offset] = ((LT*)src)[src_offset];
 }
 
-template <typename in_t, typename out_t>
+template <typename in_t, typename out_t, typename index_t>
 struct L2NormScaleFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<2>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<2>& tl,
                                              float* output, float* output_per_tensor, float scale, bool per_tensor,
                                              int max_chunks_per_tensor) {
     // I'd like this kernel to propagate infs/nans.
     // if(*noop_gmem == 1)
     //   return;
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     in_t* in = (in_t*)tl.addresses[0][tensor_loc];
     in += chunk_idx * chunk_size;
@@ -59,7 +59,7 @@ struct L2NormScaleFunctor {
 
     // to make things simple, we put aligned case in a different code path
     if (n % ILP == 0 && chunk_size % ILP == 0 && is_aligned(in) && is_aligned(out)) {
-      for (int i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
+      for (index_t i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
         // load
         load_store(r_in, in, 0, i_start);
 #pragma unroll
@@ -72,11 +72,11 @@ struct L2NormScaleFunctor {
         load_store(out, r_out, i_start, 0);
       }
     } else {
-      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+      for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
           r_in[ii] = 0;
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             r_in[ii] = in[i];
             float next = static_cast<float>(in[i]);
@@ -90,7 +90,7 @@ struct L2NormScaleFunctor {
         }
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) out[i] = r_out[ii];
         }
       }
@@ -110,18 +110,18 @@ struct L2NormScaleFunctor {
   }
 };
 // Probably better to template, but since we are not likely to support other norm
-template <typename x_t>
+template <typename x_t, typename index_t>
 struct MaxNormFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<1>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<1>& tl,
                                              float* output, float* output_per_tensor, bool per_tensor,
                                              int max_chunks_per_tensor) {
     // I'd like this kernel to propagate infs/nans.
     // if(*noop_gmem == 1)
     //   return;
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     x_t* x = (x_t*)tl.addresses[0][tensor_loc];
     x += chunk_idx * chunk_size;
@@ -139,7 +139,7 @@ struct MaxNormFunctor {
 
     // to make things simple, we put aligned case in a different code path
     if (n % ILP == 0 && chunk_size % ILP == 0 && is_aligned(x)) {
-      for (int i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
+      for (index_t i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
         // load
         load_store(r_x, x, 0, i_start);
 #pragma unroll
@@ -149,10 +149,10 @@ struct MaxNormFunctor {
         }
       }
     } else {
-      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+      for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             float next = static_cast<float>(x[i]);
             vals[ii] = fmaxf(fabsf(vals[ii]), fabsf(next));
@@ -225,14 +225,36 @@ std::tuple<at::Tensor, at::Tensor> multi_tensor_l2norm_scale_cuda(int chunk_size
     ret_per_tensor = at::empty({0}, float_options);
   }
 
-  DISPATCH_FLOAT_AND_HALF(
-      tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_scale_cuda",
-      DISPATCH_FLOAT_AND_HALF(
-          tensor_lists[1][0].scalar_type(), 1, "multi_tensor_l2norm_scale_cuda",
-          multi_tensor_apply<2>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
-                                L2NormScaleFunctor<scalar_t_0, scalar_t_1>(), output.data_ptr<float>(),
-                                per_tensor ? output_per_tensor.data_ptr<float>() : nullptr, scale, per_tensor,
-                                max_chunks_per_tensor);))
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
+  if (requires_64bit_indexing) {
+    DISPATCH_FLOAT_AND_HALF(
+        tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_scale_cuda",
+        DISPATCH_FLOAT_AND_HALF(
+            tensor_lists[1][0].scalar_type(), 1, "multi_tensor_l2norm_scale_cuda",
+            multi_tensor_apply<2>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                                  L2NormScaleFunctor<scalar_t_0, scalar_t_1, int64_t>(), output.data_ptr<float>(),
+                                  per_tensor ? output_per_tensor.data_ptr<float>() : nullptr, scale, per_tensor,
+                                  max_chunks_per_tensor);))
+  } else {
+    DISPATCH_FLOAT_AND_HALF(
+        tensor_lists[0][0].scalar_type(), 0, "multi_tensor_l2norm_scale_cuda",
+        DISPATCH_FLOAT_AND_HALF(
+            tensor_lists[1][0].scalar_type(), 1, "multi_tensor_l2norm_scale_cuda",
+            multi_tensor_apply<2>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
+                                  L2NormScaleFunctor<scalar_t_0, scalar_t_1, int32_t>(), output.data_ptr<float>(),
+                                  per_tensor ? output_per_tensor.data_ptr<float>() : nullptr, scale, per_tensor,
+                                  max_chunks_per_tensor);))
+  }
 
   AT_CUDA_CHECK(cudaGetLastError());
   // AT_CUDA_CHECK(cudaDeviceSynchronize());

--- a/csrc/multi_tensor_lamb.cu
+++ b/csrc/multi_tensor_lamb.cu
@@ -35,9 +35,9 @@ std::tuple<at::Tensor, at::Tensor> multi_tensor_l2norm_cuda(int chunk_size, at::
 
 using MATH_T = float;
 
-template <typename T>
+template <typename T, typename index_t>
 struct LAMBStage1Functor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<4>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<4>& tl,
                                              const float beta1, const float beta2, const float beta3,
                                              const float beta1_correction, const float beta2_correction,
                                              const float epsilon, adamMode_t mode, const float decay,
@@ -46,9 +46,9 @@ struct LAMBStage1Functor {
     // if(*noop_gmem == 1)
     //   return;
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     float clipped_global_grad_norm =
         (*global_grad_norm) > max_global_grad_norm ? (*global_grad_norm) / max_global_grad_norm : 1.0f;
@@ -77,7 +77,7 @@ struct LAMBStage1Functor {
       T l_p[ILP];
       T l_m[ILP];
       T l_v[ILP];
-      for (int i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
+      for (index_t i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
         // load
         load_store(l_g, g, 0, i_start);
         if (decay != 0) load_store(l_p, p, 0, i_start);
@@ -130,14 +130,14 @@ struct LAMBStage1Functor {
       }
     } else {
       // see note in multi_tensor_scale_kernel.cu
-      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+      for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
         MATH_T r_g[ILP];
         MATH_T r_p[ILP];
         MATH_T r_m[ILP];
         MATH_T r_v[ILP];
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             r_g[ii] = g[i];
             // special ?optimization? for lamb stage 1
@@ -179,7 +179,7 @@ struct LAMBStage1Functor {
         }
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             g[i] = r_p[ii];
             m[i] = r_m[ii];
@@ -193,19 +193,19 @@ struct LAMBStage1Functor {
 
 // Step 2 reads in 'update' value and per-tensor param_norm and update_norm.
 // It computes new parameter value.
-template <typename T>
+template <typename T, typename index_t>
 struct LAMBStage2Functor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<2>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<2>& tl,
                                              const float* per_tensor_param_norm, const float* per_tensor_update_norm,
                                              const float learning_rate, const float decay, bool use_nvlamb) {
     // I'd like this kernel to propagate infs/nans.
     // if(*noop_gmem == 1)
     //   return;
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
     int tensor_num = tl.start_tensor_this_launch + tensor_loc;
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     MATH_T ratio = learning_rate;
     // nvlamb: apply adaptive learning rate to all parameters
@@ -228,7 +228,7 @@ struct LAMBStage2Functor {
     if (n % ILP == 0 && chunk_size % ILP == 0 && is_aligned(p) && is_aligned(update)) {
       T r_p[ILP];
       T r_update[ILP];
-      for (int i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
+      for (index_t i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
         // load
         load_store(r_p, p, 0, i_start);
         load_store(r_update, update, 0, i_start);
@@ -239,12 +239,12 @@ struct LAMBStage2Functor {
         load_store(p, r_p, i_start, 0);
       }
     } else {
-      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+      for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
         MATH_T r_p[ILP];
         MATH_T r_update[ILP];
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             r_p[ii] = p[i];
             r_update[ii] = update[i];
@@ -256,7 +256,7 @@ struct LAMBStage2Functor {
         }
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             p[i] = r_p[ii];
           }
@@ -294,26 +294,60 @@ void multi_tensor_lamb_cuda(int chunk_size, at::Tensor noop_flag, std::vector<st
   // Compute per tensor param norm
   auto param_norm_tuple = multi_tensor_l2norm_cuda(chunk_size, noop_flag, param_list, true);
 
-  // We now in-place modify grad to store update before compute its norm
-  // Generally this is not a issue since people modify grad in step() method all the time
-  // We can also grab list of empty tensor to avoid this, but I'd like to save space/cpu code
-  DISPATCH_FLOAT_AND_HALF(tensor_lists[0][0].scalar_type(), 0, "lamb_stage_1",
-                          multi_tensor_apply<4>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
-                                                LAMBStage1Functor<scalar_t_0>(), beta1, beta2,
-                                                beta3,  // 1-beta1 or 1 depends on averaging mode
-                                                bias_correction1, bias_correction2, epsilon, (adamMode_t)mode,
-                                                weight_decay, global_grad_norm.data_ptr<float>(), max_grad_norm);)
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
 
-  // Compute update norms
-  auto update_norm_tuple = multi_tensor_l2norm_cuda(chunk_size, noop_flag, grad_list, true);
+  if (requires_64bit_indexing) {
+    // We now in-place modify grad to store update before compute its norm
+    // Generally this is not a issue since people modify grad in step() method all the time
+    // We can also grab list of empty tensor to avoid this, but I'd like to save space/cpu code
+    DISPATCH_FLOAT_AND_HALF(tensor_lists[0][0].scalar_type(), 0, "lamb_stage_1",
+                            multi_tensor_apply<4>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                                                  LAMBStage1Functor<scalar_t_0, int64_t>(), beta1, beta2,
+                                                  beta3,  // 1-beta1 or 1 depends on averaging mode
+                                                  bias_correction1, bias_correction2, epsilon, (adamMode_t)mode,
+                                                  weight_decay, global_grad_norm.data_ptr<float>(), max_grad_norm);)
 
-  std::vector<std::vector<at::Tensor>> grad_param_list(tensor_lists.begin(), tensor_lists.begin() + 2);
+    // Compute update norms
+    auto update_norm_tuple = multi_tensor_l2norm_cuda(chunk_size, noop_flag, grad_list, true);
 
-  DISPATCH_FLOAT_AND_HALF(
-      tensor_lists[0][0].scalar_type(), 0, "lamb_stage_2",
-      multi_tensor_apply<2>(BLOCK_SIZE, chunk_size, noop_flag, grad_param_list, LAMBStage2Functor<scalar_t_0>(),
-                            std::get<1>(param_norm_tuple).data_ptr<float>(),
-                            std::get<1>(update_norm_tuple).data_ptr<float>(), lr, weight_decay, use_nvlamb);)
+    std::vector<std::vector<at::Tensor>> grad_param_list(tensor_lists.begin(), tensor_lists.begin() + 2);
+
+    DISPATCH_FLOAT_AND_HALF(
+        tensor_lists[0][0].scalar_type(), 0, "lamb_stage_2",
+        multi_tensor_apply<2>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, grad_param_list,
+                              LAMBStage2Functor<scalar_t_0, int64_t>(), std::get<1>(param_norm_tuple).data_ptr<float>(),
+                              std::get<1>(update_norm_tuple).data_ptr<float>(), lr, weight_decay, use_nvlamb);)
+  } else {
+    // We now in-place modify grad to store update before compute its norm
+    // Generally this is not a issue since people modify grad in step() method all the time
+    // We can also grab list of empty tensor to avoid this, but I'd like to save space/cpu code
+    DISPATCH_FLOAT_AND_HALF(tensor_lists[0][0].scalar_type(), 0, "lamb_stage_1",
+                            multi_tensor_apply<4>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
+                                                  LAMBStage1Functor<scalar_t_0, int32_t>(), beta1, beta2,
+                                                  beta3,  // 1-beta1 or 1 depends on averaging mode
+                                                  bias_correction1, bias_correction2, epsilon, (adamMode_t)mode,
+                                                  weight_decay, global_grad_norm.data_ptr<float>(), max_grad_norm);)
+
+    // Compute update norms
+    auto update_norm_tuple = multi_tensor_l2norm_cuda(chunk_size, noop_flag, grad_list, true);
+
+    std::vector<std::vector<at::Tensor>> grad_param_list(tensor_lists.begin(), tensor_lists.begin() + 2);
+
+    DISPATCH_FLOAT_AND_HALF(
+        tensor_lists[0][0].scalar_type(), 0, "lamb_stage_2",
+        multi_tensor_apply<2>(BLOCK_SIZE, chunk_size, noop_flag, grad_param_list,
+                              LAMBStage2Functor<scalar_t_0, int32_t>(), std::get<1>(param_norm_tuple).data_ptr<float>(),
+                              std::get<1>(update_norm_tuple).data_ptr<float>(), lr, weight_decay, use_nvlamb);)
+  }
 
   AT_CUDA_CHECK(cudaGetLastError());
 }

--- a/csrc/multi_tensor_lamb_mp.cu
+++ b/csrc/multi_tensor_lamb_mp.cu
@@ -35,9 +35,9 @@ std::tuple<at::Tensor, at::Tensor> multi_tensor_l2norm_mp_cuda(int chunk_size, a
 
 using MATH_T = float;
 
-template <typename T, typename param_t>
+template <typename T, typename param_t, typename index_t>
 struct LAMBStage1Functor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<4>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<4>& tl,
                                              const float beta1, const float beta2, const float beta3,
                                              const int* step_ptr, const int bias_correction, const float epsilon,
                                              adamMode_t mode, const float decay, const float* global_grad_norm,
@@ -55,9 +55,9 @@ struct LAMBStage1Functor {
       beta2_correction = 1 - std::pow(beta2, step);
     }
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     float clipped_global_grad_norm =
         (*global_grad_norm) > (*max_global_grad_norm) ? (*global_grad_norm) / (*max_global_grad_norm) : 1.0f;
@@ -86,7 +86,7 @@ struct LAMBStage1Functor {
       param_t l_p[ILP];
       param_t l_m[ILP];
       param_t l_v[ILP];
-      for (int i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
+      for (index_t i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
         // load
         load_store(l_g, g, 0, i_start);
         if (decay != 0) load_store(l_p, p, 0, i_start);
@@ -141,14 +141,14 @@ struct LAMBStage1Functor {
       }
     } else {
       // see note in multi_tensor_scale_kernel.cu
-      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+      for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
         MATH_T r_g[ILP];
         MATH_T r_p[ILP];
         MATH_T r_m[ILP];
         MATH_T r_v[ILP];
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             r_g[ii] = g[i] * (*inv_scale);
             // special ?optimization? for lamb stage 1
@@ -190,7 +190,7 @@ struct LAMBStage1Functor {
         }
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             g[i] = r_p[ii];
             m[i] = r_m[ii];
@@ -206,20 +206,20 @@ struct LAMBStage1Functor {
 // It computes new parameter value.
 // N == 2: FP32 params, no master params
 // N == 3: FP16 params, FP32 master params.
-template <typename T, int N, typename param_t>
+template <typename T, int N, typename param_t, typename index_t>
 struct LAMBStage2Functor {
   static_assert((N == 2 && std::is_same<T, param_t>::value) || (N == 3 && std::is_same<param_t, float>::value), "");
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<N>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<N>& tl,
                                              const float* per_tensor_param_norm, const float* per_tensor_update_norm,
                                              const float* learning_rate, const float decay, bool use_nvlamb) {
     if (*noop_gmem) {
       return;
     }
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
     int tensor_num = tl.start_tensor_this_launch + tensor_loc;
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     MATH_T ratio = *learning_rate;
     // nvlamb: apply adaptive learning rate to all parameters
@@ -254,7 +254,7 @@ struct LAMBStage2Functor {
       param_t r_p[ILP];
       T r_update[ILP];
       T r_out_p[ILP];
-      for (int i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
+      for (index_t i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
         // load
         load_store(r_p, p, 0, i_start);
         load_store(r_update, update, 0, i_start);
@@ -274,12 +274,12 @@ struct LAMBStage2Functor {
         }
       }
     } else {
-      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+      for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
         MATH_T r_p[ILP];
         MATH_T r_update[ILP];
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             r_p[ii] = p[i];
             r_update[ii] = update[i];
@@ -291,7 +291,7 @@ struct LAMBStage2Functor {
         }
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) {
             p[i] = r_p[ii];
             if (N == 3) {
@@ -330,6 +330,17 @@ void multi_tensor_lamb_mp_cuda(int chunk_size, at::Tensor noop_flag, std::vector
   float beta3 = 1.0f;
   if (grad_averaging == 1) beta3 = 1 - beta1;
 
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
   std::vector<std::vector<at::Tensor>> stage1_tensor_lists(tensor_lists.begin(), tensor_lists.begin() + 4);
   std::vector<std::vector<at::Tensor>> grad_list(tensor_lists.begin(), tensor_lists.begin() + 1);
   std::vector<std::vector<at::Tensor>> param_list(tensor_lists.begin() + 1, tensor_lists.begin() + 2);
@@ -340,49 +351,86 @@ void multi_tensor_lamb_mp_cuda(int chunk_size, at::Tensor noop_flag, std::vector
   // We now in-place modify grad to store update before compute its norm
   // Generally this is not a issue since people modify grad in step() method all the time
   // We can also grab list of empty tensor to avoid this, but I'd like to save space/cpu code
-  if (n_tensors == 4) {
-    DISPATCH_FLOAT_AND_HALF(
-        tensor_lists[0][0].scalar_type(), 0, "lamb_stage_1",
-        multi_tensor_apply<4>(BLOCK_SIZE, chunk_size, noop_flag, stage1_tensor_lists,
-                              LAMBStage1Functor<scalar_t_0, scalar_t_0>(), beta1, beta2,
-                              beta3,  // 1-beta1 or 1 depends on averaging mode
-                              // bias_correction1,
-                              // bias_correction2,
-                              step.data_ptr<int>(), bias_correction, epsilon, (adamMode_t)mode, weight_decay,
-                              global_grad_norm.data_ptr<float>(), max_grad_norm.data_ptr<float>(),
-                              found_inf.data_ptr<float>(), inv_scale.data_ptr<float>());)
+  if (requires_64bit_indexing) {
+    if (n_tensors == 4) {
+      DISPATCH_FLOAT_AND_HALF(
+          tensor_lists[0][0].scalar_type(), 0, "lamb_stage_1",
+          multi_tensor_apply<4>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, stage1_tensor_lists,
+                                LAMBStage1Functor<scalar_t_0, scalar_t_0, int64_t>(), beta1, beta2,
+                                beta3,  // 1-beta1 or 1 depends on averaging mode
+                                step.data_ptr<int>(), bias_correction, epsilon, (adamMode_t)mode, weight_decay,
+                                global_grad_norm.data_ptr<float>(), max_grad_norm.data_ptr<float>(),
+                                found_inf.data_ptr<float>(), inv_scale.data_ptr<float>());)
+    } else {
+      DISPATCH_FLOAT_HALF_AND_BFLOAT(
+          tensor_lists[0][0].scalar_type(), 0, "lamb_stage_1",
+          multi_tensor_apply<4>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, stage1_tensor_lists,
+                                LAMBStage1Functor<scalar_t_0, float, int64_t>(), beta1, beta2,
+                                beta3,  // 1-beta1 or 1 depends on averaging mode
+                                step.data_ptr<int>(), bias_correction, epsilon, (adamMode_t)mode, weight_decay,
+                                global_grad_norm.data_ptr<float>(), max_grad_norm.data_ptr<float>(),
+                                found_inf.data_ptr<float>(), inv_scale.data_ptr<float>());)
+    }
   } else {
-    DISPATCH_FLOAT_HALF_AND_BFLOAT(
-        tensor_lists[0][0].scalar_type(), 0, "lamb_stage_1",
-        multi_tensor_apply<4>(BLOCK_SIZE, chunk_size, noop_flag, stage1_tensor_lists,
-                              LAMBStage1Functor<scalar_t_0, float>(), beta1, beta2,
-                              beta3,  // 1-beta1 or 1 depends on averaging mode
-                              // bias_correction1,
-                              // bias_correction2,
-                              step.data_ptr<int>(), bias_correction, epsilon, (adamMode_t)mode, weight_decay,
-                              global_grad_norm.data_ptr<float>(), max_grad_norm.data_ptr<float>(),
-                              found_inf.data_ptr<float>(), inv_scale.data_ptr<float>());)
+    if (n_tensors == 4) {
+      DISPATCH_FLOAT_AND_HALF(
+          tensor_lists[0][0].scalar_type(), 0, "lamb_stage_1",
+          multi_tensor_apply<4>(BLOCK_SIZE, chunk_size, noop_flag, stage1_tensor_lists,
+                                LAMBStage1Functor<scalar_t_0, scalar_t_0, int32_t>(), beta1, beta2,
+                                beta3,  // 1-beta1 or 1 depends on averaging mode
+                                step.data_ptr<int>(), bias_correction, epsilon, (adamMode_t)mode, weight_decay,
+                                global_grad_norm.data_ptr<float>(), max_grad_norm.data_ptr<float>(),
+                                found_inf.data_ptr<float>(), inv_scale.data_ptr<float>());)
+    } else {
+      DISPATCH_FLOAT_HALF_AND_BFLOAT(
+          tensor_lists[0][0].scalar_type(), 0, "lamb_stage_1",
+          multi_tensor_apply<4>(BLOCK_SIZE, chunk_size, noop_flag, stage1_tensor_lists,
+                                LAMBStage1Functor<scalar_t_0, float, int32_t>(), beta1, beta2,
+                                beta3,  // 1-beta1 or 1 depends on averaging mode
+                                step.data_ptr<int>(), bias_correction, epsilon, (adamMode_t)mode, weight_decay,
+                                global_grad_norm.data_ptr<float>(), max_grad_norm.data_ptr<float>(),
+                                found_inf.data_ptr<float>(), inv_scale.data_ptr<float>());)
+    }
   }
 
   // Compute update norms
   auto update_norm_tuple = multi_tensor_l2norm_mp_cuda(chunk_size, noop_flag, grad_list, true);
 
   std::vector<std::vector<at::Tensor>> grad_param_list(tensor_lists.begin(), tensor_lists.begin() + 2);
-  if (n_tensors == 4) {
-    DISPATCH_FLOAT_AND_HALF(tensor_lists[0][0].scalar_type(), 0, "lamb_stage_2",
-                            multi_tensor_apply<2>(BLOCK_SIZE, chunk_size, noop_flag, grad_param_list,
-                                                  LAMBStage2Functor<scalar_t_0, 2, scalar_t_0>(),
-                                                  std::get<1>(param_norm_tuple).data_ptr<float>(),
-                                                  std::get<1>(update_norm_tuple).data_ptr<float>(),
-                                                  lr.data_ptr<float>(), weight_decay, use_nvlamb);)
+  if (requires_64bit_indexing) {
+    if (n_tensors == 4) {
+      DISPATCH_FLOAT_AND_HALF(
+          tensor_lists[0][0].scalar_type(), 0, "lamb_stage_2",
+          multi_tensor_apply<2>(
+              (int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, grad_param_list,
+              LAMBStage2Functor<scalar_t_0, 2, scalar_t_0, int64_t>(), std::get<1>(param_norm_tuple).data_ptr<float>(),
+              std::get<1>(update_norm_tuple).data_ptr<float>(), lr.data_ptr<float>(), weight_decay, use_nvlamb);)
+    } else {
+      grad_param_list.push_back(tensor_lists[4]);
+      DISPATCH_FLOAT_HALF_AND_BFLOAT(
+          tensor_lists[0][0].scalar_type(), 0, "lamb_stage_2",
+          multi_tensor_apply<3>(
+              (int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, grad_param_list,
+              LAMBStage2Functor<scalar_t_0, 3, float, int64_t>(), std::get<1>(param_norm_tuple).data_ptr<float>(),
+              std::get<1>(update_norm_tuple).data_ptr<float>(), lr.data_ptr<float>(), weight_decay, use_nvlamb);)
+    }
   } else {
-    grad_param_list.push_back(tensor_lists[4]);
-    DISPATCH_FLOAT_HALF_AND_BFLOAT(tensor_lists[0][0].scalar_type(), 0, "lamb_stage_2",
-                                   multi_tensor_apply<3>(BLOCK_SIZE, chunk_size, noop_flag, grad_param_list,
-                                                         LAMBStage2Functor<scalar_t_0, 3, float>(),
-                                                         std::get<1>(param_norm_tuple).data_ptr<float>(),
-                                                         std::get<1>(update_norm_tuple).data_ptr<float>(),
-                                                         lr.data_ptr<float>(), weight_decay, use_nvlamb);)
+    if (n_tensors == 4) {
+      DISPATCH_FLOAT_AND_HALF(tensor_lists[0][0].scalar_type(), 0, "lamb_stage_2",
+                              multi_tensor_apply<2>(BLOCK_SIZE, chunk_size, noop_flag, grad_param_list,
+                                                    LAMBStage2Functor<scalar_t_0, 2, scalar_t_0, int32_t>(),
+                                                    std::get<1>(param_norm_tuple).data_ptr<float>(),
+                                                    std::get<1>(update_norm_tuple).data_ptr<float>(),
+                                                    lr.data_ptr<float>(), weight_decay, use_nvlamb);)
+    } else {
+      grad_param_list.push_back(tensor_lists[4]);
+      DISPATCH_FLOAT_HALF_AND_BFLOAT(tensor_lists[0][0].scalar_type(), 0, "lamb_stage_2",
+                                     multi_tensor_apply<3>(BLOCK_SIZE, chunk_size, noop_flag, grad_param_list,
+                                                           LAMBStage2Functor<scalar_t_0, 3, float, int32_t>(),
+                                                           std::get<1>(param_norm_tuple).data_ptr<float>(),
+                                                           std::get<1>(update_norm_tuple).data_ptr<float>(),
+                                                           lr.data_ptr<float>(), weight_decay, use_nvlamb);)
+    }
   }
   AT_CUDA_CHECK(cudaGetLastError());
 }

--- a/csrc/multi_tensor_lamb_stage_1.cu
+++ b/csrc/multi_tensor_lamb_stage_1.cu
@@ -14,9 +14,9 @@
 #define ILP 4
 
 // Step 1 computes the 'update' value of regular Adam optimizer.
-template <typename GRAD_T, typename T, typename UPD_T>
+template <typename GRAD_T, typename T, typename UPD_T, typename index_t>
 struct LAMBStage1Functor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<5>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<5>& tl,
                                              const float* per_tensor_decay, const float beta1, const float beta2,
                                              const float beta1_correction, const float beta2_correction,
                                              const float epsilon, const float clipped_global_grad_norm) {
@@ -24,10 +24,10 @@ struct LAMBStage1Functor {
     // if(*noop_gmem == 1)
     //   return;
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
     int tensor_num = tl.start_tensor_this_launch + tensor_loc;
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     float decay = per_tensor_decay[tensor_num];
 
@@ -49,14 +49,14 @@ struct LAMBStage1Functor {
     n -= chunk_idx * chunk_size;
 
     // see note in multi_tensor_scale_kernel.cu
-    for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+    for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
       GRAD_T r_g[ILP];
       T r_p[ILP];
       T r_m[ILP];
       T r_v[ILP];
 #pragma unroll
       for (int ii = 0; ii < ILP; ii++) {
-        int i = i_start + threadIdx.x + ii * blockDim.x;
+        index_t i = i_start + threadIdx.x + ii * blockDim.x;
         if (i < n && i < chunk_size) {
           r_g[ii] = g[i];
           r_p[ii] = p[i];
@@ -81,7 +81,7 @@ struct LAMBStage1Functor {
       }
 #pragma unroll
       for (int ii = 0; ii < ILP; ii++) {
-        int i = i_start + threadIdx.x + ii * blockDim.x;
+        index_t i = i_start + threadIdx.x + ii * blockDim.x;
         if (i < n && i < chunk_size) {
           update[i] = (UPD_T)r_p[ii];
           m[i] = r_m[ii];
@@ -103,16 +103,41 @@ void multi_tensor_lamb_stage1_cuda(int chunk_size, at::Tensor noop_flag,
   float next_step = float(step + 1);
   float beta1_correction = 1.0f - std::pow(beta1, next_step);
   float beta2_correction = 1.0f - std::pow(beta2, next_step);
-  DISPATCH_FLOAT_AND_HALF(
-      tensor_lists[0][0].scalar_type(), 0, "lamb_stage_1",
-      DISPATCH_FLOAT_AND_HALF(
-          tensor_lists[1][0].scalar_type(), 1, "lamb_stage_1",
-          DISPATCH_FLOAT_AND_HALF(
-              tensor_lists[4][0].scalar_type(), 2, "lamb_stage_1",
-              multi_tensor_apply<5>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
-                                    LAMBStage1Functor<scalar_t_0, scalar_t_1, scalar_t_2>(),
-                                    per_tensor_decay.data_ptr<float>(), beta1, beta2, beta1_correction,
-                                    beta2_correction, epsilon, clipped_global_grad_norm);)))
+
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
+  if (requires_64bit_indexing) {
+    DISPATCH_FLOAT_AND_HALF(
+        tensor_lists[0][0].scalar_type(), 0, "lamb_stage_1",
+        DISPATCH_FLOAT_AND_HALF(
+            tensor_lists[1][0].scalar_type(), 1, "lamb_stage_1",
+            DISPATCH_FLOAT_AND_HALF(
+                tensor_lists[4][0].scalar_type(), 2, "lamb_stage_1",
+                multi_tensor_apply<5>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                                      LAMBStage1Functor<scalar_t_0, scalar_t_1, scalar_t_2, int64_t>(),
+                                      per_tensor_decay.data_ptr<float>(), beta1, beta2, beta1_correction,
+                                      beta2_correction, epsilon, clipped_global_grad_norm);)))
+  } else {
+    DISPATCH_FLOAT_AND_HALF(
+        tensor_lists[0][0].scalar_type(), 0, "lamb_stage_1",
+        DISPATCH_FLOAT_AND_HALF(
+            tensor_lists[1][0].scalar_type(), 1, "lamb_stage_1",
+            DISPATCH_FLOAT_AND_HALF(
+                tensor_lists[4][0].scalar_type(), 2, "lamb_stage_1",
+                multi_tensor_apply<5>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
+                                      LAMBStage1Functor<scalar_t_0, scalar_t_1, scalar_t_2, int32_t>(),
+                                      per_tensor_decay.data_ptr<float>(), beta1, beta2, beta1_correction,
+                                      beta2_correction, epsilon, clipped_global_grad_norm);)))
+  }
 
   AT_CUDA_CHECK(cudaGetLastError());
 

--- a/csrc/multi_tensor_lamb_stage_2.cu
+++ b/csrc/multi_tensor_lamb_stage_2.cu
@@ -17,19 +17,19 @@ using MATH_T = float;
 
 // Step 2 reads in 'update' value and per-tensor param_norm and update_norm.
 // It computes new parameter value.
-template <typename T, typename UPD_T>
+template <typename T, typename UPD_T, typename index_t>
 struct LAMBStage2Functor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<2>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<2>& tl,
                                              const float* per_tensor_param_norm, const float* per_tensor_update_norm,
                                              const float learning_rate, const float decay, bool use_nvlamb) {
     // I'd like this kernel to propagate infs/nans.
     // if(*noop_gmem == 1)
     //   return;
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
     int tensor_num = tl.start_tensor_this_launch + tensor_loc;
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     MATH_T ratio = learning_rate;
     // nvlamb: apply adaptive learning rate to all parameters
@@ -48,12 +48,12 @@ struct LAMBStage2Functor {
 
     n -= chunk_idx * chunk_size;
 
-    for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+    for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
       T r_p[ILP];
       UPD_T r_update[ILP];
 #pragma unroll
       for (int ii = 0; ii < ILP; ii++) {
-        int i = i_start + threadIdx.x + ii * blockDim.x;
+        index_t i = i_start + threadIdx.x + ii * blockDim.x;
         if (i < n && i < chunk_size) {
           r_p[ii] = p[i];
           r_update[ii] = update[i];
@@ -65,7 +65,7 @@ struct LAMBStage2Functor {
       }
 #pragma unroll
       for (int ii = 0; ii < ILP; ii++) {
-        int i = i_start + threadIdx.x + ii * blockDim.x;
+        index_t i = i_start + threadIdx.x + ii * blockDim.x;
         if (i < n && i < chunk_size) {
           p[i] = r_p[ii];
         }
@@ -82,13 +82,36 @@ void multi_tensor_lamb_stage2_cuda(int chunk_size, at::Tensor noop_flag,
 
   using namespace at;
 
-  DISPATCH_FLOAT_AND_HALF(
-      tensor_lists[0][0].scalar_type(), 0, "lamb_stage_2",
-      DISPATCH_FLOAT_AND_HALF(
-          tensor_lists[1][0].scalar_type(), 1, "lamb_stage_2",
-          multi_tensor_apply<2>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
-                                LAMBStage2Functor<scalar_t_0, scalar_t_1>(), per_tensor_param_norm.data_ptr<float>(),
-                                per_tensor_update_norm.data_ptr<float>(), lr, weight_decay, use_nvlamb);))
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
+  if (requires_64bit_indexing) {
+    DISPATCH_FLOAT_AND_HALF(
+        tensor_lists[0][0].scalar_type(), 0, "lamb_stage_2",
+        DISPATCH_FLOAT_AND_HALF(
+            tensor_lists[1][0].scalar_type(), 1, "lamb_stage_2",
+            multi_tensor_apply<2>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                                  LAMBStage2Functor<scalar_t_0, scalar_t_1, int64_t>(),
+                                  per_tensor_param_norm.data_ptr<float>(), per_tensor_update_norm.data_ptr<float>(), lr,
+                                  weight_decay, use_nvlamb);))
+  } else {
+    DISPATCH_FLOAT_AND_HALF(
+        tensor_lists[0][0].scalar_type(), 0, "lamb_stage_2",
+        DISPATCH_FLOAT_AND_HALF(
+            tensor_lists[1][0].scalar_type(), 1, "lamb_stage_2",
+            multi_tensor_apply<2>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
+                                  LAMBStage2Functor<scalar_t_0, scalar_t_1, int32_t>(),
+                                  per_tensor_param_norm.data_ptr<float>(), per_tensor_update_norm.data_ptr<float>(), lr,
+                                  weight_decay, use_nvlamb);))
+  }
 
   AT_CUDA_CHECK(cudaGetLastError());
 

--- a/csrc/multi_tensor_novograd.cu
+++ b/csrc/multi_tensor_novograd.cu
@@ -23,9 +23,9 @@ void multi_tensor_norm_out_cuda(int chunk_size, at::Tensor noop_flag, std::vecto
 
 using MATH_T = float;
 
-template <typename T>
+template <typename T, typename index_t>
 struct NovoGradFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<3>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<3>& tl,
                                              const float beta1, const float beta2, const float beta3,
                                              const float beta1_correction, const float beta2_correction,
                                              const float epsilon, const float lr, momentMode_t m_mode,
@@ -34,10 +34,10 @@ struct NovoGradFunctor {
     // if(*noop_gmem == 1)
     //   return;
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
     int tensor_num = tl.start_tensor_this_launch + tensor_loc;
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     float grad_norm = per_tensor_grad_norm[tensor_num];
 
@@ -53,13 +53,13 @@ struct NovoGradFunctor {
     n -= chunk_idx * chunk_size;
 
     // see note in multi_tensor_scale_kernel.cu
-    for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+    for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
       MATH_T r_g[ILP];
       MATH_T r_p[ILP];
       MATH_T r_m[ILP];
 #pragma unroll
       for (int ii = 0; ii < ILP; ii++) {
-        int i = i_start + threadIdx.x + ii * blockDim.x;
+        index_t i = i_start + threadIdx.x + ii * blockDim.x;
         if (i < n && i < chunk_size) {
           r_g[ii] = g[i];
           r_p[ii] = p[i];
@@ -90,7 +90,7 @@ struct NovoGradFunctor {
       }
 #pragma unroll
       for (int ii = 0; ii < ILP; ii++) {
-        int i = i_start + threadIdx.x + ii * blockDim.x;
+        index_t i = i_start + threadIdx.x + ii * blockDim.x;
         if (i < n && i < chunk_size) {
           p[i] = r_p[ii];
           m[i] = r_m[ii];
@@ -126,14 +126,36 @@ void multi_tensor_novograd_cuda(int chunk_size, at::Tensor noop_flag, std::vecto
   // L-inf: gn = a * gn + b * n
   multi_tensor_norm_out_cuda(chunk_size, noop_flag, grad_list, grad_norms, beta2, (1.0f - beta2), norm_type);
 
-  // Assume single type across p,g,m1,m2 now
-  DISPATCH_DOUBLE_FLOAT_AND_HALF(
-      tensor_lists[0][0].scalar_type(), 0, "novograd",
-      multi_tensor_apply<3>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, NovoGradFunctor<scalar_t_0>(), beta1,
-                            beta2,
-                            beta3,  // 1-beta1 or 1 depends on averaging mode
-                            bias_correction1, bias_correction2, epsilon, lr, (momentMode_t)moment_mode, weight_decay,
-                            grad_norms.data_ptr<float>());)
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
+  if (requires_64bit_indexing) {
+    // Assume single type across p,g,m1,m2 now
+    DISPATCH_DOUBLE_FLOAT_AND_HALF(
+        tensor_lists[0][0].scalar_type(), 0, "novograd",
+        multi_tensor_apply<3>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                              NovoGradFunctor<scalar_t_0, int64_t>(), beta1, beta2,
+                              beta3,  // 1-beta1 or 1 depends on averaging mode
+                              bias_correction1, bias_correction2, epsilon, lr, (momentMode_t)moment_mode, weight_decay,
+                              grad_norms.data_ptr<float>());)
+  } else {
+    // Assume single type across p,g,m1,m2 now
+    DISPATCH_DOUBLE_FLOAT_AND_HALF(
+        tensor_lists[0][0].scalar_type(), 0, "novograd",
+        multi_tensor_apply<3>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, NovoGradFunctor<scalar_t_0, int32_t>(),
+                              beta1, beta2,
+                              beta3,  // 1-beta1 or 1 depends on averaging mode
+                              bias_correction1, bias_correction2, epsilon, lr, (momentMode_t)moment_mode, weight_decay,
+                              grad_norms.data_ptr<float>());)
+  }
 
   AT_CUDA_CHECK(cudaGetLastError());
 }

--- a/csrc/multi_tensor_scale_kernel.cu
+++ b/csrc/multi_tensor_scale_kernel.cu
@@ -26,17 +26,17 @@ __device__ __forceinline__ void load_store(T* dst, T* src, int dst_offset, int s
   ((LT*)dst)[dst_offset] = ((LT*)src)[src_offset];
 }
 
-template <typename in_t, typename out_t>
+template <typename in_t, typename out_t, typename index_t>
 struct ScaleFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<2>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<2>& tl,
                                              float scale) {
     // I'd like this kernel to propagate infs/nans.
     // if(*noop_gmem == 1)
     //   return;
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     in_t* in = (in_t*)tl.addresses[0][tensor_loc];
     in += chunk_idx * chunk_size;
@@ -52,7 +52,7 @@ struct ScaleFunctor {
 
     // to make things simple, we put aligned case in a different code path
     if (n % ILP == 0 && chunk_size % ILP == 0 && is_aligned(in) && is_aligned(out)) {
-      for (int i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
+      for (index_t i_start = threadIdx.x; i_start * ILP < n && i_start * ILP < chunk_size; i_start += blockDim.x) {
         // load
         load_store(r_in, in, 0, i_start);
 #pragma unroll
@@ -65,11 +65,11 @@ struct ScaleFunctor {
       }
     } else {
       // Non-divergent exit condition for __syncthreads, not necessary here
-      for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+      for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
           r_in[ii] = 0;
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) r_in[ii] = in[i];
         }
         // note for clarification to future michael:
@@ -84,7 +84,7 @@ struct ScaleFunctor {
         }
 #pragma unroll
         for (int ii = 0; ii < ILP; ii++) {
-          int i = i_start + threadIdx.x + ii * blockDim.x;
+          index_t i = i_start + threadIdx.x + ii * blockDim.x;
           if (i < n && i < chunk_size) out[i] = r_out[ii];
         }
       }
@@ -100,11 +100,31 @@ void multi_tensor_scale_cuda(int chunk_size, at::Tensor noop_flag, std::vector<s
   // If build times suffer, think about where to put this dispatch,
   // and what logic should be moved out of multi_tensor_apply.
 
-  DISPATCH_FLOAT_HALF_AND_BFLOAT(
-      tensor_lists[0][0].scalar_type(), 0, "multi_tensor_scale_cuda",
-      DISPATCH_FLOAT_HALF_AND_BFLOAT(tensor_lists[1][0].scalar_type(), 1, "multi_tensor_scale_cuda",
-                                     multi_tensor_apply<2>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
-                                                           ScaleFunctor<scalar_t_0, scalar_t_1>(), scale);))
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
+  if (requires_64bit_indexing) {
+    DISPATCH_FLOAT_HALF_AND_BFLOAT(
+        tensor_lists[0][0].scalar_type(), 0, "multi_tensor_scale_cuda",
+        DISPATCH_FLOAT_HALF_AND_BFLOAT(
+            tensor_lists[1][0].scalar_type(), 1, "multi_tensor_scale_cuda",
+            multi_tensor_apply<2>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                                  ScaleFunctor<scalar_t_0, scalar_t_1, int64_t>(), scale);))
+  } else {
+    DISPATCH_FLOAT_HALF_AND_BFLOAT(
+        tensor_lists[0][0].scalar_type(), 0, "multi_tensor_scale_cuda",
+        DISPATCH_FLOAT_HALF_AND_BFLOAT(tensor_lists[1][0].scalar_type(), 1, "multi_tensor_scale_cuda",
+                                       multi_tensor_apply<2>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
+                                                             ScaleFunctor<scalar_t_0, scalar_t_1, int32_t>(), scale);))
+  }
   AT_CUDA_CHECK(cudaGetLastError());
 
   // AT_CUDA_CHECK(cudaDeviceSynchronize());

--- a/csrc/multi_tensor_sgd_kernel.cu
+++ b/csrc/multi_tensor_sgd_kernel.cu
@@ -25,17 +25,17 @@
  * first run : necessary for proper momentum handling & init
  * wd_after_momentum : apply weight decay _after_ momentum instead of before
  **/
-template <int N, typename T_grad, typename T_weight>
+template <int N, typename T_grad, typename T_weight, typename index_t>
 struct SGDFunctor {
-  __device__ __forceinline__ void operator()(int chunk_size, volatile int* noop_gmem, TensorListMetadata<N>& tl,
+  __device__ __forceinline__ void operator()(index_t chunk_size, volatile int* noop_gmem, TensorListMetadata<N>& tl,
                                              float wd, float momentum, float dampening, float lr, bool nesterov,
                                              bool first_run, bool wd_after_momentum, float scale) {
     // Early exit if we don't need to do anything
     if (*noop_gmem) return;
 
-    int tensor_loc = tl.block_to_tensor[blockIdx.x];
-    int chunk_idx = tl.block_to_chunk[blockIdx.x];
-    int n = tl.sizes[tensor_loc];
+    index_t tensor_loc = tl.block_to_tensor[blockIdx.x];
+    index_t chunk_idx = tl.block_to_chunk[blockIdx.x];
+    index_t n = tl.sizes[tensor_loc];
 
     T_grad* grad_in = (T_grad*)tl.addresses[0][tensor_loc];
     grad_in += chunk_idx * chunk_size;
@@ -58,13 +58,13 @@ struct SGDFunctor {
     float incoming_grads[ILP];
     float incoming_weights[ILP];
     float incoming_moms[ILP];
-    for (int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
+    for (index_t i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * ILP) {
 #pragma unroll
       for (int ii = 0; ii < ILP; ii++) {
         incoming_grads[ii] = 0;
         incoming_weights[ii] = 0;
         incoming_moms[ii] = 0;
-        int i = i_start + threadIdx.x + ii * blockDim.x;
+        index_t i = i_start + threadIdx.x + ii * blockDim.x;
         if (i < n && i < chunk_size) {
           incoming_grads[ii] = static_cast<float>(grad_in[i]) * scale;
           incoming_weights[ii] = static_cast<float>(weight_in[i]);
@@ -79,7 +79,7 @@ struct SGDFunctor {
 // There is still compute ILP benefit from unrolling the loop though.
 #pragma unroll
       for (int ii = 0; ii < ILP; ii++) {
-        int i = i_start + threadIdx.x + ii * blockDim.x;
+        index_t i = i_start + threadIdx.x + ii * blockDim.x;
         if (i < n && i < chunk_size) {
           // apply weight decay before momentum if necessary
           if (wd != 0.f && !wd_after_momentum) incoming_grads[ii] += wd * incoming_weights[ii];
@@ -128,6 +128,17 @@ void multi_tensor_sgd_cuda(int chunk_size, at::Tensor noop_flag, std::vector<std
   TORCH_CHECK(noop_flag.device() == tensor_lists[0][0].device(),
               "expected noop flag to be on the same device as tensors");
 
+  bool requires_64bit_indexing = false;
+  for (auto it = tensor_lists.begin(); it != tensor_lists.end(); it++) {
+    for (auto it2 = it->begin(); it2 != it->end(); it2++) {
+      if (it2->numel() >= INT_MAX) {
+        requires_64bit_indexing = true;
+        break;
+      }
+    }
+    if (requires_64bit_indexing) break;
+  }
+
   // We have 3 possibilities to handle here, in terms of
   // grad_type, param_type, momentum_type, requires_fp16_copy
   // 1. fp16, fp16, fp16, No
@@ -138,46 +149,59 @@ void multi_tensor_sgd_cuda(int chunk_size, at::Tensor noop_flag, std::vector<std
   // switches etc. to handle the cross-product of cases where
   // we don't want the majority of them.
 
-  // Case 1. fp16, fp16, fp16, No
-  if (grad_type == at::ScalarType::Half && weight_type == at::ScalarType::Half && num_tensors == 3) {
-    multi_tensor_apply<3>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, SGDFunctor<3, at::Half, at::Half>(), wd,
-                          momentum, dampening, lr, nesterov, first_run, wd_after_momentum, scale);
-  }
-  // Case 2. fp16, fp32, fp32, No
-  // else if (grad_type == at::ScalarType::Half &&
-  //          weight_type == at::ScalarType::Float &&
-  //          num_tensors == 3) {
-  //   multi_tensor_apply<3>(
-  //       BLOCK_SIZE,
-  //       chunk_size,
-  //       noop_flag,
-  //       tensor_lists,
-  //       SGDFunctor<3, at::Half, float>(),
-  //       wd,
-  //       momentum,
-  //       dampening,
-  //       lr,
-  //       nesterov,
-  //       first_run,
-  //       wd_after_momentum);
-  // }
-  // Case 2. fp32, fp32, fp32, No
-  else if (grad_type == at::ScalarType::Float && weight_type == at::ScalarType::Float && num_tensors == 3) {
-    multi_tensor_apply<3>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, SGDFunctor<3, float, float>(), wd, momentum,
-                          dampening, lr, nesterov, first_run, wd_after_momentum, scale);
-  }
-  // Case 3. fp16, fp32, fp32, Yes
-  else if (grad_type == at::ScalarType::Half && weight_type == at::ScalarType::Float && num_tensors == 4) {
-    multi_tensor_apply<4>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, SGDFunctor<4, at::Half, float>(), wd,
-                          momentum, dampening, lr, nesterov, first_run, wd_after_momentum, scale);
-  }
-  // Case 4. fp32, fp32, fp32, Yes
-  else if (grad_type == at::ScalarType::Float && weight_type == at::ScalarType::Float && num_tensors == 4) {
-    multi_tensor_apply<4>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, SGDFunctor<4, float, float>(), wd, momentum,
-                          dampening, lr, nesterov, first_run, wd_after_momentum, scale);
+  if (requires_64bit_indexing) {
+    // Case 1. fp16, fp16, fp16, No
+    if (grad_type == at::ScalarType::Half && weight_type == at::ScalarType::Half && num_tensors == 3) {
+      multi_tensor_apply<3>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                            SGDFunctor<3, at::Half, at::Half, int64_t>(), wd, momentum, dampening, lr, nesterov,
+                            first_run, wd_after_momentum, scale);
+    }
+    // Case 2. fp32, fp32, fp32, No
+    else if (grad_type == at::ScalarType::Float && weight_type == at::ScalarType::Float && num_tensors == 3) {
+      multi_tensor_apply<3>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                            SGDFunctor<3, float, float, int64_t>(), wd, momentum, dampening, lr, nesterov, first_run,
+                            wd_after_momentum, scale);
+    }
+    // Case 3. fp16, fp32, fp32, Yes
+    else if (grad_type == at::ScalarType::Half && weight_type == at::ScalarType::Float && num_tensors == 4) {
+      multi_tensor_apply<4>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                            SGDFunctor<4, at::Half, float, int64_t>(), wd, momentum, dampening, lr, nesterov, first_run,
+                            wd_after_momentum, scale);
+    }
+    // Case 4. fp32, fp32, fp32, Yes
+    else if (grad_type == at::ScalarType::Float && weight_type == at::ScalarType::Float && num_tensors == 4) {
+      multi_tensor_apply<4>((int64_t)BLOCK_SIZE, (int64_t)chunk_size, noop_flag, tensor_lists,
+                            SGDFunctor<4, float, float, int64_t>(), wd, momentum, dampening, lr, nesterov, first_run,
+                            wd_after_momentum, scale);
+    } else {
+      AT_ERROR("multi_tensor_sgd only supports some combinations of gradient & weight types. Given: ", "gradient: ",
+               grad_type, ", weight: ", weight_type, ", num_lists: ", num_tensors);
+    }
   } else {
-    AT_ERROR("multi_tensor_sgd only supports some combinations of gradient & weight types. Given: ", "gradient: ",
-             grad_type, ", weight: ", weight_type, ", num_lists: ", num_tensors);
+    // Case 1. fp16, fp16, fp16, No
+    if (grad_type == at::ScalarType::Half && weight_type == at::ScalarType::Half && num_tensors == 3) {
+      multi_tensor_apply<3>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists,
+                            SGDFunctor<3, at::Half, at::Half, int32_t>(), wd, momentum, dampening, lr, nesterov,
+                            first_run, wd_after_momentum, scale);
+    }
+    // Case 2. fp32, fp32, fp32, No
+    else if (grad_type == at::ScalarType::Float && weight_type == at::ScalarType::Float && num_tensors == 3) {
+      multi_tensor_apply<3>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, SGDFunctor<3, float, float, int32_t>(), wd,
+                            momentum, dampening, lr, nesterov, first_run, wd_after_momentum, scale);
+    }
+    // Case 3. fp16, fp32, fp32, Yes
+    else if (grad_type == at::ScalarType::Half && weight_type == at::ScalarType::Float && num_tensors == 4) {
+      multi_tensor_apply<4>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, SGDFunctor<4, at::Half, float, int32_t>(),
+                            wd, momentum, dampening, lr, nesterov, first_run, wd_after_momentum, scale);
+    }
+    // Case 4. fp32, fp32, fp32, Yes
+    else if (grad_type == at::ScalarType::Float && weight_type == at::ScalarType::Float && num_tensors == 4) {
+      multi_tensor_apply<4>(BLOCK_SIZE, chunk_size, noop_flag, tensor_lists, SGDFunctor<4, float, float, int32_t>(), wd,
+                            momentum, dampening, lr, nesterov, first_run, wd_after_momentum, scale);
+    } else {
+      AT_ERROR("multi_tensor_sgd only supports some combinations of gradient & weight types. Given: ", "gradient: ",
+               grad_type, ", weight: ", weight_type, ", num_lists: ", num_tensors);
+    }
   }
 
   AT_CUDA_CHECK(cudaGetLastError());

--- a/tests/L0/run_optimizers/test_adam.py
+++ b/tests/L0/run_optimizers/test_adam.py
@@ -268,10 +268,15 @@ class AdamTest(unittest.TestCase):
 
             self.model_.load_state_dict(copy.deepcopy(self.model.state_dict()))
 
+    # Use fp32 for large tensor tests: torch.optim.Adam with fp16 params computes
+    # entirely in fp16, where eps=1e-8 underflows to zero, causing division-by-zero
+    # NaN for rare near-zero gradients. FusedAdam is unaffected (fp32 math internally).
+
     @largeTensorTest("60GB", "cuda")
     def testLargeTensor(self):
-        t = torch.zeros(2359332864, dtype=torch.half, device="cuda")
-        t2 = torch.zeros(2359332864, dtype=torch.half, device="cuda")
+        numel = 2359332864
+        t = torch.zeros(numel, dtype=torch.float, device="cuda")
+        t2 = torch.zeros(numel, dtype=torch.float, device="cuda")
         grad = torch.randn_like(t)
         t.grad = grad
         t2.grad = grad
@@ -280,8 +285,42 @@ class AdamTest(unittest.TestCase):
         optimizer = apex.optimizers.FusedAdam(params, lr=self.lr)
         optimizer.step()
         optimizer2 = torch.optim.Adam(params2, lr=self.lr)
+        optimizer2.step()
         torch.testing.assert_close(t, t2)
-        torch.cuda.synchronize()
+
+    @largeTensorTest("60GB", "cuda")
+    def testLargeTensorCapturable(self):
+        numel = 2359332864
+        t = torch.zeros(numel, dtype=torch.float, device="cuda")
+        t2 = torch.zeros(numel, dtype=torch.float, device="cuda")
+        grad = torch.randn_like(t)
+        t.grad = grad
+        t2.grad = grad
+        params = [t]
+        params2 = [t2]
+        optimizer = apex.optimizers.FusedAdam(params, lr=self.lr, capturable=True)
+        optimizer.step()
+        optimizer2 = torch.optim.Adam(params2, lr=self.lr)
+        optimizer2.step()
+        torch.testing.assert_close(t, t2)
+
+    @largeTensorTest("60GB", "cuda")
+    def testLargeTensorCapturableMaster(self):
+        numel = 2359332864
+        t = torch.zeros(numel, dtype=torch.float, device="cuda")
+        t2 = torch.zeros(numel, dtype=torch.float, device="cuda")
+        grad = torch.randn_like(t)
+        t.grad = grad
+        t2.grad = grad
+        params = [t]
+        params2 = [t2]
+        optimizer = apex.optimizers.FusedAdam(
+            params, lr=self.lr, capturable=True, master_weights=True
+        )
+        optimizer.step()
+        optimizer2 = torch.optim.Adam(params2, lr=self.lr)
+        optimizer2.step()
+        torch.testing.assert_close(t, t2)
 
 
 if __name__ == "__main__":

--- a/tests/L0/run_optimizers/test_fused_novograd.py
+++ b/tests/L0/run_optimizers/test_fused_novograd.py
@@ -5,6 +5,7 @@ import unittest
 
 from test_fused_optimizer import TestFusedOptimizer
 from itertools import product
+from torch.testing._internal.common_device_type import largeTensorTest
 
 
 class Novograd(Optimizer):
@@ -190,6 +191,41 @@ class TestFusedNovoGrad(TestFusedOptimizer):
             max_abs_diff, max_rel_diff = self.get_max_diff(ref_param, tst_param)
             self.assertLessEqual(max_abs_diff, self.max_abs_diff)
             self.assertLessEqual(max_rel_diff, self.max_rel_diff)
+
+    @largeTensorTest("60GB", "cuda")
+    def test_large_tensor(self):
+        numel = 2359332864
+        t = torch.zeros(numel, dtype=torch.float, device="cuda")
+        t2 = torch.zeros(numel, dtype=torch.float, device="cuda")
+        grad = torch.randn_like(t)
+        t.grad = grad
+        t2.grad = grad
+        tst_options = {
+            "lr": 1e-3,
+            "betas": (0.95, 0),
+            "eps": 1e-8,
+            "weight_decay": 0,
+            "grad_averaging": False,
+            "amsgrad": False,
+            "bias_correction": False,
+            "reg_inside_moment": True,
+            "norm_type": 2,
+            "init_zero": False,
+            "set_grad_none": True,
+        }
+        ref_options = {
+            "lr": 1e-3,
+            "betas": (0.95, 0),
+            "eps": 1e-8,
+            "weight_decay": 0,
+            "grad_averaging": False,
+            "amsgrad": False,
+        }
+        optimizer = apex.optimizers.FusedNovoGrad([t], **tst_options)
+        optimizer.step()
+        optimizer2 = Novograd([t2], **ref_options)
+        optimizer2.step()
+        torch.testing.assert_close(t, t2)
 
 
 if __name__ == "__main__":

--- a/tests/L0/run_optimizers/test_fused_optimizer.py
+++ b/tests/L0/run_optimizers/test_fused_optimizer.py
@@ -3,6 +3,7 @@ import random
 import unittest
 
 import torch
+from torch.testing._internal.common_device_type import largeTensorTest
 
 import apex
 
@@ -291,6 +292,20 @@ class TestFusedAdagrad(TestFusedOptimizer):
             self.assertLessEqual(max_abs_diff, self.max_abs_diff)
             self.assertLessEqual(max_rel_diff, self.max_rel_diff)
 
+    @largeTensorTest("60GB", "cuda")
+    def test_large_tensor(self):
+        numel = 2359332864
+        t = torch.zeros(numel, dtype=torch.float, device="cuda")
+        t2 = torch.zeros(numel, dtype=torch.float, device="cuda")
+        grad = torch.randn_like(t)
+        t.grad = grad
+        t2.grad = grad
+        optimizer = apex.optimizers.FusedAdagrad([t], lr=5e-4, eps=1e-8, weight_decay=0)
+        optimizer.step()
+        optimizer2 = torch.optim.Adagrad([t2], lr=5e-4, eps=1e-8, weight_decay=0)
+        optimizer2.step()
+        torch.testing.assert_close(t, t2)
+
 
 class TestFusedSGD(TestFusedOptimizer):
     def __init__(self, *args, **kwargs):
@@ -311,6 +326,20 @@ class TestFusedSGD(TestFusedOptimizer):
         for current_dev, tensor_dev in product(devices, devices):
             with torch.cuda.device(current_dev):
                 self.gen_single_type_test(param_type=torch.float, device=tensor_dev)
+
+    @largeTensorTest("60GB", "cuda")
+    def test_large_tensor(self):
+        numel = 2359332864
+        t = torch.zeros(numel, dtype=torch.float, device="cuda")
+        t2 = torch.zeros(numel, dtype=torch.float, device="cuda")
+        grad = torch.randn_like(t)
+        t.grad = grad
+        t2.grad = grad
+        optimizer = apex.optimizers.FusedSGD([t], lr=0.25, momentum=0.125)
+        optimizer.step()
+        optimizer2 = torch.optim.SGD([t2], lr=0.25, momentum=0.125)
+        optimizer2.step()
+        torch.testing.assert_close(t, t2)
 
 
 if __name__ == "__main__":

--- a/tests/L0/run_optimizers/test_lamb.py
+++ b/tests/L0/run_optimizers/test_lamb.py
@@ -3,6 +3,7 @@ import os
 
 import torch
 from torch.optim import Optimizer
+from torch.testing._internal.common_device_type import largeTensorTest
 import apex
 from apex.multi_tensor_apply import multi_tensor_applier
 from itertools import product
@@ -294,6 +295,22 @@ class TestFusedLAMB(TestLamb):
                 ref_optim.step()
                 tst_optim.step()
                 torch.testing.assert_close(tst_param, ref_param)
+
+    @largeTensorTest("60GB", "cuda")
+    def test_large_tensor(self):
+        numel = 2359332864
+        t = torch.zeros(numel, dtype=torch.float, device="cuda")
+        t2 = torch.zeros(numel, dtype=torch.float, device="cuda")
+        grad = torch.randn_like(t)
+        t.grad = grad
+        # FusedLAMB kernel overwrites gradient tensor in-place to store update
+        t2.grad = grad.clone()
+        lamb_option = {"lr": 5e-4, "betas": (0.9, 0.999), "eps": 1e-6, "weight_decay": 0.01}
+        optimizer = apex.optimizers.FusedLAMB([t], use_nvlamb=True, **lamb_option)
+        optimizer.step()
+        optimizer2 = RefLAMB([t2], **lamb_option)
+        optimizer2.step()
+        torch.testing.assert_close(t, t2)
 
 
 class TestFusedMixedPrecisionLamb(TestLamb):

--- a/tests/L0/run_optimizers/test_multi_tensor.py
+++ b/tests/L0/run_optimizers/test_multi_tensor.py
@@ -1,0 +1,289 @@
+import unittest
+
+import torch
+from torch.testing._internal.common_device_type import largeTensorTest
+
+try:
+    import amp_C
+    from apex.multi_tensor_apply import multi_tensor_applier
+
+    HAS_APEX = True
+except ImportError:
+    HAS_APEX = False
+
+
+@unittest.skipIf(not HAS_APEX, "`amp_C` is not found.")
+class MultiTensorScaleTest(unittest.TestCase):
+    def testFP32(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        src = torch.full((1024,), 2.0, dtype=torch.float, device="cuda")
+        dst = torch.zeros_like(src)
+        multi_tensor_applier(amp_C.multi_tensor_scale, noop_flag, [[src], [dst]], 0.5)
+        torch.testing.assert_close(dst, torch.ones(1024, device="cuda"))
+
+    def testFP16toFP32(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        src = torch.full((1024,), 4.0, dtype=torch.half, device="cuda")
+        dst = torch.zeros(1024, dtype=torch.float, device="cuda")
+        multi_tensor_applier(amp_C.multi_tensor_scale, noop_flag, [[src], [dst]], 0.25)
+        torch.testing.assert_close(dst, torch.ones(1024, device="cuda"))
+
+    def testMultiTensor(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        srcs = [torch.full((s,), 3.0, dtype=torch.float, device="cuda") for s in [1024, 2048, 512]]
+        dsts = [torch.zeros_like(s) for s in srcs]
+        multi_tensor_applier(amp_C.multi_tensor_scale, noop_flag, [srcs, dsts], 2.0)
+        for dst in dsts:
+            torch.testing.assert_close(dst, torch.full_like(dst, 6.0))
+
+    @largeTensorTest("60GB", "cuda")
+    def testLargeTensor(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        src = torch.full((2359332864,), 2.0, dtype=torch.float, device="cuda")
+        dst = torch.zeros_like(src)
+        multi_tensor_applier(amp_C.multi_tensor_scale, noop_flag, [[src], [dst]], 0.5)
+        torch.testing.assert_close(dst[-1:], torch.tensor([1.0], device="cuda"))
+        torch.testing.assert_close(dst[:1], torch.tensor([1.0], device="cuda"))
+
+    @largeTensorTest("60GB", "cuda")
+    def testLargeTensorHalf(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        src = torch.full((2359332864,), 2.0, dtype=torch.half, device="cuda")
+        dst = torch.zeros(2359332864, dtype=torch.float, device="cuda")
+        multi_tensor_applier(amp_C.multi_tensor_scale, noop_flag, [[src], [dst]], 0.5)
+        torch.testing.assert_close(dst[-1:], torch.tensor([1.0], device="cuda"))
+
+
+@unittest.skipIf(not HAS_APEX, "`amp_C` is not found.")
+class MultiTensorL2NormTest(unittest.TestCase):
+    def testFP32(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        t = torch.ones(1024, dtype=torch.float, device="cuda")
+        norm, _ = multi_tensor_applier(amp_C.multi_tensor_l2norm, noop_flag, [[t]], False)
+        expected = torch.tensor([1024.0**0.5], device="cuda")
+        torch.testing.assert_close(norm, expected)
+
+    def testFP16(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        t = torch.ones(1024, dtype=torch.half, device="cuda")
+        norm, _ = multi_tensor_applier(amp_C.multi_tensor_l2norm, noop_flag, [[t]], False)
+        expected = torch.tensor([1024.0**0.5], device="cuda")
+        torch.testing.assert_close(norm, expected)
+
+    def testMultiTensor(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        tensors = [torch.ones(s, dtype=torch.float, device="cuda") for s in [1024, 2048, 512]]
+        norm, _ = multi_tensor_applier(amp_C.multi_tensor_l2norm, noop_flag, [tensors], False)
+        expected = torch.tensor([(1024 + 2048 + 512) ** 0.5], device="cuda")
+        torch.testing.assert_close(norm, expected)
+
+    def testUnscale(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        t = torch.ones(1024, dtype=torch.float, device="cuda")
+        inv_scale = torch.tensor([0.5], dtype=torch.float, device="cuda")
+        norm, _ = multi_tensor_applier(
+            amp_C.multi_tensor_unscale_l2norm, noop_flag, [[t]], inv_scale, False
+        )
+        expected = torch.tensor([1024.0**0.5 * 0.5], device="cuda")
+        torch.testing.assert_close(norm, expected)
+
+    @largeTensorTest("60GB", "cuda")
+    def testLargeTensor(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        t = torch.ones(2359332864, dtype=torch.float, device="cuda")
+        norm, _ = multi_tensor_applier(amp_C.multi_tensor_l2norm, noop_flag, [[t]], False)
+        expected = torch.tensor([2359332864.0**0.5], device="cuda")
+        # Hierarchical float32 reduction over 2.3B elements introduces accumulation error
+        torch.testing.assert_close(norm, expected, atol=1.0, rtol=1e-5)
+
+    @largeTensorTest("60GB", "cuda")
+    def testLargeTensorHalf(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        t = torch.ones(2359332864, dtype=torch.half, device="cuda")
+        norm, _ = multi_tensor_applier(amp_C.multi_tensor_l2norm, noop_flag, [[t]], False)
+        expected = torch.tensor([2359332864.0**0.5], device="cuda")
+        torch.testing.assert_close(norm, expected, atol=256.0, rtol=1e-2)
+
+    @largeTensorTest("60GB", "cuda")
+    def testUnscaleLargeTensor(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        t = torch.ones(2359332864, dtype=torch.float, device="cuda")
+        inv_scale = torch.tensor([0.5], dtype=torch.float, device="cuda")
+        norm, _ = multi_tensor_applier(
+            amp_C.multi_tensor_unscale_l2norm, noop_flag, [[t]], inv_scale, False
+        )
+        expected = torch.tensor([2359332864.0**0.5 * 0.5], device="cuda")
+        torch.testing.assert_close(norm, expected, atol=1.0, rtol=1e-5)
+
+
+@unittest.skipIf(not HAS_APEX, "`amp_C` is not found.")
+class MultiTensorSGDTest(unittest.TestCase):
+    def testBasic(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        lr = 0.01
+
+        grad = torch.ones(1024, dtype=torch.float, device="cuda")
+        weight = torch.ones(1024, dtype=torch.float, device="cuda")
+        mom = torch.zeros(1024, dtype=torch.float, device="cuda")
+
+        multi_tensor_applier(
+            amp_C.multi_tensor_sgd,
+            noop_flag,
+            [[grad], [weight], [mom]],
+            0.0,
+            0.9,
+            0.0,
+            lr,
+            False,
+            True,
+            False,
+            1.0,
+        )
+        expected = torch.full((1024,), 1.0 - lr, device="cuda")
+        torch.testing.assert_close(weight, expected)
+
+    def testMultiTensor(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        lr = 0.1
+
+        grads = [torch.ones(s, dtype=torch.float, device="cuda") for s in [1024, 2048]]
+        weights = [torch.ones(s, dtype=torch.float, device="cuda") for s in [1024, 2048]]
+        moms = [torch.zeros(s, dtype=torch.float, device="cuda") for s in [1024, 2048]]
+
+        multi_tensor_applier(
+            amp_C.multi_tensor_sgd,
+            noop_flag,
+            [grads, weights, moms],
+            0.0,
+            0.9,
+            0.0,
+            lr,
+            False,
+            True,
+            False,
+            1.0,
+        )
+        for w in weights:
+            torch.testing.assert_close(w, torch.full_like(w, 1.0 - lr))
+
+    @largeTensorTest("60GB", "cuda")
+    def testLargeTensor(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        lr = 0.01
+
+        grad = torch.ones(2359332864, dtype=torch.float, device="cuda")
+        weight = torch.ones(2359332864, dtype=torch.float, device="cuda")
+        mom = torch.zeros(2359332864, dtype=torch.float, device="cuda")
+
+        multi_tensor_applier(
+            amp_C.multi_tensor_sgd,
+            noop_flag,
+            [[grad], [weight], [mom]],
+            0.0,
+            0.9,
+            0.0,
+            lr,
+            False,
+            True,
+            False,
+            1.0,
+        )
+        expected = torch.tensor([1.0 - lr], device="cuda")
+        torch.testing.assert_close(weight[-1:], expected)
+        torch.testing.assert_close(weight[:1], expected)
+
+
+@unittest.skipIf(not HAS_APEX, "`amp_C` is not found.")
+class MultiTensorAxpbyTest(unittest.TestCase):
+    def testBasic(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        x = torch.full((1024,), 2.0, dtype=torch.float, device="cuda")
+        y = torch.full((1024,), 3.0, dtype=torch.float, device="cuda")
+        out = torch.zeros(1024, dtype=torch.float, device="cuda")
+        # out = a*x + b*y = 0.5*2 + 0.25*3 = 1.75
+        multi_tensor_applier(amp_C.multi_tensor_axpby, noop_flag, [[x], [y], [out]], 0.5, 0.25, -1)
+        torch.testing.assert_close(out, torch.full((1024,), 1.75, device="cuda"))
+
+    def testMultiTensor(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        xs = [torch.full((s,), 1.0, dtype=torch.float, device="cuda") for s in [1024, 2048]]
+        ys = [torch.full((s,), 2.0, dtype=torch.float, device="cuda") for s in [1024, 2048]]
+        outs = [torch.zeros(s, dtype=torch.float, device="cuda") for s in [1024, 2048]]
+        # out = 2*x + 3*y = 2*1 + 3*2 = 8
+        multi_tensor_applier(amp_C.multi_tensor_axpby, noop_flag, [xs, ys, outs], 2.0, 3.0, -1)
+        for out in outs:
+            torch.testing.assert_close(out, torch.full_like(out, 8.0))
+
+    @largeTensorTest("60GB", "cuda")
+    def testLargeTensor(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        numel = 2359332864
+        x = torch.full((numel,), 2.0, dtype=torch.float, device="cuda")
+        y = torch.full((numel,), 3.0, dtype=torch.float, device="cuda")
+        out = torch.zeros(numel, dtype=torch.float, device="cuda")
+        multi_tensor_applier(amp_C.multi_tensor_axpby, noop_flag, [[x], [y], [out]], 0.5, 0.25, -1)
+        # out = 0.5*2 + 0.25*3 = 1.75 (exact in float32)
+        expected = torch.full((numel,), 1.75, device="cuda")
+        torch.testing.assert_close(out, expected)
+
+
+@unittest.skipIf(not HAS_APEX, "`amp_C` is not found.")
+class MultiTensorL2NormMPTest(unittest.TestCase):
+    def testFP32(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        t = torch.ones(1024, dtype=torch.float, device="cuda")
+        norm, _ = multi_tensor_applier(amp_C.multi_tensor_l2norm_mp, noop_flag, [[t]], False)
+        expected = torch.tensor([1024.0**0.5], device="cuda")
+        torch.testing.assert_close(norm, expected)
+
+    def testBF16(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        t = torch.ones(1024, dtype=torch.bfloat16, device="cuda")
+        norm, _ = multi_tensor_applier(amp_C.multi_tensor_l2norm_mp, noop_flag, [[t]], False)
+        expected = torch.tensor([1024.0**0.5], device="cuda")
+        torch.testing.assert_close(norm, expected)
+
+    @largeTensorTest("60GB", "cuda")
+    def testLargeTensor(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        t = torch.ones(2359332864, dtype=torch.float, device="cuda")
+        norm, _ = multi_tensor_applier(amp_C.multi_tensor_l2norm_mp, noop_flag, [[t]], False)
+        expected = torch.tensor([2359332864.0**0.5], device="cuda")
+        torch.testing.assert_close(norm, expected, atol=1.0, rtol=1e-5)
+
+
+@unittest.skipIf(not HAS_APEX, "`amp_C` is not found.")
+class MultiTensorL2NormScaleTest(unittest.TestCase):
+    def testBasic(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        src = torch.ones(1024, dtype=torch.float, device="cuda")
+        dst = torch.zeros(1024, dtype=torch.float, device="cuda")
+        scale = 2.0
+        norm, _ = multi_tensor_applier(
+            amp_C.multi_tensor_l2norm_scale, noop_flag, [[src], [dst]], scale, False
+        )
+        # norm = sqrt(sum(1^2)) = sqrt(1024)
+        expected_norm = torch.tensor([1024.0**0.5], device="cuda")
+        torch.testing.assert_close(norm, expected_norm)
+        # dst = src * scale = 2.0
+        torch.testing.assert_close(dst, torch.full((1024,), 2.0, device="cuda"))
+
+    @largeTensorTest("60GB", "cuda")
+    def testLargeTensor(self):
+        noop_flag = torch.tensor([0], dtype=torch.int, device="cuda")
+        numel = 2359332864
+        src = torch.ones(numel, dtype=torch.float, device="cuda")
+        dst = torch.zeros(numel, dtype=torch.float, device="cuda")
+        scale = 0.5
+        norm, _ = multi_tensor_applier(
+            amp_C.multi_tensor_l2norm_scale, noop_flag, [[src], [dst]], scale, False
+        )
+        expected_norm = torch.tensor([numel**0.5], device="cuda")
+        torch.testing.assert_close(norm, expected_norm, atol=1.0, rtol=1e-5)
+        # dst = src * scale = 0.5 (exact for uniform inputs)
+        expected_dst = torch.full((numel,), 0.5, device="cuda")
+        torch.testing.assert_close(dst, expected_dst)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
During llm training, we encountered a case where the number of tensor elements exceeded INT_MAX, leading to illegal memory access. The multi_tensor_l2norm and multi_tensor_scale interfaces do not support int64_t indexing, while the multi_tensor_adam interface has supported int64_t indexing in previous #1765 and #1825 . 
To avoid similar issues in the future, we extend the int64_t indexing to all other remaining multi tensor ops and add corresponding tests.

[test.log](https://github.com/user-attachments/files/28737465/test.log)
